### PR TITLE
Standardize attachment data type to Uint8Array

### DIFF
--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -644,15 +644,13 @@ export class SQLiteAdapter implements StackAdapter {
   // Attachments
   // -------------------------------------------------------
 
-  async putAttachment(data: Blob | Buffer, mimeType: string): Promise<string> {
+  async putAttachment(data: Uint8Array, mimeType: string): Promise<string> {
     const fileId = generateId();
     const ext = mimeType.split('/')[1] ?? 'bin';
     const filename = `${fileId}.${ext}`;
     const filePath = join(this.attachmentsDir, filename);
 
-    const buffer = data instanceof Blob ? Buffer.from(await data.arrayBuffer()) : data;
-
-    await writeFile(filePath, buffer);
+    await writeFile(filePath, data);
 
     this.db.run(
       'INSERT INTO attachments (file_id, mime_type, created_at, path) VALUES (?, ?, ?, ?)',
@@ -662,7 +660,7 @@ export class SQLiteAdapter implements StackAdapter {
     return fileId;
   }
 
-  async getAttachment(fileId: string): Promise<Blob | Buffer> {
+  async getAttachment(fileId: string): Promise<Uint8Array> {
     const rows = this.execQuery<{ path: string }>(
       'SELECT path FROM attachments WHERE file_id = ?',
       [fileId],

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -495,11 +495,11 @@ export class Stack {
   // Attachments
   // -------------------------------------------------------
 
-  async putAttachment(data: Blob | Buffer, mimeType: string): Promise<string> {
+  async putAttachment(data: Uint8Array, mimeType: string): Promise<string> {
     return this.adapter.putAttachment(data, mimeType);
   }
 
-  async getAttachment(fileId: string): Promise<Blob | Buffer> {
+  async getAttachment(fileId: string): Promise<Uint8Array> {
     return this.adapter.getAttachment(fileId);
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -300,7 +300,7 @@ export interface StackAdapter {
   listTypes(): Promise<StackType[]>;
 
   // Attachments
-  putAttachment(data: Blob | Buffer, mimeType: string): Promise<FileId>;
-  getAttachment(fileId: FileId): Promise<Blob | Buffer>;
+  putAttachment(data: Uint8Array, mimeType: string): Promise<FileId>;
+  getAttachment(fileId: FileId): Promise<Uint8Array>;
   deleteAttachment(fileId: FileId): Promise<void>;
 }

--- a/packages/core/tests/stack.test.ts
+++ b/packages/core/tests/stack.test.ts
@@ -119,11 +119,11 @@ class MockAdapter implements StackAdapter {
     return [...this.types.values()];
   }
 
-  async putAttachment(_data: Blob | Buffer, _mimeType: string) {
+  async putAttachment(_data: Uint8Array, _mimeType: string) {
     return 'file-123';
   }
-  async getAttachment(_fileId: string): Promise<Buffer> {
-    return Buffer.from('');
+  async getAttachment(_fileId: string): Promise<Uint8Array> {
+    return new Uint8Array();
   }
   async deleteAttachment(_fileId: string) {}
 }


### PR DESCRIPTION
## Summary
This PR standardizes the attachment handling across the codebase by replacing the union type `Blob | Buffer` with `Uint8Array` for all attachment-related operations. This provides a more consistent and platform-agnostic approach to handling binary data.

## Key Changes
- Updated `StackAdapter` interface to use `Uint8Array` for `putAttachment()` and `getAttachment()` method signatures
- Modified `Stack` class attachment methods to accept and return `Uint8Array` instead of `Blob | Buffer`
- Simplified `SQLiteAdapter.putAttachment()` by removing the conditional logic that converted `Blob` to `Buffer`, now directly writing `Uint8Array` to disk
- Updated `SQLiteAdapter.getAttachment()` to return `Uint8Array`
- Updated `MockAdapter` in tests to match the new interface signatures

## Implementation Details
- The change eliminates the need for runtime type checking and conversion in the SQLite adapter
- `Uint8Array` is a standard JavaScript typed array that works consistently across Node.js and browser environments
- This simplification reduces complexity while maintaining full compatibility with binary data handling

https://claude.ai/code/session_01Dgk1axrB36JjU5ncTjVmut