### PR TITLE
fix: export AttachmentMeta, add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm run build
+
+      - run: pnpm run typecheck
+
+      - run: pnpm run lint
+
+      - run: pnpm run test

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export type {
   RecordId,
   TypeId,
   FileId,
+  AttachmentMeta,
   StackRecord,
   RecordVersion,
   StackType,

--- a/packages/core/tests/stack.test.ts
+++ b/packages/core/tests/stack.test.ts
@@ -10,6 +10,7 @@ import type {
   QueryResult,
   Association,
   AdapterCapabilities,
+  AttachmentMeta,
 } from '../src/types.js';
 
 // -------------------------------------------------------
@@ -125,7 +126,13 @@ class MockAdapter implements StackAdapter {
   async getAttachment(_fileId: string): Promise<Uint8Array> {
     return new Uint8Array();
   }
+  async getAttachmentMeta(_fileId: string): Promise<AttachmentMeta | null> {
+    return null;
+  }
   async deleteAttachment(_fileId: string) {}
+
+  flush?: () => Promise<void>;
+  close?: () => Promise<void>;
 }
 
 // -------------------------------------------------------
@@ -557,7 +564,9 @@ describe('delete', () => {
 describe('flush / close', () => {
   test('flush() delegates to adapter.flush() when implemented', async () => {
     let flushed = false;
-    adapter.flush = async () => { flushed = true; };
+    adapter.flush = async () => {
+      flushed = true;
+    };
     await stack.flush();
     expect(flushed).toBe(true);
   });
@@ -568,7 +577,9 @@ describe('flush / close', () => {
 
   test('close() delegates to adapter.close() when implemented', async () => {
     let closed = false;
-    adapter.close = async () => { closed = true; };
+    adapter.close = async () => {
+      closed = true;
+    };
     await stack.close();
     expect(closed).toBe(true);
   });


### PR DESCRIPTION
## Summary

- Exports `AttachmentMeta` from `packages/core/src/index.ts` — it's part of the public `StackAdapter.getAttachmentMeta` signature but was never added to the package's export list, so any consumer importing it by name (`adapter-sqlite`, `adapter-api`) failed to build with `TS2305`. This has been silently broken since PR #14.
- Adds a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs `build`, `typecheck`, `lint`, and `test` across all packages on every push to `main` and every PR — there was no CI at all before this, which is exactly how the export bug above went unnoticed through two more merges.
- Fixes `MockAdapter` in `packages/core/tests/stack.test.ts`, which was missing `getAttachmentMeta` (required by `StackAdapter`) and the optional `flush`/`close` hooks the test suite assigns at runtime. `typecheck` was failing on `main` before this fix — needed to make the new CI job actually pass.

## Notes

- `format:check` is intentionally left out of the CI workflow for now — `main` currently has pre-existing Prettier drift across 8 unrelated files (`docs/spec.md`, two READMEs, `adapter-api`/`adapter-sqlite` source, etc.). Happy to add a follow-up PR to clean that up and turn the gate on, but didn't want to bundle a large, unrelated reformat into this fix.
- `build`, `typecheck`, `lint`, and `test` all pass cleanly on this branch.

## Test plan

- [x] `pnpm run build` passes (previously failed for `adapter-sqlite`/`adapter-api`)
- [x] `pnpm run typecheck` passes (previously failed on `packages/core`'s own test suite)
- [x] `pnpm run lint` passes
- [x] `pnpm run test` passes (248 tests across all packages)
- [x] CI workflow added and scoped to currently-passing checks


---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3wAK82yALLxZva8baqhqo)_