### PR TITLE
Add StackNotFoundError and document API error status codes

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -280,7 +280,7 @@ Cross-stack group resolution (where the `_group` Record lives in a different sta
 
 **Enforcement: `Stack.asEntity()`**
 
-The core library ships a permission-enforcing wrapper so server implementations don't need to reimplement this resolution logic. `stack.asEntity(entityId)` — `entityId` is `null` for an anonymous/unauthenticated requester — returns a `ScopedStack`: the same read/write/query/version surface as `Stack`, but every operation is checked against the rules above. The owner always has full access. Reading or writing a Record that exists but isn't visible throws `StackPermissionError`; a missing Record still throws a plain `Error`, so callers can distinguish "not found" from "forbidden" (typically 404 vs 403 at the HTTP layer).
+The core library ships a permission-enforcing wrapper so server implementations don't need to reimplement this resolution logic. `stack.asEntity(entityId)` — `entityId` is `null` for an anonymous/unauthenticated requester — returns a `ScopedStack`: the same read/write/query/version surface as `Stack`, but every operation is checked against the rules above. The owner always has full access. Reading or writing a Record that exists but isn't visible throws `StackPermissionError`; a missing Record throws `StackNotFoundError`, so callers can distinguish "not found" from "forbidden" (typically 404 vs 403 at the HTTP layer).
 
 Plain `Stack` methods remain unscoped and perform no permission checks — correct for single-entity embedded use, where there's no requester distinct from the app itself. Use `asEntity()` when one `Stack` instance serves requests from multiple, possibly untrusted, entities, e.g. a server adapter.
 
@@ -489,6 +489,21 @@ Authorization: Bearer <token>
 ```
 
 (As a non-normative example, `SQLiteAdapter` ships an optional hashed-token store — `createToken` / `lookupToken` / `listTokens` / `revokeToken` — for servers that want DB-backed bearer tokens without rolling their own storage. This is adapter-specific tooling, not part of the wire protocol; other adapters are free to manage tokens however they like, or not at all.)
+
+### Error responses
+
+Standard HTTP status codes are used throughout:
+
+| Status | Meaning | When |
+| ------ | ------- | ---- |
+| **400** | Bad request | Structurally malformed request — missing a required field, unparseable query parameter, invalid JSON |
+| **401** | Unauthorized | Missing or invalid bearer token |
+| **403** | Forbidden | `StackPermissionError` — record exists but the requester lacks access |
+| **404** | Not found | `StackNotFoundError` — record or version does not exist |
+| **413** | Request entity too large | Attachment upload exceeds the server's size limit |
+| **422** | Unprocessable entity | `StackValidationError` — request is syntactically valid but content fails schema validation (e.g. a required field has the wrong type) |
+
+The distinction between **400** and **422** matters for write endpoints (`POST /records`, `PATCH /records/:id`, `POST /types`): a 400 means the request couldn't be parsed at all; a 422 means the server understood the request but the content didn't satisfy the type schema.
 
 ### Records
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -494,14 +494,14 @@ Authorization: Bearer <token>
 
 Standard HTTP status codes are used throughout:
 
-| Status | Meaning | When |
-| ------ | ------- | ---- |
-| **400** | Bad request | Structurally malformed request — missing a required field, unparseable query parameter, invalid JSON |
-| **401** | Unauthorized | Missing or invalid bearer token |
-| **403** | Forbidden | `StackPermissionError` — record exists but the requester lacks access |
-| **404** | Not found | `StackNotFoundError` — record or version does not exist |
-| **413** | Request entity too large | Attachment upload exceeds the server's size limit |
-| **422** | Unprocessable entity | `StackValidationError` — request is syntactically valid but content fails schema validation (e.g. a required field has the wrong type) |
+| Status  | Meaning                  | When                                                                                                                                   |
+| ------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **400** | Bad request              | Structurally malformed request — missing a required field, unparseable query parameter, invalid JSON                                   |
+| **401** | Unauthorized             | Missing or invalid bearer token                                                                                                        |
+| **403** | Forbidden                | `StackPermissionError` — record exists but the requester lacks access                                                                  |
+| **404** | Not found                | `StackNotFoundError` — record or version does not exist                                                                                |
+| **413** | Request entity too large | Attachment upload exceeds the server's size limit                                                                                      |
+| **422** | Unprocessable entity     | `StackValidationError` — request is syntactically valid but content fails schema validation (e.g. a required field has the wrong type) |
 
 The distinction between **400** and **422** matters for write endpoints (`POST /records`, `PATCH /records/:id`, `POST /types`): a 400 means the request couldn't be parsed at all; a 422 means the server understood the request but the content didn't satisfy the type schema.
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export {
   StackValidationError,
   StackMigrationError,
   StackPermissionError,
+  StackNotFoundError,
 } from './stack.js';
 export type { CreateRecordOptions, GetRecordOptions, DeleteRecordOptions } from './stack.js';
 

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -85,6 +85,14 @@ export class StackPermissionError extends Error {
   }
 }
 
+/** Thrown when a record (or specific version) does not exist. */
+export class StackNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StackNotFoundError';
+  }
+}
+
 // -------------------------------------------------------
 // Stack class
 // -------------------------------------------------------
@@ -392,7 +400,7 @@ export class Stack {
   async update(id: string, content: Record<string, unknown | null>): Promise<StackRecord> {
     const existing = await this.adapter.getRecord(id);
     if (!existing) {
-      throw new Error(`Record not found: "${id}"`);
+      throw new StackNotFoundError(`Record not found: "${id}"`);
     }
 
     // Resolve the latest type version and migrate existing content
@@ -457,7 +465,7 @@ export class Stack {
   async setPermissions(id: string, permissions: Permission[]): Promise<void> {
     const existing = await this.adapter.getRecord(id);
     if (!existing) {
-      throw new Error(`Record not found: "${id}"`);
+      throw new StackNotFoundError(`Record not found: "${id}"`);
     }
     await this.adapter.updateRecord(id, { permissions });
   }
@@ -497,12 +505,12 @@ export class Stack {
   async restoreVersion(id: string, version: number): Promise<StackRecord> {
     const existing = await this.adapter.getRecord(id);
     if (!existing) {
-      throw new Error(`Record not found: "${id}"`);
+      throw new StackNotFoundError(`Record not found: "${id}"`);
     }
 
     const target = await this.adapter.getVersion(id, version);
     if (!target) {
-      throw new Error(`Version ${version} not found for record "${id}"`);
+      throw new StackNotFoundError(`Version ${version} not found for record "${id}"`);
     }
 
     // Snapshot current state before restoring
@@ -579,8 +587,9 @@ const DEFAULT_QUERY_LIMIT = 50;
  *
  * Read methods return null for a Record that doesn't exist, and throw
  * StackPermissionError for one that exists but isn't readable by the requester.
- * Write methods throw StackPermissionError for a Record that exists but isn't
- * writable. This lets callers distinguish "not found" from "forbidden".
+ * Write methods throw StackNotFoundError for a missing Record and
+ * StackPermissionError for one that exists but isn't writable. This lets
+ * callers distinguish "not found" from "forbidden".
  */
 export class ScopedStack {
   constructor(
@@ -614,7 +623,7 @@ export class ScopedStack {
   /** Fetch a Record the requester has write access to, or throw. */
   private async requireWritable(id: string): Promise<StackRecord> {
     const existing = await this.stack.get(id, { migrate: false });
-    if (!existing) throw new Error(`Record not found: "${id}"`);
+    if (!existing) throw new StackNotFoundError(`Record not found: "${id}"`);
     if (!(await this.checkWrite(existing))) throw new StackPermissionError();
     return existing;
   }
@@ -679,14 +688,14 @@ export class ScopedStack {
 
   async getVersions(id: string): Promise<RecordVersion[]> {
     const existing = await this.stack.get(id, { migrate: false });
-    if (!existing) throw new Error(`Record not found: "${id}"`);
+    if (!existing) throw new StackNotFoundError(`Record not found: "${id}"`);
     if (!(await this.checkRead(existing))) throw new StackPermissionError();
     return this.stack.getVersions(id);
   }
 
   async getVersion(id: string, version: number): Promise<RecordVersion | null> {
     const existing = await this.stack.get(id, { migrate: false });
-    if (!existing) throw new Error(`Record not found: "${id}"`);
+    if (!existing) throw new StackNotFoundError(`Record not found: "${id}"`);
     if (!(await this.checkRead(existing))) throw new StackPermissionError();
     return this.stack.getVersion(id, version);
   }

--- a/packages/core/tests/scoped-stack.test.ts
+++ b/packages/core/tests/scoped-stack.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach } from 'vitest';
-import { Stack, StackPermissionError } from '../src/stack.js';
+import { Stack, StackPermissionError, StackNotFoundError } from '../src/stack.js';
 import { generateId } from '../src/id.js';
 import type {
   StackAdapter,
@@ -312,12 +312,12 @@ describe('ScopedStack — write access', () => {
     expect((await adapter.getRecord(record.id))?.associations).toContainEqual(tag);
   });
 
-  test('write methods throw a plain Error (not StackPermissionError) for a missing record', async () => {
+  test('write methods throw StackNotFoundError (not StackPermissionError) for a missing record', async () => {
+    await expect(stack.asEntity(OWNER).update('nonexistent', {})).rejects.toThrow(
+      StackNotFoundError,
+    );
     await expect(stack.asEntity(OWNER).update('nonexistent', {})).rejects.not.toThrow(
       StackPermissionError,
-    );
-    await expect(stack.asEntity(OWNER).update('nonexistent', {})).rejects.toThrow(
-      'Record not found',
     );
   });
 });


### PR DESCRIPTION
Closes #24: Adds StackNotFoundError (alongside StackPermissionError and
StackValidationError) and throws it in Stack.update(), Stack.setPermissions(),
Stack.restoreVersion(), and all ScopedStack methods that previously threw a
plain Error for missing records. Callers can now catch by type rather than
string-matching the message.

Closes #23: Documents the 400 vs 422 distinction in docs/spec.md — 400 for
structurally malformed requests, 422 for content that fails schema validation —
along with the full status code table (401, 403, 404, 413) for the API adapter.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qdxwx62u3Y2jByPQqSXhVx