### PR TITLE
Add Stack.asEntity() for permission-scoped access

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -280,7 +280,7 @@ Cross-stack group resolution (where the `_group` Record lives in a different sta
 
 **Enforcement: `Stack.asEntity()`**
 
-The core library ships a permission-enforcing wrapper so server implementations don't need to reimplement this resolution logic. `stack.asEntity(entityId)` — `entityId` is `null` for an anonymous/unauthenticated requester — returns a `ScopedStack`: the same read/write/query/version surface as `Stack`, but every operation is checked against the rules above. The owner always has full access. Reading or writing a Record that exists but isn't visible throws `PermissionError`; a missing Record still throws a plain `Error`, so callers can distinguish "not found" from "forbidden" (typically 404 vs 403 at the HTTP layer).
+The core library ships a permission-enforcing wrapper so server implementations don't need to reimplement this resolution logic. `stack.asEntity(entityId)` — `entityId` is `null` for an anonymous/unauthenticated requester — returns a `ScopedStack`: the same read/write/query/version surface as `Stack`, but every operation is checked against the rules above. The owner always has full access. Reading or writing a Record that exists but isn't visible throws `StackPermissionError`; a missing Record still throws a plain `Error`, so callers can distinguish "not found" from "forbidden" (typically 404 vs 403 at the HTTP layer).
 
 Plain `Stack` methods remain unscoped and perform no permission checks — correct for single-entity embedded use, where there's no requester distinct from the app itself. Use `asEntity()` when one `Stack` instance serves requests from multiple, possibly untrusted, entities, e.g. a server adapter.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -278,6 +278,16 @@ Group permissions reference a `_group` Record by ID. The group may be a simple p
 
 Cross-stack group resolution (where the `_group` Record lives in a different stack than the Record being accessed) requires the server to have read access to that stack.
 
+**Enforcement: `Stack.asEntity()`**
+
+The core library ships a permission-enforcing wrapper so server implementations don't need to reimplement this resolution logic. `stack.asEntity(entityId)` — `entityId` is `null` for an anonymous/unauthenticated requester — returns a `ScopedStack`: the same read/write/query/version surface as `Stack`, but every operation is checked against the rules above. The owner always has full access. Reading or writing a Record that exists but isn't visible throws `PermissionError`; a missing Record still throws a plain `Error`, so callers can distinguish "not found" from "forbidden" (typically 404 vs 403 at the HTTP layer).
+
+Plain `Stack` methods remain unscoped and perform no permission checks — correct for single-entity embedded use, where there's no requester distinct from the app itself. Use `asEntity()` when one `Stack` instance serves requests from multiple, possibly untrusted, entities, e.g. a server adapter.
+
+`ScopedStack.query()`'s `total` is always `null`. The adapter's unfiltered count would otherwise leak the existence and cardinality of Records the requester can't read, even when the returned `records` array comes back empty. Computing an exact filtered count would require evaluating every match rather than just the returned page, so it's intentionally not attempted.
+
+`ScopedStack`'s group-membership check only resolves `_group` Records living in the same stack as the Record being accessed — it does not yet implement the cross-stack case described above. A server relying on cross-stack groups must still handle that case itself.
+
 ---
 
 ## Versions

--- a/packages/adapter-api/src/index.ts
+++ b/packages/adapter-api/src/index.ts
@@ -339,7 +339,11 @@ export class APIAdapter implements StackAdapter {
   }
 
   async queryRecords(query: StackQuery): Promise<QueryResult> {
-    type Envelope = { records: Record<string, unknown>[]; cursor: string | null; total: number };
+    type Envelope = {
+      records: Record<string, unknown>[];
+      cursor: string | null;
+      total: number | null;
+    };
 
     let raw: Envelope;
     if (this.capabilities.contentFieldQuery) {

--- a/packages/core/src/access.ts
+++ b/packages/core/src/access.ts
@@ -1,0 +1,76 @@
+/**
+ * Stack — Permission Resolution
+ * -------------------------------------------------------
+ * Implements the Permissions model from the spec: a pure predicate over a
+ * Record's `permissions` field, with no dependency on a transport layer or
+ * storage backend. Used by ScopedStack (see stack.ts) to enforce access
+ * control; exported standalone for callers that want the raw predicate.
+ */
+
+import type { RecordId, StackRecord } from './types.js';
+
+export type AccessMode = 'read' | 'write';
+
+/**
+ * Resolves a Record by ID. Used to walk a `_group` Record's associations for
+ * membership checks without requiring a full StackAdapter.
+ */
+export type RecordResolver = (id: RecordId) => Promise<StackRecord | null>;
+
+/**
+ * Check whether an entity has read or write access to a Record.
+ *
+ * - No permissions (absent/empty): owner only.
+ * - public: anyone can read; write still requires an explicit grant.
+ * - entity: direct entityId match.
+ * - group: walk the _group Record's relationship associations for membership.
+ */
+export async function checkAccess(
+  record: StackRecord,
+  requesterEntityId: string | null,
+  ownerEntityId: string | null,
+  mode: AccessMode,
+  resolveRecord: RecordResolver,
+): Promise<boolean> {
+  // Owner always has full access.
+  if (requesterEntityId && requesterEntityId === ownerEntityId) return true;
+
+  const perms = record.permissions;
+
+  // No permissions = private.
+  if (!perms || perms.length === 0) return false;
+
+  for (const p of perms) {
+    if (p.access === 'public' && mode === 'read') return true;
+
+    if (p.access === 'entity' && p.entityId === requesterEntityId) {
+      if (mode === 'read' && p.read) return true;
+      if (mode === 'write' && p.write) return true;
+    }
+
+    if (p.access === 'group' && requesterEntityId) {
+      const member = await isGroupMember(p.groupId, requesterEntityId, resolveRecord);
+      if (member) {
+        if (mode === 'read' && p.read) return true;
+        if (mode === 'write' && p.write) return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+async function isGroupMember(
+  groupRecordId: RecordId,
+  entityId: string,
+  resolveRecord: RecordResolver,
+): Promise<boolean> {
+  const group = await resolveRecord(groupRecordId);
+  if (!group) return false;
+  return (group.associations ?? []).some(
+    (a) =>
+      a.kind === 'relationship' &&
+      (a.label === 'member' || a.label === 'admin') &&
+      a.recordId === entityId,
+  );
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,7 +14,7 @@ export {
   ScopedStack,
   StackValidationError,
   StackMigrationError,
-  PermissionError,
+  StackPermissionError,
 } from './stack.js';
 export type { CreateRecordOptions, GetRecordOptions, DeleteRecordOptions } from './stack.js';
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,8 +9,18 @@
  */
 
 // Core class
-export { Stack, StackValidationError, StackMigrationError } from './stack.js';
+export {
+  Stack,
+  ScopedStack,
+  StackValidationError,
+  StackMigrationError,
+  PermissionError,
+} from './stack.js';
 export type { CreateRecordOptions, GetRecordOptions, DeleteRecordOptions } from './stack.js';
+
+// Permissions
+export { checkAccess } from './access.js';
+export type { AccessMode, RecordResolver } from './access.js';
 
 // Types
 export type {

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -78,10 +78,10 @@ export class StackMigrationError extends Error {
 }
 
 /** Thrown by ScopedStack when a requester lacks permission for the operation. */
-export class PermissionError extends Error {
+export class StackPermissionError extends Error {
   constructor(message = 'Permission denied') {
     super(message);
-    this.name = 'PermissionError';
+    this.name = 'StackPermissionError';
   }
 }
 
@@ -578,8 +578,8 @@ const DEFAULT_QUERY_LIMIT = 50;
  * via `stack.asEntity(entityId)` — see there for when to use it.
  *
  * Read methods return null for a Record that doesn't exist, and throw
- * PermissionError for one that exists but isn't readable by the requester.
- * Write methods throw PermissionError for a Record that exists but isn't
+ * StackPermissionError for one that exists but isn't readable by the requester.
+ * Write methods throw StackPermissionError for a Record that exists but isn't
  * writable. This lets callers distinguish "not found" from "forbidden".
  */
 export class ScopedStack {
@@ -615,14 +615,14 @@ export class ScopedStack {
   private async requireWritable(id: string): Promise<StackRecord> {
     const existing = await this.stack.get(id, { migrate: false });
     if (!existing) throw new Error(`Record not found: "${id}"`);
-    if (!(await this.checkWrite(existing))) throw new PermissionError();
+    if (!(await this.checkWrite(existing))) throw new StackPermissionError();
     return existing;
   }
 
   async get(id: string, opts: GetRecordOptions = {}): Promise<StackRecord | null> {
     const record = await this.stack.get(id, opts);
     if (!record) return null;
-    if (!(await this.checkRead(record))) throw new PermissionError();
+    if (!(await this.checkRead(record))) throw new StackPermissionError();
     return record;
   }
 
@@ -680,14 +680,14 @@ export class ScopedStack {
   async getVersions(id: string): Promise<RecordVersion[]> {
     const existing = await this.stack.get(id, { migrate: false });
     if (!existing) throw new Error(`Record not found: "${id}"`);
-    if (!(await this.checkRead(existing))) throw new PermissionError();
+    if (!(await this.checkRead(existing))) throw new StackPermissionError();
     return this.stack.getVersions(id);
   }
 
   async getVersion(id: string, version: number): Promise<RecordVersion | null> {
     const existing = await this.stack.get(id, { migrate: false });
     if (!existing) throw new Error(`Record not found: "${id}"`);
-    if (!(await this.checkRead(existing))) throw new PermissionError();
+    if (!(await this.checkRead(existing))) throw new StackPermissionError();
     return this.stack.getVersion(id, version);
   }
 

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -17,6 +17,7 @@
 import { generateId } from './id.js';
 import { hashSchema, isCompatible, parseTypeId } from './schema.js';
 import { validateContent } from './validate.js';
+import { checkAccess } from './access.js';
 import type { ValidationError } from './validate.js';
 import type {
   StackRecord,
@@ -76,6 +77,14 @@ export class StackMigrationError extends Error {
   }
 }
 
+/** Thrown by ScopedStack when a requester lacks permission for the operation. */
+export class PermissionError extends Error {
+  constructor(message = 'Permission denied') {
+    super(message);
+    this.name = 'PermissionError';
+  }
+}
+
 // -------------------------------------------------------
 // Stack class
 // -------------------------------------------------------
@@ -102,6 +111,22 @@ export class Stack {
 
   get capabilities(): AdapterCapabilities {
     return this.adapter.capabilities;
+  }
+
+  /**
+   * Get a permission-scoped view of this Stack, as if the request came from
+   * the given entity. Pass null for an anonymous/unauthenticated requester.
+   * Reads and writes are checked against each Record's `permissions`; the
+   * owner always has full access.
+   *
+   * Plain Stack methods are unscoped and skip permission checks entirely —
+   * correct for single-entity embedded use, where there's no requester
+   * distinct from the app itself. Use asEntity() when one Stack instance
+   * serves requests from multiple, possibly untrusted, entities (e.g. a
+   * multi-tenant API server).
+   */
+  asEntity(entityId: string | null): ScopedStack {
+    return new ScopedStack(this, entityId);
   }
 
   // -------------------------------------------------------
@@ -538,5 +563,136 @@ export class Stack {
       ...(record.entityId && { entityId: record.entityId }),
     };
     await this.adapter.saveVersion(record.id, version);
+  }
+}
+
+// -------------------------------------------------------
+// ScopedStack
+// -------------------------------------------------------
+
+/** Default page size used to fill a permission-filtered query result. */
+const DEFAULT_QUERY_LIMIT = 50;
+
+/**
+ * A permission-enforcing view of a Stack for a single requester. Obtained
+ * via `stack.asEntity(entityId)` — see there for when to use it.
+ *
+ * Read methods return null for a Record that doesn't exist, and throw
+ * PermissionError for one that exists but isn't readable by the requester.
+ * Write methods throw PermissionError for a Record that exists but isn't
+ * writable. This lets callers distinguish "not found" from "forbidden".
+ */
+export class ScopedStack {
+  constructor(
+    private readonly stack: Stack,
+    private readonly requesterEntityId: string | null,
+  ) {}
+
+  private resolveRecord = (id: string): Promise<StackRecord | null> =>
+    this.stack.get(id, { migrate: false });
+
+  private checkRead(record: StackRecord): Promise<boolean> {
+    return checkAccess(
+      record,
+      this.requesterEntityId,
+      this.stack.ownerEntityId,
+      'read',
+      this.resolveRecord,
+    );
+  }
+
+  private checkWrite(record: StackRecord): Promise<boolean> {
+    return checkAccess(
+      record,
+      this.requesterEntityId,
+      this.stack.ownerEntityId,
+      'write',
+      this.resolveRecord,
+    );
+  }
+
+  /** Fetch a Record the requester has write access to, or throw. */
+  private async requireWritable(id: string): Promise<StackRecord> {
+    const existing = await this.stack.get(id, { migrate: false });
+    if (!existing) throw new Error(`Record not found: "${id}"`);
+    if (!(await this.checkWrite(existing))) throw new PermissionError();
+    return existing;
+  }
+
+  async get(id: string, opts: GetRecordOptions = {}): Promise<StackRecord | null> {
+    const record = await this.stack.get(id, opts);
+    if (!record) return null;
+    if (!(await this.checkRead(record))) throw new PermissionError();
+    return record;
+  }
+
+  /**
+   * Query records, filtered to only those the requester can read.
+   *
+   * Pagination is filtered-then-refilled: each adapter page is fetched in
+   * full and entirely evaluated before deciding whether to fetch another,
+   * so the returned page may overshoot `limit` slightly, but never skips a
+   * record that shared a page with the one that crossed the threshold (the
+   * adapter's cursor can't address a position mid-page).
+   *
+   * `total` is always null — see the QueryResult.total doc comment.
+   */
+  async query(query: StackQuery = {}): Promise<QueryResult> {
+    const limit = query.limit ?? DEFAULT_QUERY_LIMIT;
+    const records: StackRecord[] = [];
+    let page: QueryResult = { records: [], cursor: query.cursor ?? null, total: null };
+
+    do {
+      page = await this.stack.query({ ...query, cursor: page.cursor ?? undefined });
+      for (const record of page.records) {
+        if (await this.checkRead(record)) records.push(record);
+      }
+    } while (records.length < limit && page.cursor);
+
+    return { records, cursor: page.cursor, total: null };
+  }
+
+  async update(id: string, content: Record<string, unknown | null>): Promise<StackRecord> {
+    await this.requireWritable(id);
+    return this.stack.update(id, content);
+  }
+
+  async associate(id: string, association: Association): Promise<void> {
+    await this.requireWritable(id);
+    return this.stack.associate(id, association);
+  }
+
+  async dissociate(id: string, association: Association): Promise<void> {
+    await this.requireWritable(id);
+    return this.stack.dissociate(id, association);
+  }
+
+  async setPermissions(id: string, permissions: Permission[]): Promise<void> {
+    await this.requireWritable(id);
+    return this.stack.setPermissions(id, permissions);
+  }
+
+  async delete(id: string, opts: DeleteRecordOptions = {}): Promise<void> {
+    await this.requireWritable(id);
+    return this.stack.delete(id, opts);
+  }
+
+  async getVersions(id: string): Promise<RecordVersion[]> {
+    const existing = await this.stack.get(id, { migrate: false });
+    if (!existing) throw new Error(`Record not found: "${id}"`);
+    if (!(await this.checkRead(existing))) throw new PermissionError();
+    return this.stack.getVersions(id);
+  }
+
+  async getVersion(id: string, version: number): Promise<RecordVersion | null> {
+    const existing = await this.stack.get(id, { migrate: false });
+    if (!existing) throw new Error(`Record not found: "${id}"`);
+    if (!(await this.checkRead(existing))) throw new PermissionError();
+    return this.stack.getVersion(id, version);
+  }
+
+  async restoreVersion(id: string, version: number): Promise<StackRecord> {
+    await this.requireWritable(id);
+    return this.stack.restoreVersion(id, version);
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -239,7 +239,14 @@ export type StackQuery = {
 export type QueryResult = {
   records: StackRecord[];
   cursor: string | null;
-  total: number;
+  /**
+   * Total count of matching records, ignoring pagination. `null` when the
+   * count cannot be reported without leaking information across a
+   * permission boundary — e.g. a permission-scoped query (see
+   * `Stack.asEntity()`) never reports an unfiltered total, since that would
+   * reveal the existence/cardinality of records the requester can't read.
+   */
+  total: number | null;
 };
 
 // -------------------------------------------------------

--- a/packages/core/tests/scoped-stack.test.ts
+++ b/packages/core/tests/scoped-stack.test.ts
@@ -1,0 +1,406 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { Stack, PermissionError } from '../src/stack.js';
+import { generateId } from '../src/id.js';
+import type {
+  StackAdapter,
+  StackRecord,
+  StackType,
+  TypeId,
+  RecordVersion,
+  StackQuery,
+  QueryResult,
+  Association,
+  AdapterCapabilities,
+  AttachmentMeta,
+  Permission,
+} from '../src/types.js';
+
+// -------------------------------------------------------
+// Mock adapter with real cursor-based pagination — needed to exercise
+// ScopedStack.query()'s filter-then-refill loop across multiple pages.
+// -------------------------------------------------------
+
+class PaginatingMockAdapter implements StackAdapter {
+  readonly capabilities: AdapterCapabilities = {
+    fullTextSearch: false,
+    contentFieldQuery: false,
+    sortableFields: ['createdAt', 'updatedAt', 'version'],
+  };
+
+  readonly records = new Map<string, StackRecord>();
+  readonly order: string[] = [];
+  readonly versions = new Map<string, RecordVersion[]>();
+  readonly types = new Map<string, StackType>();
+  readonly config = new Map<string, string>([
+    ['entity_id', 'owner-123'],
+    ['timezone', 'UTC'],
+  ]);
+
+  async getConfig(key: string) {
+    return this.config.get(key) ?? null;
+  }
+  async setConfig(key: string, value: string) {
+    this.config.set(key, value);
+  }
+
+  async createRecord(record: StackRecord) {
+    this.records.set(record.id, { ...record });
+    this.order.push(record.id);
+    return record;
+  }
+
+  async getRecord(id: string) {
+    return this.records.get(id) ?? null;
+  }
+
+  async updateRecord(id: string, changes: Partial<StackRecord>) {
+    const existing = this.records.get(id);
+    if (!existing) throw new Error(`Not found: ${id}`);
+    const updated = { ...existing, ...changes };
+    this.records.set(id, updated);
+    return updated;
+  }
+
+  async deleteRecord(id: string, opts: { hard?: boolean } = {}) {
+    if (opts.hard) {
+      this.records.delete(id);
+      this.order.splice(this.order.indexOf(id), 1);
+    } else {
+      const record = this.records.get(id);
+      if (record) this.records.set(id, { ...record, deletedAt: new Date() });
+    }
+  }
+
+  /** Cursor is just a stringified offset into insertion order — fine for tests. */
+  async queryRecords(query: StackQuery): Promise<QueryResult> {
+    const f = query.filter ?? {};
+    let results = this.order.map((id) => this.records.get(id)!);
+    if (!f.includeDeleted) results = results.filter((r) => !r.deletedAt);
+    if (f.typeId) {
+      const ids = Array.isArray(f.typeId) ? f.typeId : [f.typeId];
+      results = results.filter((r) => ids.includes(r.typeId));
+    }
+
+    const limit = query.limit ?? 50;
+    const start = query.cursor ? Number(query.cursor) : 0;
+    const page = results.slice(start, start + limit);
+    const nextStart = start + limit;
+    const cursor = nextStart < results.length ? String(nextStart) : null;
+
+    return { records: page, cursor, total: results.length };
+  }
+
+  async associate(id: string, association: Association) {
+    const record = this.records.get(id);
+    if (!record) throw new Error(`Not found: ${id}`);
+    const assocs = record.associations ?? [];
+    this.records.set(id, { ...record, associations: [...assocs, association] });
+  }
+
+  async dissociate(id: string, association: Association) {
+    const record = this.records.get(id);
+    if (!record) throw new Error(`Not found: ${id}`);
+    const assocs = (record.associations ?? []).filter(
+      (a) => !(a.kind === association.kind && a.label === association.label),
+    );
+    this.records.set(id, { ...record, associations: assocs });
+  }
+
+  async getVersions(id: string) {
+    return this.versions.get(id) ?? [];
+  }
+  async getVersion(id: string, version: number) {
+    return (this.versions.get(id) ?? []).find((v) => v.version === version) ?? null;
+  }
+  async saveVersion(id: string, version: RecordVersion) {
+    const existing = this.versions.get(id) ?? [];
+    this.versions.set(id, [...existing, version]);
+  }
+
+  async saveType(type: StackType) {
+    this.types.set(type.id, type);
+  }
+  async getType(id: TypeId) {
+    return this.types.get(id) ?? null;
+  }
+  async listTypes() {
+    return [...this.types.values()];
+  }
+
+  async putAttachment(_data: Uint8Array, _mimeType: string) {
+    return 'file-123';
+  }
+  async getAttachment(_fileId: string): Promise<Uint8Array> {
+    return new Uint8Array();
+  }
+  async getAttachmentMeta(_fileId: string): Promise<AttachmentMeta | null> {
+    return null;
+  }
+  async deleteAttachment(_fileId: string) {}
+}
+
+// -------------------------------------------------------
+// Test setup
+// -------------------------------------------------------
+
+const NOTE = 'com.example.test/note@1';
+const OWNER = 'owner-123';
+const MEMBER = 'member-456';
+const STRANGER = 'stranger-789';
+
+let adapter: PaginatingMockAdapter;
+let stack: Stack;
+
+function makeRecord(overrides: Partial<StackRecord> = {}): StackRecord {
+  const now = new Date();
+  return {
+    id: generateId(),
+    typeId: NOTE,
+    createdAt: now,
+    updatedAt: now,
+    content: {},
+    version: 1,
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  adapter = new PaginatingMockAdapter();
+  stack = await Stack.create(adapter);
+  await stack.defineType(NOTE, 'Note', { text: { kind: 'text' } });
+});
+
+// -------------------------------------------------------
+// Read access
+// -------------------------------------------------------
+
+describe('ScopedStack — read access', () => {
+  test('owner can read a private record', async () => {
+    const record = await adapter.createRecord(makeRecord());
+    const view = stack.asEntity(OWNER);
+    expect(await view.get(record.id)).toEqual(record);
+  });
+
+  test('anonymous requester cannot read a private record', async () => {
+    const record = await adapter.createRecord(makeRecord());
+    const view = stack.asEntity(null);
+    await expect(view.get(record.id)).rejects.toThrow(PermissionError);
+  });
+
+  test('anonymous requester can read a public record', async () => {
+    const record = await adapter.createRecord(makeRecord({ permissions: [{ access: 'public' }] }));
+    const view = stack.asEntity(null);
+    expect((await view.get(record.id))?.id).toBe(record.id);
+  });
+
+  test('entity with a matching read grant can read', async () => {
+    const record = await adapter.createRecord(
+      makeRecord({
+        permissions: [{ access: 'entity', entityId: MEMBER, read: true, write: false }],
+      }),
+    );
+    expect((await stack.asEntity(MEMBER).get(record.id))?.id).toBe(record.id);
+  });
+
+  test('entity without a matching grant cannot read', async () => {
+    const record = await adapter.createRecord(
+      makeRecord({
+        permissions: [{ access: 'entity', entityId: MEMBER, read: true, write: false }],
+      }),
+    );
+    await expect(stack.asEntity(STRANGER).get(record.id)).rejects.toThrow(PermissionError);
+  });
+
+  test('group member can read via a group read grant', async () => {
+    const group = await adapter.createRecord(
+      makeRecord({
+        typeId: '_group',
+        associations: [{ kind: 'relationship', label: 'member', recordId: MEMBER }],
+      }),
+    );
+    const record = await adapter.createRecord(
+      makeRecord({
+        permissions: [{ access: 'group', groupId: group.id, read: true, write: false }],
+      }),
+    );
+    expect((await stack.asEntity(MEMBER).get(record.id))?.id).toBe(record.id);
+  });
+
+  test('non-member cannot read via a group read grant', async () => {
+    const group = await adapter.createRecord(
+      makeRecord({
+        typeId: '_group',
+        associations: [{ kind: 'relationship', label: 'member', recordId: MEMBER }],
+      }),
+    );
+    const record = await adapter.createRecord(
+      makeRecord({
+        permissions: [{ access: 'group', groupId: group.id, read: true, write: false }],
+      }),
+    );
+    await expect(stack.asEntity(STRANGER).get(record.id)).rejects.toThrow(PermissionError);
+  });
+
+  test('get() returns null, not PermissionError, for a record that does not exist', async () => {
+    expect(await stack.asEntity(OWNER).get('nonexistent')).toBeNull();
+    expect(await stack.asEntity(null).get('nonexistent')).toBeNull();
+  });
+});
+
+// -------------------------------------------------------
+// Write access
+// -------------------------------------------------------
+
+describe('ScopedStack — write access', () => {
+  test('owner can update any record', async () => {
+    const record = await adapter.createRecord(makeRecord());
+    const updated = await stack.asEntity(OWNER).update(record.id, { text: 'hi' });
+    expect(updated.content.text).toBe('hi');
+  });
+
+  test('public access does not grant write', async () => {
+    const record = await adapter.createRecord(makeRecord({ permissions: [{ access: 'public' }] }));
+    await expect(stack.asEntity(STRANGER).update(record.id, { text: 'hi' })).rejects.toThrow(
+      PermissionError,
+    );
+  });
+
+  test('entity with write:true can update', async () => {
+    const record = await adapter.createRecord(
+      makeRecord({
+        permissions: [{ access: 'entity', entityId: MEMBER, read: true, write: true }],
+      }),
+    );
+    const updated = await stack.asEntity(MEMBER).update(record.id, { text: 'hi' });
+    expect(updated.content.text).toBe('hi');
+  });
+
+  test('entity with write:false cannot update even with read:true', async () => {
+    const record = await adapter.createRecord(
+      makeRecord({
+        permissions: [{ access: 'entity', entityId: MEMBER, read: true, write: false }],
+      }),
+    );
+    await expect(stack.asEntity(MEMBER).update(record.id, { text: 'hi' })).rejects.toThrow(
+      PermissionError,
+    );
+  });
+
+  test('delete enforces write access', async () => {
+    const record = await adapter.createRecord(makeRecord());
+    await expect(stack.asEntity(STRANGER).delete(record.id)).rejects.toThrow(PermissionError);
+    await stack.asEntity(OWNER).delete(record.id);
+    expect((await adapter.getRecord(record.id))?.deletedAt).toBeDefined();
+  });
+
+  test('associate/dissociate/setPermissions enforce write access', async () => {
+    const record = await adapter.createRecord(makeRecord());
+    const tag: Association = { kind: 'tag', label: 'starred' };
+    const perms: Permission[] = [{ access: 'public' }];
+
+    await expect(stack.asEntity(STRANGER).associate(record.id, tag)).rejects.toThrow(
+      PermissionError,
+    );
+    await expect(stack.asEntity(STRANGER).dissociate(record.id, tag)).rejects.toThrow(
+      PermissionError,
+    );
+    await expect(stack.asEntity(STRANGER).setPermissions(record.id, perms)).rejects.toThrow(
+      PermissionError,
+    );
+
+    await stack.asEntity(OWNER).associate(record.id, tag);
+    expect((await adapter.getRecord(record.id))?.associations).toContainEqual(tag);
+  });
+
+  test('write methods throw a plain Error (not PermissionError) for a missing record', async () => {
+    await expect(stack.asEntity(OWNER).update('nonexistent', {})).rejects.not.toThrow(
+      PermissionError,
+    );
+    await expect(stack.asEntity(OWNER).update('nonexistent', {})).rejects.toThrow(
+      'Record not found',
+    );
+  });
+});
+
+// -------------------------------------------------------
+// Versions
+// -------------------------------------------------------
+
+describe('ScopedStack — versions', () => {
+  test('restoreVersion enforces write access', async () => {
+    const record = await adapter.createRecord(makeRecord());
+    await adapter.saveVersion(record.id, {
+      version: 1,
+      content: { text: 'old' },
+      updatedAt: new Date(),
+    });
+    await expect(stack.asEntity(STRANGER).restoreVersion(record.id, 1)).rejects.toThrow(
+      PermissionError,
+    );
+    const restored = await stack.asEntity(OWNER).restoreVersion(record.id, 1);
+    expect(restored.content.text).toBe('old');
+  });
+
+  test('getVersions/getVersion enforce read access', async () => {
+    const record = await adapter.createRecord(makeRecord());
+    await adapter.saveVersion(record.id, { version: 1, content: {}, updatedAt: new Date() });
+    await expect(stack.asEntity(STRANGER).getVersions(record.id)).rejects.toThrow(PermissionError);
+    await expect(stack.asEntity(OWNER).getVersions(record.id)).resolves.toHaveLength(1);
+  });
+});
+
+// -------------------------------------------------------
+// Query — permission filtering and pagination
+// -------------------------------------------------------
+
+describe('ScopedStack.query', () => {
+  test('filters out records the requester cannot read', async () => {
+    await adapter.createRecord(makeRecord()); // private
+    const pub = await adapter.createRecord(makeRecord({ permissions: [{ access: 'public' }] }));
+
+    const result = await stack.asEntity(null).query();
+    expect(result.records.map((r) => r.id)).toEqual([pub.id]);
+  });
+
+  test('total is always null on scoped queries, even though the adapter reports a real count', async () => {
+    await adapter.createRecord(makeRecord({ permissions: [{ access: 'public' }] }));
+    const unscoped = await stack.query();
+    expect(unscoped.total).toBe(1);
+
+    const scoped = await stack.asEntity(null).query();
+    expect(scoped.total).toBeNull();
+  });
+
+  test('refills across multiple adapter pages without skipping records, even if the result lands under the requested limit', async () => {
+    // 6 records fetched 2-at-a-time (limit: 2), only the last one is public.
+    // Pages 1 and 2 contain zero visible records, so the loop must refetch
+    // through all 3 pages — stopping only because the cursor is exhausted,
+    // not because it hit the limit — and still find the one visible record.
+    let visibleId = '';
+    for (let i = 0; i < 6; i++) {
+      const isPublic = i === 5;
+      const record = await adapter.createRecord(
+        makeRecord(isPublic ? { permissions: [{ access: 'public' }] } : {}),
+      );
+      if (isPublic) visibleId = record.id;
+    }
+
+    const result = await stack.asEntity(null).query({ limit: 2 });
+    expect(result.records.map((r) => r.id)).toEqual([visibleId]);
+    expect(result.cursor).toBeNull();
+  });
+
+  test('a page may overshoot the requested limit rather than split mid-page', async () => {
+    // priv, priv, priv, pub, pub, pub — fetched 2 at a time with limit: 2.
+    // Page 1 (priv,priv): 0 visible. Page 2 (priv,pub): 1 visible, still
+    // under limit, so a 3rd page is fetched. Page 3 (pub,pub): both visible,
+    // pushing the total to 3 — over the requested limit of 2, by design.
+    for (let i = 0; i < 6; i++) {
+      await adapter.createRecord(makeRecord(i >= 3 ? { permissions: [{ access: 'public' }] } : {}));
+    }
+
+    const result = await stack.asEntity(null).query({ limit: 2 });
+    expect(result.records).toHaveLength(3);
+    expect(result.cursor).toBeNull();
+  });
+});

--- a/packages/core/tests/scoped-stack.test.ts
+++ b/packages/core/tests/scoped-stack.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach } from 'vitest';
-import { Stack, PermissionError } from '../src/stack.js';
+import { Stack, StackPermissionError } from '../src/stack.js';
 import { generateId } from '../src/id.js';
 import type {
   StackAdapter,
@@ -184,7 +184,7 @@ describe('ScopedStack — read access', () => {
   test('anonymous requester cannot read a private record', async () => {
     const record = await adapter.createRecord(makeRecord());
     const view = stack.asEntity(null);
-    await expect(view.get(record.id)).rejects.toThrow(PermissionError);
+    await expect(view.get(record.id)).rejects.toThrow(StackPermissionError);
   });
 
   test('anonymous requester can read a public record', async () => {
@@ -208,7 +208,7 @@ describe('ScopedStack — read access', () => {
         permissions: [{ access: 'entity', entityId: MEMBER, read: true, write: false }],
       }),
     );
-    await expect(stack.asEntity(STRANGER).get(record.id)).rejects.toThrow(PermissionError);
+    await expect(stack.asEntity(STRANGER).get(record.id)).rejects.toThrow(StackPermissionError);
   });
 
   test('group member can read via a group read grant', async () => {
@@ -238,10 +238,10 @@ describe('ScopedStack — read access', () => {
         permissions: [{ access: 'group', groupId: group.id, read: true, write: false }],
       }),
     );
-    await expect(stack.asEntity(STRANGER).get(record.id)).rejects.toThrow(PermissionError);
+    await expect(stack.asEntity(STRANGER).get(record.id)).rejects.toThrow(StackPermissionError);
   });
 
-  test('get() returns null, not PermissionError, for a record that does not exist', async () => {
+  test('get() returns null, not StackPermissionError, for a record that does not exist', async () => {
     expect(await stack.asEntity(OWNER).get('nonexistent')).toBeNull();
     expect(await stack.asEntity(null).get('nonexistent')).toBeNull();
   });
@@ -261,7 +261,7 @@ describe('ScopedStack — write access', () => {
   test('public access does not grant write', async () => {
     const record = await adapter.createRecord(makeRecord({ permissions: [{ access: 'public' }] }));
     await expect(stack.asEntity(STRANGER).update(record.id, { text: 'hi' })).rejects.toThrow(
-      PermissionError,
+      StackPermissionError,
     );
   });
 
@@ -282,13 +282,13 @@ describe('ScopedStack — write access', () => {
       }),
     );
     await expect(stack.asEntity(MEMBER).update(record.id, { text: 'hi' })).rejects.toThrow(
-      PermissionError,
+      StackPermissionError,
     );
   });
 
   test('delete enforces write access', async () => {
     const record = await adapter.createRecord(makeRecord());
-    await expect(stack.asEntity(STRANGER).delete(record.id)).rejects.toThrow(PermissionError);
+    await expect(stack.asEntity(STRANGER).delete(record.id)).rejects.toThrow(StackPermissionError);
     await stack.asEntity(OWNER).delete(record.id);
     expect((await adapter.getRecord(record.id))?.deletedAt).toBeDefined();
   });
@@ -299,22 +299,22 @@ describe('ScopedStack — write access', () => {
     const perms: Permission[] = [{ access: 'public' }];
 
     await expect(stack.asEntity(STRANGER).associate(record.id, tag)).rejects.toThrow(
-      PermissionError,
+      StackPermissionError,
     );
     await expect(stack.asEntity(STRANGER).dissociate(record.id, tag)).rejects.toThrow(
-      PermissionError,
+      StackPermissionError,
     );
     await expect(stack.asEntity(STRANGER).setPermissions(record.id, perms)).rejects.toThrow(
-      PermissionError,
+      StackPermissionError,
     );
 
     await stack.asEntity(OWNER).associate(record.id, tag);
     expect((await adapter.getRecord(record.id))?.associations).toContainEqual(tag);
   });
 
-  test('write methods throw a plain Error (not PermissionError) for a missing record', async () => {
+  test('write methods throw a plain Error (not StackPermissionError) for a missing record', async () => {
     await expect(stack.asEntity(OWNER).update('nonexistent', {})).rejects.not.toThrow(
-      PermissionError,
+      StackPermissionError,
     );
     await expect(stack.asEntity(OWNER).update('nonexistent', {})).rejects.toThrow(
       'Record not found',
@@ -335,7 +335,7 @@ describe('ScopedStack — versions', () => {
       updatedAt: new Date(),
     });
     await expect(stack.asEntity(STRANGER).restoreVersion(record.id, 1)).rejects.toThrow(
-      PermissionError,
+      StackPermissionError,
     );
     const restored = await stack.asEntity(OWNER).restoreVersion(record.id, 1);
     expect(restored.content.text).toBe('old');
@@ -344,7 +344,9 @@ describe('ScopedStack — versions', () => {
   test('getVersions/getVersion enforce read access', async () => {
     const record = await adapter.createRecord(makeRecord());
     await adapter.saveVersion(record.id, { version: 1, content: {}, updatedAt: new Date() });
-    await expect(stack.asEntity(STRANGER).getVersions(record.id)).rejects.toThrow(PermissionError);
+    await expect(stack.asEntity(STRANGER).getVersions(record.id)).rejects.toThrow(
+      StackPermissionError,
+    );
     await expect(stack.asEntity(OWNER).getVersions(record.id)).resolves.toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary

Permission enforcement (`checkAccess`, group-membership resolution, pagination-safe filtering) currently lives only in spec prose — every server implementation would otherwise need to reimplement it, and reimplementations are exactly where subtle bugs creep in (we already found one: an unfiltered `total` count alongside permission-filtered results, plus pagination filtering that can silently skip records sharing a page with the threshold-crossing record).

This PR moves enforcement into core as a reusable primitive:

- **`Stack.asEntity(entityId: string | null): ScopedStack`** — returns a permission-enforcing view over the stack. `ScopedStack` mirrors `Stack`'s method surface (`get`, `update`, `delete`, `associate`, `dissociate`, `setPermissions`, `query`, `getVersions`, `getVersion`, `restoreVersion`) but checks read/write access (owner, `public`, `entity`, `group`) before delegating.
- **`PermissionError`** — thrown for access-denied cases, distinct from a plain `Error`/`null` for not-found, so callers can map cleanly to 403 vs 404.
- **`checkAccess`** (moved from server's `src/lib/access.ts` into `src/access.ts`) — decoupled from `StackAdapter` via a minimal `RecordResolver` callback type, so `ScopedStack` doesn't need raw adapter access (consistent with the "apps never talk to a `StackAdapter` directly" design principle).
- **`ScopedStack.query()`** uses a filter-then-refill loop across adapter pages — each page is fully evaluated for visibility before deciding whether to fetch another, so a visible record sharing a page with the limit-crossing record is never silently dropped.
- **`QueryResult.total` widens to `number | null`.** Permission-scoped queries always return `total: null`. Reporting the real unfiltered count alongside filtered records would leak the existence/cardinality of records the requester can't read — e.g. an attacker with zero access to a record type could still infer counts via `typeId`/tag/date filters. Since permission tiers are rarely correlated with those filter dimensions, the "upper bound" framing doesn't hold up; the leak is usually exact. This change is non-breaking for unscoped queries — `SQLiteAdapter`, `adapter-api`, and existing tests all continue to return real numbers.
- `docs/spec.md` updated with an "Enforcement: `Stack.asEntity()`" subsection under Permissions.

## Test plan

- [x] `pnpm run build`
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run test` — 269 tests passing, including 21 new tests in `packages/core/tests/scoped-stack.test.ts` covering read/write access (owner, public, entity grant, group grant, and their negative cases), not-found vs forbidden distinction, version access, and query permission-filtering/pagination (including the multi-page refill and overshoot-rather-than-split-mid-page cases)
- [x] `pnpm run format:check`

https://claude.ai/code/session_01Q3wAK82yALLxZva8baqhqo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3wAK82yALLxZva8baqhqo)_