### PR TITLE
Add API adapter implementation for remote stack servers

### DIFF
--- a/packages/adapter-api/package.json
+++ b/packages/adapter-api/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@haverstack/adapter-api",
+  "version": "0.1.0",
+  "description": "Remote server adapter for Haverstack",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prepublishOnly": "pnpm run build",
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src tests"
+  },
+  "dependencies": {
+    "@haverstack/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/adapter-api/src/index.ts
+++ b/packages/adapter-api/src/index.ts
@@ -298,7 +298,7 @@ export class APIAdapter implements StackAdapter {
   }
 
   async setConfig(_key: string, _value: string): Promise<void> {
-    // Server owns its config; writes are not forwarded
+    throw new APIAdapterError('setConfig is not supported: server configuration is managed server-side');
   }
 
   // -------------------------------------------------------

--- a/packages/adapter-api/src/index.ts
+++ b/packages/adapter-api/src/index.ts
@@ -1,0 +1,438 @@
+/**
+ * Stack — API Adapter
+ * -------------------------------------------------------
+ * Implements StackAdapter over HTTP. On open(), calls the
+ * discovery endpoint to populate AdapterCapabilities before
+ * returning, so capabilities are available synchronously
+ * once the adapter is in hand.
+ *
+ * Authentication uses a bearer token in the Authorization
+ * header. Token issuance is server-defined and out of scope.
+ *
+ * v1 requires connectivity — offline queue and conflict
+ * detection are deferred.
+ */
+
+import type {
+  StackAdapter,
+  StackRecord,
+  StackType,
+  TypeSchema,
+  TypeId,
+  RecordVersion,
+  StackQuery,
+  QueryResult,
+  Association,
+  AdapterCapabilities,
+  RecordId,
+  FileId,
+  Permission,
+} from '@haverstack/core';
+
+// -------------------------------------------------------
+// Public option types
+// -------------------------------------------------------
+
+export type APIAdapterOpenOptions = {
+  /** Base URL of the stack server e.g. "https://example.com". Trailing slash is stripped. */
+  url: string;
+  /** Bearer token issued by the stack server. Omit for unauthenticated access. */
+  token?: string;
+};
+
+// -------------------------------------------------------
+// Error types
+// -------------------------------------------------------
+
+export class APIAdapterError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode?: number,
+  ) {
+    super(message);
+    this.name = 'APIAdapterError';
+  }
+}
+
+export class APIAdapterAuthError extends APIAdapterError {
+  constructor(message = 'Unauthorized: invalid or missing token') {
+    super(message, 401);
+    this.name = 'APIAdapterAuthError';
+  }
+}
+
+export class APIAdapterConnectionError extends APIAdapterError {
+  constructor(url: string, cause?: unknown) {
+    super(`Could not reach server at "${url}"`);
+    this.name = 'APIAdapterConnectionError';
+    if (cause) this.cause = cause;
+  }
+}
+
+// -------------------------------------------------------
+// Discovery response shape
+// -------------------------------------------------------
+
+type DiscoveryResponse = {
+  version: string;
+  entityId: string;
+  timezone?: string;
+  capabilities: AdapterCapabilities;
+};
+
+// -------------------------------------------------------
+// Domain object parsers (wire JSON → typed domain objects)
+// -------------------------------------------------------
+
+const fromISO = (s: string): Date => new Date(s);
+
+const parseRecord = (raw: Record<string, unknown>): StackRecord => {
+  const record: StackRecord = {
+    id: raw.id as string,
+    typeId: raw.typeId as string,
+    createdAt: fromISO(raw.createdAt as string),
+    updatedAt: fromISO(raw.updatedAt as string),
+    content: raw.content as Record<string, unknown>,
+    version: raw.version as number,
+  };
+  if (raw.parentId != null) record.parentId = raw.parentId as string;
+  if (raw.entityId != null) record.entityId = raw.entityId as string;
+  if (raw.appId != null) record.appId = raw.appId as string;
+  if (raw.deletedAt != null) record.deletedAt = fromISO(raw.deletedAt as string);
+  if (raw.permissions != null) record.permissions = raw.permissions as Permission[];
+  if (raw.associations != null) record.associations = raw.associations as Association[];
+  return record;
+};
+
+const parseType = (raw: Record<string, unknown>): StackType => {
+  const t: StackType = {
+    id: raw.id as string,
+    baseId: raw.baseId as string,
+    version: raw.version as number,
+    name: raw.name as string,
+    schema: raw.schema as TypeSchema,
+    schemaHash: raw.schemaHash as string,
+    createdAt: fromISO(raw.createdAt as string),
+  };
+  if (raw.migratesFrom != null) t.migratesFrom = raw.migratesFrom as string;
+  return t;
+};
+
+const parseVersion = (raw: Record<string, unknown>): RecordVersion => {
+  const v: RecordVersion = {
+    version: raw.version as number,
+    content: raw.content as Record<string, unknown>,
+    updatedAt: fromISO(raw.updatedAt as string),
+  };
+  if (raw.entityId != null) v.entityId = raw.entityId as string;
+  return v;
+};
+
+// -------------------------------------------------------
+// Query parameter builder (used when contentFieldQuery is false)
+// -------------------------------------------------------
+
+const buildQueryParams = (query: StackQuery): URLSearchParams => {
+  const p = new URLSearchParams();
+  const f = query.filter ?? {};
+
+  if (f.typeId !== undefined) {
+    const ids = Array.isArray(f.typeId) ? f.typeId : [f.typeId];
+    for (const id of ids) p.append('typeId', id);
+  }
+  if (f.parentId !== undefined) p.set('parentId', f.parentId === null ? 'null' : f.parentId);
+  if (f.appId !== undefined) {
+    const ids = Array.isArray(f.appId) ? f.appId : [f.appId];
+    for (const id of ids) p.append('appId', id);
+  }
+  if (f.entityId !== undefined) {
+    const ids = Array.isArray(f.entityId) ? f.entityId : [f.entityId];
+    for (const id of ids) p.append('entityId', id);
+  }
+  if (f.createdAt?.before) p.set('createdBefore', f.createdAt.before.toISOString());
+  if (f.createdAt?.after) p.set('createdAfter', f.createdAt.after.toISOString());
+  if (f.updatedAt?.before) p.set('updatedBefore', f.updatedAt.before.toISOString());
+  if (f.updatedAt?.after) p.set('updatedAfter', f.updatedAt.after.toISOString());
+  if (f.tags) for (const tag of f.tags) p.append('tag', tag);
+  if (f.hasAttachment) p.set('hasAttachment', f.hasAttachment);
+  if (f.relatedTo) p.set('relatedTo', f.relatedTo.recordId);
+  if (f.search) p.set('search', f.search);
+  if (f.includeDeleted) p.set('includeDeleted', 'true');
+  if (query.sort?.field) p.set('sort', query.sort.field);
+  if (query.sort?.direction) p.set('direction', query.sort.direction);
+  if (query.limit) p.set('limit', String(query.limit));
+  if (query.cursor) p.set('cursor', query.cursor);
+
+  return p;
+};
+
+// -------------------------------------------------------
+// APIAdapter
+// -------------------------------------------------------
+
+export class APIAdapter implements StackAdapter {
+  readonly capabilities: AdapterCapabilities;
+
+  private constructor(
+    private readonly baseUrl: string,
+    private readonly token: string | undefined,
+    private readonly config: Map<string, string>,
+    capabilities: AdapterCapabilities,
+  ) {
+    this.capabilities = capabilities;
+  }
+
+  /**
+   * Connect to a remote stack server. Calls GET /.well-known/stack to verify
+   * the server and populate AdapterCapabilities before returning.
+   *
+   * Throws APIAdapterAuthError on 401.
+   * Throws APIAdapterConnectionError if the server is unreachable.
+   */
+  static async open(opts: APIAdapterOpenOptions): Promise<APIAdapter> {
+    const baseUrl = opts.url.replace(/\/$/, '');
+    const headers: Record<string, string> = opts.token
+      ? { Authorization: `Bearer ${opts.token}` }
+      : {};
+
+    let res: Response;
+    try {
+      res = await fetch(`${baseUrl}/.well-known/stack`, { headers });
+    } catch (err) {
+      throw new APIAdapterConnectionError(baseUrl, err);
+    }
+
+    if (res.status === 401) throw new APIAdapterAuthError();
+    if (!res.ok) {
+      throw new APIAdapterError(`Discovery failed: server returned ${res.status}`, res.status);
+    }
+
+    const discovery = (await res.json()) as DiscoveryResponse;
+
+    const config = new Map<string, string>([
+      ['entity_id', discovery.entityId],
+      ['version', discovery.version],
+    ]);
+    if (discovery.timezone) config.set('timezone', discovery.timezone);
+
+    return new APIAdapter(baseUrl, opts.token, config, discovery.capabilities);
+  }
+
+  // -------------------------------------------------------
+  // Request helpers
+  // -------------------------------------------------------
+
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    { nullOn404 = false }: { nullOn404?: boolean } = {},
+  ): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const headers: Record<string, string> = {};
+    if (this.token) headers['Authorization'] = `Bearer ${this.token}`;
+    if (body !== undefined) headers['Content-Type'] = 'application/json';
+
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+      });
+    } catch (err) {
+      throw new APIAdapterConnectionError(this.baseUrl, err);
+    }
+
+    if (res.status === 401) throw new APIAdapterAuthError();
+    if (res.status === 404 && nullOn404) return null as T;
+    if (!res.ok) throw new APIAdapterError(`HTTP ${res.status}: ${method} ${path}`, res.status);
+    if (res.status === 204) return undefined as T;
+    return res.json() as Promise<T>;
+  }
+
+  private async requestBinary(path: string): Promise<Uint8Array> {
+    const url = `${this.baseUrl}${path}`;
+    const headers: Record<string, string> = {};
+    if (this.token) headers['Authorization'] = `Bearer ${this.token}`;
+
+    let res: Response;
+    try {
+      res = await fetch(url, { headers });
+    } catch (err) {
+      throw new APIAdapterConnectionError(this.baseUrl, err);
+    }
+
+    if (res.status === 401) throw new APIAdapterAuthError();
+    if (!res.ok) throw new APIAdapterError(`HTTP ${res.status}: GET ${path}`, res.status);
+    return new Uint8Array(await res.arrayBuffer());
+  }
+
+  private async uploadBinary(
+    path: string,
+    data: Uint8Array,
+    mimeType: string,
+  ): Promise<Record<string, unknown>> {
+    const url = `${this.baseUrl}${path}`;
+    const headers: Record<string, string> = { 'Content-Type': mimeType };
+    if (this.token) headers['Authorization'] = `Bearer ${this.token}`;
+
+    let res: Response;
+    try {
+      res = await fetch(url, { method: 'POST', headers, body: data as unknown as BodyInit });
+    } catch (err) {
+      throw new APIAdapterConnectionError(this.baseUrl, err);
+    }
+
+    if (res.status === 401) throw new APIAdapterAuthError();
+    if (!res.ok) throw new APIAdapterError(`HTTP ${res.status}: POST ${path}`, res.status);
+    return res.json() as Promise<Record<string, unknown>>;
+  }
+
+  // -------------------------------------------------------
+  // Config
+  // -------------------------------------------------------
+
+  async getConfig(key: string): Promise<string | null> {
+    return this.config.get(key) ?? null;
+  }
+
+  async setConfig(_key: string, _value: string): Promise<void> {
+    // Server owns its config; writes are not forwarded
+  }
+
+  // -------------------------------------------------------
+  // Records
+  // -------------------------------------------------------
+
+  async createRecord(record: StackRecord): Promise<StackRecord> {
+    const raw = await this.request<Record<string, unknown>>('POST', '/records', record);
+    return parseRecord(raw);
+  }
+
+  async getRecord(id: RecordId): Promise<StackRecord | null> {
+    const raw = await this.request<Record<string, unknown> | null>('GET', `/records/${id}`, undefined, {
+      nullOn404: true,
+    });
+    return raw ? parseRecord(raw) : null;
+  }
+
+  async updateRecord(id: RecordId, changes: Partial<StackRecord>): Promise<StackRecord> {
+    const raw = await this.request<Record<string, unknown>>('PATCH', `/records/${id}`, changes);
+    return parseRecord(raw);
+  }
+
+  async deleteRecord(id: RecordId, opts: { hard?: boolean } = {}): Promise<void> {
+    const path = opts.hard ? `/records/${id}?hard=true` : `/records/${id}`;
+    await this.request<void>('DELETE', path);
+  }
+
+  async queryRecords(query: StackQuery): Promise<QueryResult> {
+    type Envelope = { records: Record<string, unknown>[]; cursor: string | null; total: number };
+
+    let raw: Envelope;
+    if (this.capabilities.contentFieldQuery) {
+      // POST /records/query supports the full query shape including content field filters
+      raw = await this.request<Envelope>('POST', '/records/query', query);
+    } else {
+      // Servers without contentFieldQuery support only expose GET /records
+      const params = buildQueryParams(query);
+      const qs = params.toString();
+      raw = await this.request<Envelope>('GET', qs ? `/records?${qs}` : '/records');
+    }
+
+    return {
+      records: raw.records.map(parseRecord),
+      cursor: raw.cursor,
+      total: raw.total,
+    };
+  }
+
+  // -------------------------------------------------------
+  // Associations
+  // -------------------------------------------------------
+
+  async associate(id: RecordId, association: Association): Promise<void> {
+    await this.request<void>('POST', `/records/${id}/associations`, association);
+  }
+
+  async dissociate(id: RecordId, association: Association): Promise<void> {
+    await this.request<void>('DELETE', `/records/${id}/associations`, association);
+  }
+
+  // -------------------------------------------------------
+  // Versions
+  // -------------------------------------------------------
+
+  async getVersions(id: RecordId): Promise<RecordVersion[]> {
+    const raw = await this.request<Record<string, unknown>[]>('GET', `/records/${id}/versions`);
+    return raw.map(parseVersion);
+  }
+
+  async getVersion(id: RecordId, version: number): Promise<RecordVersion | null> {
+    const raw = await this.request<Record<string, unknown> | null>(
+      'GET',
+      `/records/${id}/versions/${version}`,
+      undefined,
+      { nullOn404: true },
+    );
+    return raw ? parseVersion(raw) : null;
+  }
+
+  async saveVersion(_id: RecordId, _version: RecordVersion): Promise<void> {
+    // The server snapshots versions automatically as a side effect of updateRecord.
+    // There is no client-initiated saveVersion endpoint in the wire protocol.
+  }
+
+  // -------------------------------------------------------
+  // Types
+  // -------------------------------------------------------
+
+  async saveType(type: StackType): Promise<void> {
+    await this.request<void>('POST', '/types', type);
+  }
+
+  async getType(id: TypeId): Promise<StackType | null> {
+    const raw = await this.request<Record<string, unknown> | null>(
+      'GET',
+      `/types/${encodeURIComponent(id)}`,
+      undefined,
+      { nullOn404: true },
+    );
+    return raw ? parseType(raw) : null;
+  }
+
+  async listTypes(): Promise<StackType[]> {
+    const raw = await this.request<Record<string, unknown>[]>('GET', '/types');
+    return raw.map(parseType);
+  }
+
+  // -------------------------------------------------------
+  // Attachments
+  // -------------------------------------------------------
+
+  async putAttachment(data: Uint8Array, mimeType: string): Promise<FileId> {
+    const result = await this.uploadBinary('/attachments', data, mimeType);
+    return result.fileId as string;
+  }
+
+  async getAttachment(fileId: FileId): Promise<Uint8Array> {
+    return this.requestBinary(`/attachments/${fileId}`);
+  }
+
+  async deleteAttachment(fileId: FileId): Promise<void> {
+    await this.request<void>('DELETE', `/attachments/${fileId}`);
+  }
+
+  // -------------------------------------------------------
+  // Lifecycle
+  // -------------------------------------------------------
+
+  async flush(): Promise<void> {
+    // Each request commits immediately; nothing to flush client-side.
+  }
+
+  async close(): Promise<void> {
+    // Stateless HTTP client; nothing to tear down.
+  }
+}

--- a/packages/adapter-api/tests/api.test.ts
+++ b/packages/adapter-api/tests/api.test.ts
@@ -1,0 +1,676 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  APIAdapter,
+  APIAdapterAuthError,
+  APIAdapterConnectionError,
+  APIAdapterError,
+} from '../src/index.js';
+import type { StackRecord, StackType, RecordVersion, Association } from '@haverstack/core';
+
+// -------------------------------------------------------
+// Test fixtures
+// -------------------------------------------------------
+
+const BASE_URL = 'https://stack.example.com';
+const TOKEN = 'test-token-abc';
+
+const DISCOVERY = {
+  version: '1.0',
+  entityId: 'entity-owner-123',
+  timezone: 'America/New_York',
+  capabilities: {
+    fullTextSearch: true,
+    contentFieldQuery: true,
+    sortableFields: ['createdAt', 'updatedAt', 'version'],
+  },
+};
+
+const RECORD_RAW = {
+  id: 'rec-abc123',
+  typeId: 'com.example/note@1',
+  createdAt: '2024-06-15T12:00:00.000Z',
+  updatedAt: '2024-06-15T12:00:00.000Z',
+  content: { text: 'Hello world' },
+  version: 1,
+};
+
+const NOTE_TYPE_RAW = {
+  id: 'com.example/note@1',
+  baseId: 'com.example/note',
+  version: 1,
+  name: 'Note',
+  schema: { text: { kind: 'text', required: true } },
+  schemaHash: 'abc123hash',
+  createdAt: '2024-01-01T00:00:00.000Z',
+};
+
+const VERSION_RAW = {
+  version: 1,
+  content: { text: 'original' },
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  entityId: 'entity-owner-123',
+};
+
+// -------------------------------------------------------
+// Mock helpers
+// -------------------------------------------------------
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+const noContent = (): Response => new Response(null, { status: 204 });
+
+let mockFetch: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  mockFetch = vi.fn();
+  vi.stubGlobal('fetch', mockFetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** Open an adapter — consumes the first fetch call for discovery. */
+const openAdapter = async (discoveryOverride?: object): Promise<APIAdapter> => {
+  mockFetch.mockResolvedValueOnce(jsonResponse(discoveryOverride ?? DISCOVERY));
+  return APIAdapter.open({ url: BASE_URL, token: TOKEN });
+};
+
+// -------------------------------------------------------
+// open()
+// -------------------------------------------------------
+
+describe('open', () => {
+  test('calls GET /.well-known/stack', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(DISCOVERY));
+    await APIAdapter.open({ url: BASE_URL, token: TOKEN });
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${BASE_URL}/.well-known/stack`,
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: `Bearer ${TOKEN}` }) }),
+    );
+  });
+
+  test('strips trailing slash from url', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(DISCOVERY));
+    await APIAdapter.open({ url: `${BASE_URL}/`, token: TOKEN });
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${BASE_URL}/.well-known/stack`,
+      expect.anything(),
+    );
+  });
+
+  test('populates capabilities from discovery response', async () => {
+    const adapter = await openAdapter();
+    expect(adapter.capabilities.fullTextSearch).toBe(true);
+    expect(adapter.capabilities.contentFieldQuery).toBe(true);
+    expect(adapter.capabilities.sortableFields).toEqual(['createdAt', 'updatedAt', 'version']);
+  });
+
+  test('omits Authorization header when no token provided', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(DISCOVERY));
+    await APIAdapter.open({ url: BASE_URL });
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect((init.headers as Record<string, string>)['Authorization']).toBeUndefined();
+  });
+
+  test('throws APIAdapterAuthError on 401', async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 401 }));
+    await expect(APIAdapter.open({ url: BASE_URL, token: 'bad-token' })).rejects.toThrow(
+      APIAdapterAuthError,
+    );
+  });
+
+  test('throws APIAdapterConnectionError when fetch rejects', async () => {
+    mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    await expect(APIAdapter.open({ url: BASE_URL, token: TOKEN })).rejects.toThrow(
+      APIAdapterConnectionError,
+    );
+  });
+
+  test('throws APIAdapterError on non-401 error status', async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 503 }));
+    await expect(APIAdapter.open({ url: BASE_URL, token: TOKEN })).rejects.toThrow(
+      APIAdapterError,
+    );
+  });
+});
+
+// -------------------------------------------------------
+// getConfig
+// -------------------------------------------------------
+
+describe('getConfig', () => {
+  test('returns entity_id from discovery', async () => {
+    const adapter = await openAdapter();
+    expect(await adapter.getConfig('entity_id')).toBe('entity-owner-123');
+  });
+
+  test('returns timezone from discovery', async () => {
+    const adapter = await openAdapter();
+    expect(await adapter.getConfig('timezone')).toBe('America/New_York');
+  });
+
+  test('returns version from discovery', async () => {
+    const adapter = await openAdapter();
+    expect(await adapter.getConfig('version')).toBe('1.0');
+  });
+
+  test('returns null for unknown keys', async () => {
+    const adapter = await openAdapter();
+    expect(await adapter.getConfig('nonexistent')).toBeNull();
+  });
+});
+
+// -------------------------------------------------------
+// setConfig
+// -------------------------------------------------------
+
+describe('setConfig', () => {
+  test('is a no-op — does not throw and makes no requests', async () => {
+    const adapter = await openAdapter();
+    const callsBefore = mockFetch.mock.calls.length;
+    await expect(adapter.setConfig('timezone', 'UTC')).resolves.toBeUndefined();
+    expect(mockFetch.mock.calls.length).toBe(callsBefore);
+  });
+});
+
+// -------------------------------------------------------
+// createRecord
+// -------------------------------------------------------
+
+describe('createRecord', () => {
+  test('sends POST /records with record body', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(jsonResponse(RECORD_RAW));
+
+    const record: StackRecord = {
+      id: 'rec-abc123',
+      typeId: 'com.example/note@1',
+      createdAt: new Date('2024-06-15T12:00:00.000Z'),
+      updatedAt: new Date('2024-06-15T12:00:00.000Z'),
+      content: { text: 'Hello world' },
+      version: 1,
+    };
+    await adapter.createRecord(record);
+
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${BASE_URL}/records`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  test('parses dates in response', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(jsonResponse(RECORD_RAW));
+
+    const record: StackRecord = {
+      id: 'rec-abc123',
+      typeId: 'com.example/note@1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      content: { text: 'Hello' },
+      version: 1,
+    };
+    const result = await adapter.createRecord(record);
+    expect(result.createdAt).toBeInstanceOf(Date);
+    expect(result.updatedAt).toBeInstanceOf(Date);
+    expect(result.createdAt.toISOString()).toBe('2024-06-15T12:00:00.000Z');
+  });
+
+  test('sends Authorization header', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(jsonResponse(RECORD_RAW));
+    const record: StackRecord = {
+      id: 'r1',
+      typeId: 'com.example/note@1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      content: {},
+      version: 1,
+    };
+    await adapter.createRecord(record);
+    const [, init] = mockFetch.mock.lastCall as [string, RequestInit];
+    expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${TOKEN}`);
+  });
+});
+
+// -------------------------------------------------------
+// getRecord
+// -------------------------------------------------------
+
+describe('getRecord', () => {
+  test('sends GET /records/:id', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(jsonResponse(RECORD_RAW));
+    await adapter.getRecord('rec-abc123');
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${BASE_URL}/records/rec-abc123`,
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  test('parses response into StackRecord with Date objects', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(jsonResponse(RECORD_RAW));
+    const result = await adapter.getRecord('rec-abc123');
+    expect(result).not.toBeNull();
+    expect(result!.id).toBe('rec-abc123');
+    expect(result!.createdAt).toBeInstanceOf(Date);
+  });
+
+  test('returns null on 404', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 404 }));
+    expect(await adapter.getRecord('nonexistent')).toBeNull();
+  });
+
+  test('parses optional fields when present', async () => {
+    const adapter = await openAdapter();
+    const withOptionals = {
+      ...RECORD_RAW,
+      parentId: 'parent-1',
+      entityId: 'entity-1',
+      appId: 'app-1',
+      deletedAt: '2024-06-16T00:00:00.000Z',
+      permissions: [{ access: 'public' }],
+      associations: [{ kind: 'tag', label: 'starred' }],
+    };
+    mockFetch.mockResolvedValueOnce(jsonResponse(withOptionals));
+    const result = await adapter.getRecord('rec-abc123');
+    expect(result!.parentId).toBe('parent-1');
+    expect(result!.entityId).toBe('entity-1');
+    expect(result!.appId).toBe('app-1');
+    expect(result!.deletedAt).toBeInstanceOf(Date);
+    expect(result!.permissions).toEqual([{ access: 'public' }]);
+    expect(result!.associations).toEqual([{ kind: 'tag', label: 'starred' }]);
+  });
+});
+
+// -------------------------------------------------------
+// updateRecord
+// -------------------------------------------------------
+
+describe('updateRecord', () => {
+  test('sends PATCH /records/:id', async () => {
+    const adapter = await openAdapter();
+    const updated = { ...RECORD_RAW, content: { text: 'Updated' }, version: 2 };
+    mockFetch.mockResolvedValueOnce(jsonResponse(updated));
+    await adapter.updateRecord('rec-abc123', { content: { text: 'Updated' }, version: 2 });
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${BASE_URL}/records/rec-abc123`,
+      expect.objectContaining({ method: 'PATCH' }),
+    );
+  });
+
+  test('returns updated record with parsed dates', async () => {
+    const adapter = await openAdapter();
+    const updated = { ...RECORD_RAW, content: { text: 'Updated' }, version: 2 };
+    mockFetch.mockResolvedValueOnce(jsonResponse(updated));
+    const result = await adapter.updateRecord('rec-abc123', { content: { text: 'Updated' } });
+    expect(result.content).toEqual({ text: 'Updated' });
+    expect(result.updatedAt).toBeInstanceOf(Date);
+  });
+});
+
+// -------------------------------------------------------
+// deleteRecord
+// -------------------------------------------------------
+
+describe('deleteRecord', () => {
+  test('sends DELETE /records/:id for soft delete', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(noContent());
+    await adapter.deleteRecord('rec-abc123');
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${BASE_URL}/records/rec-abc123`,
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+
+  test('appends ?hard=true for hard delete', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(noContent());
+    await adapter.deleteRecord('rec-abc123', { hard: true });
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${BASE_URL}/records/rec-abc123?hard=true`,
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+});
+
+// -------------------------------------------------------
+// queryRecords
+// -------------------------------------------------------
+
+describe('queryRecords', () => {
+  const queryEnvelope = {
+    records: [RECORD_RAW],
+    cursor: null,
+    total: 1,
+  };
+
+  test('uses POST /records/query when contentFieldQuery is true', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(jsonResponse(queryEnvelope));
+    await adapter.queryRecords({ filter: { typeId: 'com.example/note@1' } });
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${BASE_URL}/records/query`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  test('uses GET /records when contentFieldQuery is false', async () => {
+    const limitedDiscovery = {
+      ...DISCOVERY,
+      capabilities: { ...DISCOVERY.capabilities, contentFieldQuery: false },
+    };
+    const adapter = await openAdapter(limitedDiscovery);
+    mockFetch.mockResolvedValueOnce(jsonResponse(queryEnvelope));
+    await adapter.queryRecords({ filter: { typeId: 'com.example/note@1' } });
+    const [url, init] = mockFetch.mock.lastCall as [string, RequestInit];
+    expect(init.method).toBe('GET');
+    expect(url).toContain('/records');
+    expect(url).toContain('typeId=com.example%2Fnote%401');
+  });
+
+  test('parses records and cursor from response', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(jsonResponse({ ...queryEnvelope, cursor: 'page2', total: 10 }));
+    const result = await adapter.queryRecords({});
+    expect(result.records).toHaveLength(1);
+    expect(result.records[0].createdAt).toBeInstanceOf(Date);
+    expect(result.cursor).toBe('page2');
+    expect(result.total).toBe(10);
+  });
+
+  test('passes query body to POST /records/query', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(jsonResponse(queryEnvelope));
+    const query = { filter: { typeId: 'com.example/note@1' }, limit: 10 };
+    await adapter.queryRecords(query);
+    const [, init] = mockFetch.mock.lastCall as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual(query);
+  });
+
+  test('builds correct GET params — parentId null becomes "null"', async () => {
+    const limitedDiscovery = {
+      ...DISCOVERY,
+      capabilities: { ...DISCOVERY.capabilities, contentFieldQuery: false },
+    };
+    const adapter = await openAdapter(limitedDiscovery);
+    mockFetch.mockResolvedValueOnce(jsonResponse(queryEnvelope));
+    await adapter.queryRecords({ filter: { parentId: null } });
+    const [url] = mockFetch.mock.lastCall as [string];
+    expect(url).toContain('parentId=null');
+  });
+});
+
+// -------------------------------------------------------
+// associate / dissociate
+// -------------------------------------------------------
+
+describe('associate', () => {
+  test('sends POST /records/:id/associations', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(noContent());
+    const assoc: Association = { kind: 'tag', label: 'starred' };
+    await adapter.associate('rec-abc123', assoc);
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${BASE_URL}/records/rec-abc123/associations`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  test('sends the association as JSON body', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(noContent());
+    const assoc: Association = { kind: 'tag', label: 'starred' };
+    await adapter.associate('rec-abc123', assoc);
+    const [, init] = mockFetch.mock.lastCall as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual(assoc);
+  });
+});
+
+describe('dissociate', () => {
+  test('sends DELETE /records/:id/associations', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(noContent());
+    const assoc: Association = { kind: 'tag', label: 'starred' };
+    await adapter.dissociate('rec-abc123', assoc);
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${BASE_URL}/records/rec-abc123/associations`,
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+});
+
+// -------------------------------------------------------
+// Versions
+// -------------------------------------------------------
+
+describe('getVersions', () => {
+  test('sends GET /records/:id/versions', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(jsonResponse([VERSION_RAW]));
+    await adapter.getVersions('rec-abc123');
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${BASE_URL}/records/rec-abc123/versions`,
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  test('parses version array with Date objects', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(jsonResponse([VERSION_RAW]));
+    const versions = await adapter.getVersions('rec-abc123');
+    expect(versions).toHaveLength(1);
+    expect(versions[0].version).toBe(1);
+    expect(versions[0].updatedAt).toBeInstanceOf(Date);
+    expect(versions[0].entityId).toBe('entity-owner-123');
+  });
+});
+
+describe('getVersion', () => {
+  test('sends GET /records/:id/versions/:version', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(jsonResponse(VERSION_RAW));
+    await adapter.getVersion('rec-abc123', 1);
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${BASE_URL}/records/rec-abc123/versions/1`,
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  test('returns null on 404', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 404 }));
+    expect(await adapter.getVersion('rec-abc123', 99)).toBeNull();
+  });
+});
+
+describe('saveVersion', () => {
+  test('is a no-op — does not make any HTTP requests', async () => {
+    const adapter = await openAdapter();
+    const callsBefore = mockFetch.mock.calls.length;
+    const v: RecordVersion = { version: 1, content: { text: 'v1' }, updatedAt: new Date() };
+    await expect(adapter.saveVersion('rec-abc123', v)).resolves.toBeUndefined();
+    expect(mockFetch.mock.calls.length).toBe(callsBefore);
+  });
+});
+
+// -------------------------------------------------------
+// Types
+// -------------------------------------------------------
+
+describe('saveType', () => {
+  test('sends POST /types with type body', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(noContent());
+    const type: StackType = {
+      id: 'com.example/note@1',
+      baseId: 'com.example/note',
+      version: 1,
+      name: 'Note',
+      schema: { text: { kind: 'text', required: true } },
+      schemaHash: 'abc123',
+      createdAt: new Date(),
+    };
+    await adapter.saveType(type);
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${BASE_URL}/types`,
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+});
+
+describe('getType', () => {
+  test('sends GET /types/:id with URL-encoded id', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(jsonResponse(NOTE_TYPE_RAW));
+    await adapter.getType('com.example/note@1');
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${BASE_URL}/types/com.example%2Fnote%401`,
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  test('parses response into StackType with Date', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(jsonResponse(NOTE_TYPE_RAW));
+    const type = await adapter.getType('com.example/note@1');
+    expect(type).not.toBeNull();
+    expect(type!.id).toBe('com.example/note@1');
+    expect(type!.createdAt).toBeInstanceOf(Date);
+    expect(type!.schema).toEqual({ text: { kind: 'text', required: true } });
+  });
+
+  test('returns null on 404', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 404 }));
+    expect(await adapter.getType('com.example/unknown@1')).toBeNull();
+  });
+
+  test('parses migratesFrom when present', async () => {
+    const adapter = await openAdapter();
+    const withLineage = { ...NOTE_TYPE_RAW, migratesFrom: 'com.example/note@0' };
+    mockFetch.mockResolvedValueOnce(jsonResponse(withLineage));
+    const type = await adapter.getType('com.example/note@1');
+    expect(type!.migratesFrom).toBe('com.example/note@0');
+  });
+});
+
+describe('listTypes', () => {
+  test('sends GET /types', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(jsonResponse([NOTE_TYPE_RAW]));
+    const types = await adapter.listTypes();
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${BASE_URL}/types`,
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(types).toHaveLength(1);
+    expect(types[0].createdAt).toBeInstanceOf(Date);
+  });
+});
+
+// -------------------------------------------------------
+// Attachments
+// -------------------------------------------------------
+
+describe('putAttachment', () => {
+  test('sends POST /attachments with binary body and Content-Type', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(jsonResponse({ fileId: 'file-xyz' }));
+    const data = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    const fileId = await adapter.putAttachment(data, 'image/png');
+    expect(fileId).toBe('file-xyz');
+    const [url, init] = mockFetch.mock.lastCall as [string, RequestInit];
+    expect(url).toBe(`${BASE_URL}/attachments`);
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>)['Content-Type']).toBe('image/png');
+  });
+});
+
+describe('getAttachment', () => {
+  test('sends GET /attachments/:fileId and returns Uint8Array', async () => {
+    const adapter = await openAdapter();
+    const data = new Uint8Array([1, 2, 3, 4]);
+    mockFetch.mockResolvedValueOnce(new Response(data, { status: 200 }));
+    const result = await adapter.getAttachment('file-xyz');
+    expect(result).toBeInstanceOf(Uint8Array);
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${BASE_URL}/attachments/file-xyz`,
+      expect.anything(),
+    );
+  });
+});
+
+describe('deleteAttachment', () => {
+  test('sends DELETE /attachments/:fileId', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(noContent());
+    await adapter.deleteAttachment('file-xyz');
+    expect(mockFetch).toHaveBeenLastCalledWith(
+      `${BASE_URL}/attachments/file-xyz`,
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+});
+
+// -------------------------------------------------------
+// Lifecycle
+// -------------------------------------------------------
+
+describe('flush', () => {
+  test('is a no-op', async () => {
+    const adapter = await openAdapter();
+    const callsBefore = mockFetch.mock.calls.length;
+    await expect(adapter.flush()).resolves.toBeUndefined();
+    expect(mockFetch.mock.calls.length).toBe(callsBefore);
+  });
+});
+
+describe('close', () => {
+  test('is a no-op', async () => {
+    const adapter = await openAdapter();
+    const callsBefore = mockFetch.mock.calls.length;
+    await expect(adapter.close()).resolves.toBeUndefined();
+    expect(mockFetch.mock.calls.length).toBe(callsBefore);
+  });
+});
+
+// -------------------------------------------------------
+// Error propagation
+// -------------------------------------------------------
+
+describe('error propagation on subsequent requests', () => {
+  test('throws APIAdapterAuthError on 401 during getRecord', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 401 }));
+    await expect(adapter.getRecord('rec-abc')).rejects.toThrow(APIAdapterAuthError);
+  });
+
+  test('throws APIAdapterConnectionError when network fails on createRecord', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    const record: StackRecord = {
+      id: 'r1',
+      typeId: 'com.example/note@1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      content: {},
+      version: 1,
+    };
+    await expect(adapter.createRecord(record)).rejects.toThrow(APIAdapterConnectionError);
+  });
+
+  test('throws APIAdapterError on 500', async () => {
+    const adapter = await openAdapter();
+    mockFetch.mockResolvedValueOnce(new Response('Internal Server Error', { status: 500 }));
+    await expect(adapter.listTypes()).rejects.toThrow(APIAdapterError);
+  });
+});

--- a/packages/adapter-api/tests/api.test.ts
+++ b/packages/adapter-api/tests/api.test.ts
@@ -170,11 +170,9 @@ describe('getConfig', () => {
 // -------------------------------------------------------
 
 describe('setConfig', () => {
-  test('is a no-op — does not throw and makes no requests', async () => {
+  test('throws APIAdapterError — server owns its config', async () => {
     const adapter = await openAdapter();
-    const callsBefore = mockFetch.mock.calls.length;
-    await expect(adapter.setConfig('timezone', 'UTC')).resolves.toBeUndefined();
-    expect(mockFetch.mock.calls.length).toBe(callsBefore);
+    await expect(adapter.setConfig('timezone', 'UTC')).rejects.toThrow(APIAdapterError);
   });
 });
 

--- a/packages/adapter-api/tsconfig.build.json
+++ b/packages/adapter-api/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "noEmit": false
+  },
+  "exclude": ["tests/**/*.ts"]
+}

--- a/packages/adapter-api/tsconfig.json
+++ b/packages/adapter-api/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/packages/adapter-api/vitest.config.ts
+++ b/packages/adapter-api/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@haverstack/core': resolve(__dirname, '../core/src/index.ts'),
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,22 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@22.19.17)
 
+  packages/adapter-api:
+    dependencies:
+      '@haverstack/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.19.17)
+
   packages/adapter-sqlite:
     dependencies:
       '@haverstack/core':


### PR DESCRIPTION
## Summary
Introduces `@haverstack/adapter-api`, a new adapter package that implements the `StackAdapter` interface over HTTP. This enables Haverstack to connect to and interact with remote stack servers via REST APIs.

## Key Changes
- **New package**: `packages/adapter-api` with complete HTTP-based adapter implementation
- **APIAdapter class**: Implements `StackAdapter` interface with full CRUD operations for records, types, versions, and attachments
- **Discovery protocol**: Calls `GET /.well-known/stack` on initialization to verify server connectivity and populate adapter capabilities
- **Authentication**: Supports bearer token authentication via `Authorization` header
- **Error handling**: Three custom error types (`APIAdapterError`, `APIAdapterAuthError`, `APIAdapterConnectionError`) for different failure modes
- **Query support**: Dual-mode query support—uses `POST /records/query` when server supports `contentFieldQuery`, falls back to `GET /records` with URL parameters otherwise
- **Date parsing**: Automatically converts ISO 8601 date strings to JavaScript `Date` objects in responses
- **Binary attachments**: Dedicated methods for uploading and downloading binary file data with proper MIME type handling
- **Comprehensive test suite**: 676 lines of vitest tests covering all adapter methods, error cases, and edge cases

## Notable Implementation Details
- **Stateless design**: No client-side queuing or offline support in v1; each request commits immediately
- **Config handling**: Server configuration is read-only; `setConfig()` is a no-op as the server owns its configuration
- **Version snapshots**: Versions are automatically captured server-side as a side effect of `updateRecord()`; `saveVersion()` is a no-op
- **URL encoding**: Type IDs are properly URL-encoded when used in paths (e.g., `com.example/note@1` → `com.example%2Fnote%401`)
- **Query parameter building**: Supports complex filter expressions including date ranges, tags, full-text search, and related record queries

https://claude.ai/code/session_0187PrwhJE1trEXuJVkSMEAt