### PR TITLE
StackClient interface, system type pre-seeding, and entity-level grant permissions

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -125,17 +125,17 @@ A Grant authorises one or more Entities to perform specific actions on Records o
 
 ```ts
 type GrantContent = {
-  typeId: TypeId;         // Which record type this grant covers
+  typeId: TypeId; // Which record type this grant covers
   actions: GrantAction[]; // Which actions are permitted
 };
 
 type GrantAction =
-  | 'create'      // Create new records of this type
-  | 'read-own'    // Read records where record.entityId === requester
-  | 'read-any'    // Read all records of this type
-  | 'update-own'  // Update records where record.entityId === requester
-  | 'update-any'  // Update all records of this type
-  | 'delete-own'  // Delete records where record.entityId === requester
+  | 'create' // Create new records of this type
+  | 'read-own' // Read records where record.entityId === requester
+  | 'read-any' // Read all records of this type
+  | 'update-own' // Update records where record.entityId === requester
+  | 'update-any' // Update all records of this type
+  | 'delete-own' // Delete records where record.entityId === requester
   | 'delete-any'; // Delete all records of this type
 ```
 
@@ -148,9 +148,7 @@ await stack.grant('bob-entity-id', [
 ]);
 
 // Default grant — applies to any authenticated entity (null entityId on the grant record)
-await stack.grant(null, [
-  { typeId: 'com.example/comment@1', actions: ['create', 'read-own'] },
-]);
+await stack.grant(null, [{ typeId: 'com.example/comment@1', actions: ['create', 'read-own'] }]);
 ```
 
 **Design decisions:**

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -33,6 +33,8 @@ stack.timezone; // read from adapter config
 
 `SQLiteAdapter.initialize()` fails if the file already exists. `SQLiteAdapter.open()` fails if the file does not exist. This makes the distinction explicit and prevents silent config divergence.
 
+Plugin and extension code that doesn't need to know the underlying backend should accept `StackClient` rather than the concrete `Stack` or `ScopedStack`. `StackClient` is the passable interface covering the full record API (`create`, `get`, `query`, `update`, `delete`, `associate`, `dissociate`, `setPermissions`, `getVersions`, `getVersion`, `restoreVersion`) plus a `features` getter. Both `Stack` and `ScopedStack` implement it.
+
 **Stack config** is stored in a `stack_config` key/value table in the adapter. Current keys:
 
 | Key         | Description                                    |
@@ -115,6 +117,51 @@ This gives roles (member vs. admin) for free via association labels, and members
 
 ---
 
+### Grant
+
+A Grant authorises one or more Entities to perform specific actions on Records of a given Type. Grants are modeled as Records of the built-in system type `_grant`, making them queryable, versioned, and subject to the same lifecycle as any other Record.
+
+**Content fields:**
+
+```ts
+type GrantContent = {
+  typeId: TypeId;         // Which record type this grant covers
+  actions: GrantAction[]; // Which actions are permitted
+};
+
+type GrantAction =
+  | 'create'      // Create new records of this type
+  | 'read-own'    // Read records where record.entityId === requester
+  | 'read-any'    // Read all records of this type
+  | 'update-own'  // Update records where record.entityId === requester
+  | 'update-any'  // Update all records of this type
+  | 'delete-own'  // Delete records where record.entityId === requester
+  | 'delete-any'; // Delete all records of this type
+```
+
+`Stack.grant()` is the owner-facing helper for creating grant records:
+
+```ts
+// Grant a specific entity permission to create comments and manage their own
+await stack.grant('bob-entity-id', [
+  { typeId: 'com.example/comment@1', actions: ['create', 'read-own', 'update-own', 'delete-own'] },
+]);
+
+// Default grant — applies to any authenticated entity (null entityId on the grant record)
+await stack.grant(null, [
+  { typeId: 'com.example/comment@1', actions: ['create', 'read-own'] },
+]);
+```
+
+**Design decisions:**
+
+- **No wildcard `typeId`**: there is no `*` or catch-all. Every grant is opt-in per type. Adding a new type never implicitly inherits existing grants — it starts default-deny.
+- **Default grants** (grant record has no `entityId`): apply to any authenticated entity. Useful for "any logged-in user can comment" scenarios. Anonymous requesters (no `entityId`) are always denied, even under a default grant.
+- **Actions are independent**: `'create'` does not imply `'read-own'`, and so on. The combination `['create', 'read-own', 'update-own', 'delete-own']` is a common bundle for contributor access, but each action must be listed explicitly.
+- **`-own` scope**: `-own` actions apply only to Records where `record.entityId` equals the requester — Records the entity authored. Records with no `entityId` (owner-created) do not satisfy any `-own` check.
+
+---
+
 ## Types
 
 A **Type** defines the schema for the `content` field of a Record. Types are identified by a **namespaced, versioned string ID** controlled by the app author — the app is the real coordination mechanism between stacks, so Type identity is scoped to the app that defined it.
@@ -172,7 +219,7 @@ function isCompatible(
 
 Apps that care about semantics filter by exact `typeId`. Apps that want flexibility use `isCompatible()`.
 
-**System types** (reserved, library-defined): `_entity@1`, `_app@1`, `_group@1`. System types follow the same versioned ID format as user-defined types and can evolve using the same migration mechanism.
+**System types** (reserved, library-defined): `_entity@1`, `_app@1`, `_group@1`, `_grant@1`. System types follow the same versioned ID format as user-defined types and can evolve using the same migration mechanism. All four are pre-seeded when a Stack is created via `Stack.create()` — they are always available without any setup by the caller.
 
 ### Type migrations
 
@@ -222,7 +269,7 @@ type StackRecord = {
 
   // --- Optional native fields ---
   parentId?: string; // ID of a parent Record (for hierarchy/folders)
-  entityId?: string; // Author Entity, if different from stack owner
+  entityId?: string; // Author Entity. Absent means owner-created — Records written directly by the stack owner carry no entityId.
   appId?: string; // App that created this Record
   deletedAt?: Date; // Present if soft-deleted
   permissions?: Permission[]; // Access control (see Permissions)
@@ -257,6 +304,10 @@ type Association =
 
 ## Permissions
 
+Access control in a Stack has two complementary layers. `ScopedStack` (see below) enforces both.
+
+### Layer 1: Record-level permissions
+
 All Records are **private by default** — readable only by the stack owner. The `permissions` field is absent or empty on private records; there is no explicit `private` permission value. Permissions represent _grants_ of access, not restrictions. Enforcement is the responsibility of the API adapter. The JSON and SQLite adapters ignore the permissions field.
 
 ```ts
@@ -269,7 +320,7 @@ type Permission =
 
 Group permissions reference a `_group` Record by ID. The group may be a simple permission group (living in the stack owner's personal stack) or a collaborative group with its own stack — the permission model is the same either way.
 
-**Permission resolution for the API adapter:**
+**Permission resolution:**
 
 - `private` — owner only
 - `public` — any requester can read
@@ -278,9 +329,19 @@ Group permissions reference a `_group` Record by ID. The group may be a simple p
 
 Cross-stack group resolution (where the `_group` Record lives in a different stack than the Record being accessed) requires the server to have read access to that stack.
 
-**Enforcement: `Stack.asEntity()`**
+### Layer 2: Type-level grants
 
-The core library ships a permission-enforcing wrapper so server implementations don't need to reimplement this resolution logic. `stack.asEntity(entityId)` — `entityId` is `null` for an anonymous/unauthenticated requester — returns a `ScopedStack`: the same read/write/query/version surface as `Stack`, but every operation is checked against the rules above. The owner always has full access. Reading or writing a Record that exists but isn't visible throws `StackPermissionError`; a missing Record throws `StackNotFoundError`, so callers can distinguish "not found" from "forbidden" (typically 404 vs 403 at the HTTP layer).
+`_grant` records (see [Grant](#grant)) authorise Entities to perform actions across all Records of a given Type, without touching individual records. A read-any grant on `comment@1`, for example, makes all comments of that type readable by the grantee without setting `permissions` on each one.
+
+`ScopedStack` checks both layers on every operation: if either the Record's own `permissions` or a matching `_grant` record permits the action, access is granted. The owner always has full access and bypasses both checks.
+
+### Enforcement: `Stack.asEntity()`
+
+The core library ships a permission-enforcing wrapper so server implementations don't need to reimplement this resolution logic. `stack.asEntity(entityId)` — `entityId` is `null` for an anonymous/unauthenticated requester — returns a `ScopedStack`: the same surface as `Stack`, but every operation is checked against both permission layers.
+
+**`ScopedStack.create()`** additionally checks `_grant` records for a `'create'` action on the target type before allowing the Record to be written. Anonymous requesters are always denied. The owner always passes. The created Record's `entityId` is always set to the requester, so `-own` grants apply to it immediately.
+
+Reading or writing a Record that exists but isn't accessible throws `StackPermissionError`; a missing Record throws `StackNotFoundError`, so callers can distinguish "not found" from "forbidden" (typically 404 vs 403 at the HTTP layer).
 
 Plain `Stack` methods remain unscoped and perform no permission checks — correct for single-entity embedded use, where there's no requester distinct from the app itself. Use `asEntity()` when one `Stack` instance serves requests from multiple, possibly untrusted, entities, e.g. a server adapter.
 
@@ -419,6 +480,8 @@ type AdapterCapabilities = {
   sortableFields: string[];
 };
 ```
+
+`AdapterCapabilities` is the adapter-implementer-facing name. On the `StackClient` interface it is exposed as `features: StackFeatures` (`StackFeatures` is a type alias for `AdapterCapabilities`). App and plugin code should read `stack.features` rather than going through the adapter directly.
 
 **Per-adapter notes:**
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,7 +8,7 @@
  *   @haverstack/adapter-sqlite
  */
 
-// Core class
+// Core class and client interface
 export {
   Stack,
   ScopedStack,
@@ -17,7 +17,12 @@ export {
   StackPermissionError,
   StackNotFoundError,
 } from './stack.js';
-export type { CreateRecordOptions, GetRecordOptions, DeleteRecordOptions } from './stack.js';
+export type {
+  StackClient,
+  CreateRecordOptions,
+  GetRecordOptions,
+  DeleteRecordOptions,
+} from './stack.js';
 
 // Permissions
 export { checkAccess } from './access.js';
@@ -55,6 +60,8 @@ export type {
   EntityContent,
   AppContent,
   GroupContent,
+  GrantAction,
+  GrantContent,
 } from './types.js';
 
 export { SYSTEM_TYPES } from './types.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -56,6 +56,7 @@ export type {
   Migration,
   MigrationFn,
   AdapterCapabilities,
+  StackFeatures,
   StackAdapter,
   EntityContent,
   AppContent,

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -34,6 +34,7 @@ import type {
   MigrationFn,
   RecordVersion,
   AdapterCapabilities,
+  StackFeatures,
   GrantAction,
   GrantContent,
 } from './types.js';
@@ -106,6 +107,7 @@ export class StackNotFoundError extends Error {
  * and work equally well with a full Stack or a permission-scoped view.
  */
 export interface StackClient {
+  readonly features: StackFeatures;
   create<T extends Record<string, unknown> = Record<string, unknown>>(
     typeId: TypeId,
     content: T,
@@ -147,7 +149,7 @@ export class Stack implements StackClient {
     return new Stack(adapter, entityId, timezone);
   }
 
-  get capabilities(): AdapterCapabilities {
+  get features(): StackFeatures {
     return this.adapter.capabilities;
   }
 
@@ -670,6 +672,10 @@ export class ScopedStack implements StackClient {
     private readonly requesterEntityId: string | null,
   ) {}
 
+  get features(): StackFeatures {
+    return this.stack.features;
+  }
+
   private resolveRecord = (id: string): Promise<StackRecord | null> =>
     this.stack.get(id, { migrate: false });
 
@@ -713,7 +719,7 @@ export class ScopedStack implements StackClient {
     const result = await this.stack.query({
       filter: {
         typeId: grantTypeId,
-        ...(this.stack.capabilities.contentFieldQuery && { content: { typeId } }),
+        ...(this.stack.features.contentFieldQuery && { content: { typeId } }),
       },
     });
 

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -18,6 +18,7 @@ import { generateId } from './id.js';
 import { hashSchema, isCompatible, parseTypeId } from './schema.js';
 import { validateContent } from './validate.js';
 import { checkAccess } from './access.js';
+import { SYSTEM_TYPES } from './types.js';
 import type { ValidationError } from './validate.js';
 import type {
   StackRecord,
@@ -33,6 +34,8 @@ import type {
   MigrationFn,
   RecordVersion,
   AdapterCapabilities,
+  GrantAction,
+  GrantContent,
 } from './types.js';
 
 // -------------------------------------------------------
@@ -94,10 +97,37 @@ export class StackNotFoundError extends Error {
 }
 
 // -------------------------------------------------------
+// StackClient interface
+// -------------------------------------------------------
+
+/**
+ * The app-facing record API, implemented by both Stack and ScopedStack.
+ * Accept this type in plugin or extension code to remain adapter-agnostic
+ * and work equally well with a full Stack or a permission-scoped view.
+ */
+export interface StackClient {
+  create<T extends Record<string, unknown> = Record<string, unknown>>(
+    typeId: TypeId,
+    content: T,
+    opts?: CreateRecordOptions,
+  ): Promise<StackRecord & { content: T }>;
+  get(id: string, opts?: GetRecordOptions): Promise<StackRecord | null>;
+  query(query?: StackQuery): Promise<QueryResult>;
+  update(id: string, content: Record<string, unknown | null>): Promise<StackRecord>;
+  associate(id: string, association: Association): Promise<void>;
+  dissociate(id: string, association: Association): Promise<void>;
+  setPermissions(id: string, permissions: Permission[]): Promise<void>;
+  delete(id: string, opts?: DeleteRecordOptions): Promise<void>;
+  getVersions(id: string): Promise<RecordVersion[]>;
+  getVersion(id: string, version: number): Promise<RecordVersion | null>;
+  restoreVersion(id: string, version: number): Promise<StackRecord>;
+}
+
+// -------------------------------------------------------
 // Stack class
 // -------------------------------------------------------
 
-export class Stack {
+export class Stack implements StackClient {
   private readonly migrations = new Map<TypeId, Migration>();
 
   private constructor(
@@ -560,6 +590,49 @@ export class Stack {
   }
 
   // -------------------------------------------------------
+  // Grants
+  // -------------------------------------------------------
+
+  /**
+   * Create _grant records that allow entities to call ScopedStack.create()
+   * for specific record types. Pass null as entityId for a default grant
+   * that applies to any authenticated entity.
+   *
+   * The _grant@1 type is defined automatically on first use.
+   */
+  async grant(
+    entityId: string | null,
+    grants: Array<{ actions: GrantAction[]; typeId: TypeId }>,
+  ): Promise<StackRecord[]> {
+    const grantTypeId = `${SYSTEM_TYPES.GRANT}@1`;
+    if (!(await this.adapter.getType(grantTypeId))) {
+      await this.defineType(grantTypeId, 'Grant', {
+        typeId: { kind: 'string', required: true },
+        actions: { kind: 'array', items: { kind: 'string' }, required: true },
+      });
+    }
+    const records: StackRecord[] = [];
+    for (const g of grants) {
+      const now = new Date();
+      // Build the record directly rather than going through this.create() so
+      // that a null entityId produces a record with no entityId field — the
+      // signal that the grant is a default (applies to any authenticated entity).
+      // this.create() always falls back to ownerEntityId when entityId is absent.
+      const record: StackRecord = {
+        id: generateId(),
+        typeId: grantTypeId,
+        createdAt: now,
+        updatedAt: now,
+        content: { typeId: g.typeId, actions: g.actions },
+        version: 1,
+        ...(entityId ? { entityId } : {}),
+      };
+      records.push(await this.adapter.createRecord(record));
+    }
+    return records;
+  }
+
+  // -------------------------------------------------------
   // Private helpers
   // -------------------------------------------------------
 
@@ -591,7 +664,7 @@ const DEFAULT_QUERY_LIMIT = 50;
  * StackPermissionError for one that exists but isn't writable. This lets
  * callers distinguish "not found" from "forbidden".
  */
-export class ScopedStack {
+export class ScopedStack implements StackClient {
   constructor(
     private readonly stack: Stack,
     private readonly requesterEntityId: string | null,
@@ -626,6 +699,49 @@ export class ScopedStack {
     if (!existing) throw new StackNotFoundError(`Record not found: "${id}"`);
     if (!(await this.checkWrite(existing))) throw new StackPermissionError();
     return existing;
+  }
+
+  /**
+   * Check whether the requester has a _grant record permitting them to
+   * create records of the given type. The owner always passes. Any
+   * authenticated entity passes if a default grant (no entityId) exists.
+   */
+  private async checkCreateGrant(typeId: TypeId): Promise<boolean> {
+    if (this.requesterEntityId === this.stack.ownerEntityId) return true;
+
+    const grantTypeId = `${SYSTEM_TYPES.GRANT}@1`;
+    const result = await this.stack.query({
+      filter: {
+        typeId: grantTypeId,
+        ...(this.stack.capabilities.contentFieldQuery && { content: { typeId } }),
+      },
+    });
+
+    return result.records.some((r) => {
+      const c = r.content as GrantContent;
+      if (c.typeId !== typeId) return false;
+      if (!(c.actions as string[]).includes('create')) return false;
+      return !r.entityId || r.entityId === this.requesterEntityId;
+    });
+  }
+
+  /**
+   * Create a new record on behalf of the authenticated requester.
+   * Requires either an entity-specific _grant or a default _grant for
+   * the target type. Anonymous requesters (null entityId) are always denied.
+   * The created record's entityId is always set to the requester.
+   */
+  async create<T extends Record<string, unknown> = Record<string, unknown>>(
+    typeId: TypeId,
+    content: T,
+    opts: CreateRecordOptions = {},
+  ): Promise<StackRecord & { content: T }> {
+    const requester = this.requesterEntityId;
+    if (!requester) throw new StackPermissionError('Anonymous requesters cannot create records');
+    if (!(await this.checkCreateGrant(typeId))) {
+      throw new StackPermissionError(`No create grant for type "${typeId}"`);
+    }
+    return this.stack.create(typeId, content, { ...opts, entityId: requester });
   }
 
   async get(id: string, opts: GetRecordOptions = {}): Promise<StackRecord | null> {

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -715,17 +715,24 @@ export class ScopedStack implements StackClient {
     typeId: TypeId,
     actions: GrantAction[],
     record?: StackRecord,
+    prefetchedGrants?: StackRecord[],
   ): Promise<boolean> {
     if (!this.requesterEntityId) return false;
 
-    const result = await this.stack.query({
-      filter: {
-        typeId: `${SYSTEM_TYPES.GRANT}@1`,
-        ...(this.stack.features.contentFieldQuery && { content: { typeId } }),
-      },
-    });
+    let grantRecords: StackRecord[];
+    if (prefetchedGrants !== undefined) {
+      grantRecords = prefetchedGrants;
+    } else {
+      const result = await this.stack.query({
+        filter: {
+          typeId: `${SYSTEM_TYPES.GRANT}@1`,
+          ...(this.stack.features.contentFieldQuery && { content: { typeId } }),
+        },
+      });
+      grantRecords = result.records;
+    }
 
-    return result.records.some((r) => {
+    return grantRecords.some((r) => {
       const c = r.content as GrantContent;
       if (c.typeId !== typeId) return false;
       if (r.entityId && r.entityId !== this.requesterEntityId) return false;
@@ -735,6 +742,13 @@ export class ScopedStack implements StackClient {
         return true;
       });
     });
+  }
+
+  private async canRead(record: StackRecord, prefetchedGrants?: StackRecord[]): Promise<boolean> {
+    return (
+      (await this.checkRead(record)) ||
+      (await this.hasGrant(record.typeId, ['read-own', 'read-any'], record, prefetchedGrants))
+    );
   }
 
   private async checkCreateGrant(typeId: TypeId): Promise<boolean> {
@@ -786,7 +800,7 @@ export class ScopedStack implements StackClient {
   async get(id: string, opts: GetRecordOptions = {}): Promise<StackRecord | null> {
     const record = await this.stack.get(id, opts);
     if (!record) return null;
-    if (!(await this.checkRead(record))) throw new StackPermissionError();
+    if (!(await this.canRead(record))) throw new StackPermissionError();
     return record;
   }
 
@@ -800,16 +814,23 @@ export class ScopedStack implements StackClient {
    * adapter's cursor can't address a position mid-page).
    *
    * `total` is always null — see the QueryResult.total doc comment.
+   *
+   * Grant records are pre-fetched once before the pagination loop so read
+   * grants don't trigger a separate _grant@1 query per record.
    */
   async query(query: StackQuery = {}): Promise<QueryResult> {
     const limit = query.limit ?? DEFAULT_QUERY_LIMIT;
     const records: StackRecord[] = [];
-    let page: QueryResult = { records: [], cursor: query.cursor ?? null, total: null };
 
+    const prefetchedGrants = this.requesterEntityId
+      ? (await this.stack.query({ filter: { typeId: `${SYSTEM_TYPES.GRANT}@1` } })).records
+      : undefined;
+
+    let page: QueryResult = { records: [], cursor: query.cursor ?? null, total: null };
     do {
       page = await this.stack.query({ ...query, cursor: page.cursor ?? undefined });
       for (const record of page.records) {
-        if (await this.checkRead(record)) records.push(record);
+        if (await this.canRead(record, prefetchedGrants)) records.push(record);
       }
     } while (records.length < limit && page.cursor);
 
@@ -844,14 +865,14 @@ export class ScopedStack implements StackClient {
   async getVersions(id: string): Promise<RecordVersion[]> {
     const existing = await this.stack.get(id, { migrate: false });
     if (!existing) throw new StackNotFoundError(`Record not found: "${id}"`);
-    if (!(await this.checkRead(existing))) throw new StackPermissionError();
+    if (!(await this.canRead(existing))) throw new StackPermissionError();
     return this.stack.getVersions(id);
   }
 
   async getVersion(id: string, version: number): Promise<RecordVersion | null> {
     const existing = await this.stack.get(id, { migrate: false });
     if (!existing) throw new StackNotFoundError(`Record not found: "${id}"`);
-    if (!(await this.checkRead(existing))) throw new StackPermissionError();
+    if (!(await this.canRead(existing))) throw new StackPermissionError();
     return this.stack.getVersion(id, version);
   }
 

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -705,26 +705,22 @@ export class ScopedStack implements StackClient {
     );
   }
 
-  /** Fetch a Record the requester has write access to, or throw. */
-  private async requireWritable(id: string): Promise<StackRecord> {
-    const existing = await this.stack.get(id, { migrate: false });
-    if (!existing) throw new StackNotFoundError(`Record not found: "${id}"`);
-    if (!(await this.checkWrite(existing))) throw new StackPermissionError();
-    return existing;
-  }
-
   /**
-   * Check whether the requester has a _grant record permitting them to
-   * create records of the given type. The owner always passes. Any
-   * authenticated entity passes if a default grant (no entityId) exists.
+   * Check whether the requester holds a _grant record covering at least one
+   * of the given actions for the given type. For -own actions, additionally
+   * requires that `record.entityId` matches the requester (authorship check).
+   * Anonymous requesters always return false.
    */
-  private async checkCreateGrant(typeId: TypeId): Promise<boolean> {
-    if (this.requesterEntityId === this.stack.ownerEntityId) return true;
+  private async hasGrant(
+    typeId: TypeId,
+    actions: GrantAction[],
+    record?: StackRecord,
+  ): Promise<boolean> {
+    if (!this.requesterEntityId) return false;
 
-    const grantTypeId = `${SYSTEM_TYPES.GRANT}@1`;
     const result = await this.stack.query({
       filter: {
-        typeId: grantTypeId,
+        typeId: `${SYSTEM_TYPES.GRANT}@1`,
         ...(this.stack.features.contentFieldQuery && { content: { typeId } }),
       },
     });
@@ -732,9 +728,40 @@ export class ScopedStack implements StackClient {
     return result.records.some((r) => {
       const c = r.content as GrantContent;
       if (c.typeId !== typeId) return false;
-      if (!(c.actions as string[]).includes('create')) return false;
-      return !r.entityId || r.entityId === this.requesterEntityId;
+      if (r.entityId && r.entityId !== this.requesterEntityId) return false;
+      return actions.some((action) => {
+        if (!(c.actions as string[]).includes(action)) return false;
+        if (action.endsWith('-own')) return record?.entityId === this.requesterEntityId;
+        return true;
+      });
     });
+  }
+
+  private async checkCreateGrant(typeId: TypeId): Promise<boolean> {
+    if (this.requesterEntityId === this.stack.ownerEntityId) return true;
+    return this.hasGrant(typeId, ['create']);
+  }
+
+  /** Fetch a record the requester can update (via permissions or an update grant), or throw. */
+  private async requireUpdatable(id: string): Promise<StackRecord> {
+    const record = await this.stack.get(id, { migrate: false });
+    if (!record) throw new StackNotFoundError(`Record not found: "${id}"`);
+    const allowed =
+      (await this.checkWrite(record)) ||
+      (await this.hasGrant(record.typeId, ['update-own', 'update-any'], record));
+    if (!allowed) throw new StackPermissionError();
+    return record;
+  }
+
+  /** Fetch a record the requester can delete (via permissions or a delete grant), or throw. */
+  private async requireDeletable(id: string): Promise<StackRecord> {
+    const record = await this.stack.get(id, { migrate: false });
+    if (!record) throw new StackNotFoundError(`Record not found: "${id}"`);
+    const allowed =
+      (await this.checkWrite(record)) ||
+      (await this.hasGrant(record.typeId, ['delete-own', 'delete-any'], record));
+    if (!allowed) throw new StackPermissionError();
+    return record;
   }
 
   /**
@@ -790,27 +817,27 @@ export class ScopedStack implements StackClient {
   }
 
   async update(id: string, content: Record<string, unknown | null>): Promise<StackRecord> {
-    await this.requireWritable(id);
+    await this.requireUpdatable(id);
     return this.stack.update(id, content);
   }
 
   async associate(id: string, association: Association): Promise<void> {
-    await this.requireWritable(id);
+    await this.requireUpdatable(id);
     return this.stack.associate(id, association);
   }
 
   async dissociate(id: string, association: Association): Promise<void> {
-    await this.requireWritable(id);
+    await this.requireUpdatable(id);
     return this.stack.dissociate(id, association);
   }
 
   async setPermissions(id: string, permissions: Permission[]): Promise<void> {
-    await this.requireWritable(id);
+    await this.requireUpdatable(id);
     return this.stack.setPermissions(id, permissions);
   }
 
   async delete(id: string, opts: DeleteRecordOptions = {}): Promise<void> {
-    await this.requireWritable(id);
+    await this.requireDeletable(id);
     return this.stack.delete(id, opts);
   }
 
@@ -829,7 +856,7 @@ export class ScopedStack implements StackClient {
   }
 
   async restoreVersion(id: string, version: number): Promise<StackRecord> {
-    await this.requireWritable(id);
+    await this.requireUpdatable(id);
     return this.stack.restoreVersion(id, version);
   }
 }

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -44,8 +44,7 @@ import type {
 
 export type CreateRecordOptions = {
   parentId?: string;
-  /** Explicit null means no entityId — skips the ownerEntityId fallback. */
-  entityId?: string | null;
+  entityId?: string;
   appId?: string;
   permissions?: Permission[];
   associations?: Association[];
@@ -358,7 +357,6 @@ export class Stack implements StackClient {
     }
 
     const now = new Date();
-    const resolvedEntityId = opts.entityId !== undefined ? opts.entityId : this.ownerEntityId;
     const record: StackRecord = {
       id: generateId(),
       typeId,
@@ -367,7 +365,7 @@ export class Stack implements StackClient {
       content,
       version: 1,
       ...(opts.parentId && { parentId: opts.parentId }),
-      ...(resolvedEntityId != null ? { entityId: resolvedEntityId } : {}),
+      ...(opts.entityId && { entityId: opts.entityId }),
       ...(opts.appId && { appId: opts.appId }),
       ...(opts.permissions?.length && { permissions: opts.permissions }),
       ...(opts.associations?.length && { associations: opts.associations }),
@@ -613,7 +611,7 @@ export class Stack implements StackClient {
         await this.create(
           `${SYSTEM_TYPES.GRANT}@1`,
           { typeId: g.typeId, actions: g.actions },
-          { entityId },
+          entityId ? { entityId } : {},
         ),
       );
     }

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -33,7 +33,6 @@ import type {
   Migration,
   MigrationFn,
   RecordVersion,
-  AdapterCapabilities,
   StackFeatures,
   GrantAction,
   GrantContent,

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -44,7 +44,8 @@ import type {
 
 export type CreateRecordOptions = {
   parentId?: string;
-  entityId?: string;
+  /** Explicit null means no entityId — skips the ownerEntityId fallback. */
+  entityId?: string | null;
   appId?: string;
   permissions?: Permission[];
   associations?: Association[];
@@ -145,7 +146,9 @@ export class Stack implements StackClient {
   static async create(adapter: StackAdapter): Promise<Stack> {
     const entityId = await adapter.getConfig('entity_id');
     const timezone = (await adapter.getConfig('timezone')) ?? 'UTC';
-    return new Stack(adapter, entityId, timezone);
+    const stack = new Stack(adapter, entityId, timezone);
+    await stack.seedSystemTypes();
+    return stack;
   }
 
   get features(): StackFeatures {
@@ -355,6 +358,7 @@ export class Stack implements StackClient {
     }
 
     const now = new Date();
+    const resolvedEntityId = opts.entityId !== undefined ? opts.entityId : this.ownerEntityId;
     const record: StackRecord = {
       id: generateId(),
       typeId,
@@ -363,9 +367,7 @@ export class Stack implements StackClient {
       content,
       version: 1,
       ...(opts.parentId && { parentId: opts.parentId }),
-      ...(opts.entityId
-        ? { entityId: opts.entityId }
-        : this.ownerEntityId && { entityId: this.ownerEntityId }),
+      ...(resolvedEntityId != null ? { entityId: resolvedEntityId } : {}),
       ...(opts.appId && { appId: opts.appId }),
       ...(opts.permissions?.length && { permissions: opts.permissions }),
       ...(opts.associations?.length && { associations: opts.associations }),
@@ -605,30 +607,15 @@ export class Stack implements StackClient {
     entityId: string | null,
     grants: Array<{ actions: GrantAction[]; typeId: TypeId }>,
   ): Promise<StackRecord[]> {
-    const grantTypeId = `${SYSTEM_TYPES.GRANT}@1`;
-    if (!(await this.adapter.getType(grantTypeId))) {
-      await this.defineType(grantTypeId, 'Grant', {
-        typeId: { kind: 'string', required: true },
-        actions: { kind: 'array', items: { kind: 'string' }, required: true },
-      });
-    }
     const records: StackRecord[] = [];
     for (const g of grants) {
-      const now = new Date();
-      // Build the record directly rather than going through this.create() so
-      // that a null entityId produces a record with no entityId field — the
-      // signal that the grant is a default (applies to any authenticated entity).
-      // this.create() always falls back to ownerEntityId when entityId is absent.
-      const record: StackRecord = {
-        id: generateId(),
-        typeId: grantTypeId,
-        createdAt: now,
-        updatedAt: now,
-        content: { typeId: g.typeId, actions: g.actions },
-        version: 1,
-        ...(entityId ? { entityId } : {}),
-      };
-      records.push(await this.adapter.createRecord(record));
+      records.push(
+        await this.create(
+          `${SYSTEM_TYPES.GRANT}@1`,
+          { typeId: g.typeId, actions: g.actions },
+          { entityId },
+        ),
+      );
     }
     return records;
   }
@@ -636,6 +623,26 @@ export class Stack implements StackClient {
   // -------------------------------------------------------
   // Private helpers
   // -------------------------------------------------------
+
+  private async seedSystemTypes(): Promise<void> {
+    await this.defineType(`${SYSTEM_TYPES.ENTITY}@1`, 'Entity', {
+      name: { kind: 'string', required: true },
+      handle: { kind: 'string' },
+    });
+    await this.defineType(`${SYSTEM_TYPES.APP}@1`, 'App', {
+      name: { kind: 'string', required: true },
+      version: { kind: 'string' },
+    });
+    await this.defineType(`${SYSTEM_TYPES.GROUP}@1`, 'Group', {
+      name: { kind: 'string', required: true },
+      handle: { kind: 'string' },
+      stackUrl: { kind: 'string' },
+    });
+    await this.defineType(`${SYSTEM_TYPES.GRANT}@1`, 'Grant', {
+      typeId: { kind: 'string', required: true },
+      actions: { kind: 'array', items: { kind: 'string' }, required: true },
+    });
+  }
 
   private async saveVersion(record: StackRecord): Promise<void> {
     const version: RecordVersion = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -181,7 +181,7 @@ export type GroupContent = {
 };
 
 /** Actions that can be granted via a _grant record. */
-export type GrantAction = 'create';
+export type GrantAction = 'create' | 'update-own' | 'update-any' | 'delete-own' | 'delete-any';
 
 /** Content for _grant records */
 export type GrantContent = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -275,7 +275,7 @@ export type Migration = {
 };
 
 // -------------------------------------------------------
-// Adapter capabilities
+// Adapter capabilities / Stack features
 // -------------------------------------------------------
 
 export type AdapterCapabilities = {
@@ -283,6 +283,9 @@ export type AdapterCapabilities = {
   contentFieldQuery: boolean;
   sortableFields: Array<QuerySort['field']>;
 };
+
+/** What a Stack can do, as seen by app and plugin code. */
+export type StackFeatures = AdapterCapabilities;
 
 // -------------------------------------------------------
 // Attachment metadata

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -181,7 +181,14 @@ export type GroupContent = {
 };
 
 /** Actions that can be granted via a _grant record. */
-export type GrantAction = 'create' | 'update-own' | 'update-any' | 'delete-own' | 'delete-any';
+export type GrantAction =
+  | 'create'
+  | 'read-own'
+  | 'read-any'
+  | 'update-own'
+  | 'update-any'
+  | 'delete-own'
+  | 'delete-any';
 
 /** Content for _grant records */
 export type GrantContent = {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -180,11 +180,24 @@ export type GroupContent = {
   stackUrl?: string;
 };
 
+/** Actions that can be granted via a _grant record. */
+export type GrantAction = 'create';
+
+/** Content for _grant records */
+export type GrantContent = {
+  /** Which record type the grant applies to. */
+  typeId: TypeId;
+  /** Which actions are permitted. */
+  actions: GrantAction[];
+};
+
 /** Reserved system type IDs */
 export const SYSTEM_TYPES = {
   ENTITY: '_entity',
   APP: '_app',
   GROUP: '_group',
+  /** Creation-permission grants. See GrantContent. */
+  GRANT: '_grant',
 } as const;
 
 // -------------------------------------------------------

--- a/packages/core/tests/scoped-stack.test.ts
+++ b/packages/core/tests/scoped-stack.test.ts
@@ -488,3 +488,76 @@ describe('ScopedStack.create', () => {
     );
   });
 });
+
+// -------------------------------------------------------
+// ScopedStack — grant-based update/delete
+// -------------------------------------------------------
+
+describe('ScopedStack — grant-based update/delete', () => {
+  beforeEach(async () => {
+    await stack.defineType(COMMENT, 'Comment', { text: { kind: 'text', required: true } });
+  });
+
+  test('update-own: entity can update a record they authored', async () => {
+    await stack.grant(MEMBER, [{ actions: ['update-own'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT, { text: 'original' }, { entityId: MEMBER });
+    const updated = await stack.asEntity(MEMBER).update(record.id, { text: 'edited' });
+    expect(updated.content.text).toBe('edited');
+  });
+
+  test('update-own: entity cannot update a record authored by someone else', async () => {
+    await stack.grant(MEMBER, [{ actions: ['update-own'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT, { text: 'original' }, { entityId: STRANGER });
+    await expect(stack.asEntity(MEMBER).update(record.id, { text: 'edited' })).rejects.toThrow(
+      StackPermissionError,
+    );
+  });
+
+  test('update-any: entity can update records regardless of authorship', async () => {
+    await stack.grant(MEMBER, [{ actions: ['update-any'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT, { text: 'original' }, { entityId: STRANGER });
+    const updated = await stack.asEntity(MEMBER).update(record.id, { text: 'edited' });
+    expect(updated.content.text).toBe('edited');
+  });
+
+  test('delete-own: entity can delete a record they authored', async () => {
+    await stack.grant(MEMBER, [{ actions: ['delete-own'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT, { text: 'hello' }, { entityId: MEMBER });
+    await stack.asEntity(MEMBER).delete(record.id);
+    expect((await adapter.getRecord(record.id))?.deletedAt).toBeDefined();
+  });
+
+  test('delete-own: entity cannot delete a record authored by someone else', async () => {
+    await stack.grant(MEMBER, [{ actions: ['delete-own'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT, { text: 'hello' }, { entityId: STRANGER });
+    await expect(stack.asEntity(MEMBER).delete(record.id)).rejects.toThrow(StackPermissionError);
+  });
+
+  test('delete-any: entity can delete records regardless of authorship', async () => {
+    await stack.grant(MEMBER, [{ actions: ['delete-any'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT, { text: 'hello' }, { entityId: STRANGER });
+    await stack.asEntity(MEMBER).delete(record.id);
+    expect((await adapter.getRecord(record.id))?.deletedAt).toBeDefined();
+  });
+
+  test('update grant does not allow delete', async () => {
+    await stack.grant(MEMBER, [{ actions: ['update-any'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT, { text: 'hello' }, { entityId: MEMBER });
+    await expect(stack.asEntity(MEMBER).delete(record.id)).rejects.toThrow(StackPermissionError);
+  });
+
+  test('delete grant does not allow update', async () => {
+    await stack.grant(MEMBER, [{ actions: ['delete-any'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT, { text: 'hello' }, { entityId: MEMBER });
+    await expect(stack.asEntity(MEMBER).update(record.id, { text: 'edited' })).rejects.toThrow(
+      StackPermissionError,
+    );
+  });
+
+  test('default grant (null entityId) applies update-own to any authenticated entity', async () => {
+    await stack.grant(null, [{ actions: ['update-own'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT, { text: 'original' }, { entityId: STRANGER });
+    const updated = await stack.asEntity(STRANGER).update(record.id, { text: 'edited' });
+    expect(updated.content.text).toBe('edited');
+  });
+});

--- a/packages/core/tests/scoped-stack.test.ts
+++ b/packages/core/tests/scoped-stack.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect, beforeEach } from 'vitest';
-import { Stack, StackPermissionError, StackNotFoundError, StackValidationError } from '../src/stack.js';
+import {
+  Stack,
+  StackPermissionError,
+  StackNotFoundError,
+  StackValidationError,
+} from '../src/stack.js';
 import { generateId } from '../src/id.js';
 import type {
   StackAdapter,
@@ -478,8 +483,8 @@ describe('ScopedStack.create', () => {
 
   test('content validation still runs after grant check', async () => {
     await stack.grant(MEMBER, [{ actions: ['create'], typeId: COMMENT }]);
-    await expect(
-      stack.asEntity(MEMBER).create(COMMENT, {} as { text: string }),
-    ).rejects.toThrow(StackValidationError);
+    await expect(stack.asEntity(MEMBER).create(COMMENT, {} as { text: string })).rejects.toThrow(
+      StackValidationError,
+    );
   });
 });

--- a/packages/core/tests/scoped-stack.test.ts
+++ b/packages/core/tests/scoped-stack.test.ts
@@ -490,6 +490,70 @@ describe('ScopedStack.create', () => {
 });
 
 // -------------------------------------------------------
+// ScopedStack — grant-based read
+// -------------------------------------------------------
+
+describe('ScopedStack — grant-based read', () => {
+  beforeEach(async () => {
+    await stack.defineType(COMMENT, 'Comment', { text: { kind: 'text', required: true } });
+  });
+
+  test('read-any: entity can read private records of the granted type', async () => {
+    await stack.grant(MEMBER, [{ actions: ['read-any'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT, { text: 'hello' });
+    expect((await stack.asEntity(MEMBER).get(record.id))?.id).toBe(record.id);
+  });
+
+  test('read-any: does not grant access to other types', async () => {
+    await stack.grant(MEMBER, [{ actions: ['read-any'], typeId: COMMENT }]);
+    const note = await stack.create(NOTE, { text: 'private note' });
+    await expect(stack.asEntity(MEMBER).get(note.id)).rejects.toThrow(StackPermissionError);
+  });
+
+  test('read-own: entity can read records they authored', async () => {
+    await stack.grant(MEMBER, [{ actions: ['read-own'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT, { text: 'hello' }, { entityId: MEMBER });
+    expect((await stack.asEntity(MEMBER).get(record.id))?.id).toBe(record.id);
+  });
+
+  test('read-own: entity cannot read records authored by someone else', async () => {
+    await stack.grant(MEMBER, [{ actions: ['read-own'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT, { text: 'hello' }, { entityId: STRANGER });
+    await expect(stack.asEntity(MEMBER).get(record.id)).rejects.toThrow(StackPermissionError);
+  });
+
+  test('default read-any grant allows any authenticated entity to read', async () => {
+    await stack.grant(null, [{ actions: ['read-any'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT, { text: 'hello' });
+    expect((await stack.asEntity(STRANGER).get(record.id))?.id).toBe(record.id);
+  });
+
+  test('read grant is visible in query() results', async () => {
+    await stack.grant(MEMBER, [{ actions: ['read-any'], typeId: COMMENT }]);
+    await stack.create(COMMENT, { text: 'a' });
+    await stack.create(COMMENT, { text: 'b' });
+    const result = await stack.asEntity(MEMBER).query({ filter: { typeId: COMMENT } });
+    expect(result.records).toHaveLength(2);
+  });
+
+  test('query() filters out types not covered by the read grant', async () => {
+    await stack.grant(MEMBER, [{ actions: ['read-any'], typeId: COMMENT }]);
+    await stack.create(COMMENT, { text: 'visible' });
+    await stack.create(NOTE, { text: 'hidden' });
+    const result = await stack.asEntity(MEMBER).query();
+    expect(result.records.every((r) => r.typeId === COMMENT)).toBe(true);
+  });
+
+  test('read grant does not grant write access', async () => {
+    await stack.grant(MEMBER, [{ actions: ['read-any'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT, { text: 'hello' });
+    await expect(stack.asEntity(MEMBER).update(record.id, { text: 'edited' })).rejects.toThrow(
+      StackPermissionError,
+    );
+  });
+});
+
+// -------------------------------------------------------
 // ScopedStack — grant-based update/delete
 // -------------------------------------------------------
 

--- a/packages/core/tests/scoped-stack.test.ts
+++ b/packages/core/tests/scoped-stack.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach } from 'vitest';
-import { Stack, StackPermissionError, StackNotFoundError } from '../src/stack.js';
+import { Stack, StackPermissionError, StackNotFoundError, StackValidationError } from '../src/stack.js';
 import { generateId } from '../src/id.js';
 import type {
   StackAdapter,
@@ -169,6 +169,8 @@ beforeEach(async () => {
   stack = await Stack.create(adapter);
   await stack.defineType(NOTE, 'Note', { text: { kind: 'text' } });
 });
+
+const COMMENT = 'com.example.test/comment@1';
 
 // -------------------------------------------------------
 // Read access
@@ -404,5 +406,80 @@ describe('ScopedStack.query', () => {
     const result = await stack.asEntity(null).query({ limit: 2 });
     expect(result.records).toHaveLength(3);
     expect(result.cursor).toBeNull();
+  });
+});
+
+// -------------------------------------------------------
+// ScopedStack.create — grant-based creation
+// -------------------------------------------------------
+
+describe('ScopedStack.create', () => {
+  beforeEach(async () => {
+    await stack.defineType(COMMENT, 'Comment', { text: { kind: 'text', required: true } });
+  });
+
+  test('owner can always create records via ScopedStack', async () => {
+    const record = await stack.asEntity(OWNER).create(COMMENT, { text: 'hello' });
+    expect(record.typeId).toBe(COMMENT);
+    expect(record.entityId).toBe(OWNER);
+  });
+
+  test('anonymous requester cannot create records', async () => {
+    await expect(stack.asEntity(null).create(COMMENT, { text: 'hello' })).rejects.toThrow(
+      StackPermissionError,
+    );
+  });
+
+  test('authenticated entity without a grant cannot create records', async () => {
+    await expect(stack.asEntity(MEMBER).create(COMMENT, { text: 'hello' })).rejects.toThrow(
+      StackPermissionError,
+    );
+  });
+
+  test('entity with an entity-specific grant can create the granted type', async () => {
+    await stack.grant(MEMBER, [{ actions: ['create'], typeId: COMMENT }]);
+    const record = await stack.asEntity(MEMBER).create(COMMENT, { text: 'hello' });
+    expect(record.typeId).toBe(COMMENT);
+    expect(record.entityId).toBe(MEMBER);
+  });
+
+  test('entity cannot create a type other than the one granted', async () => {
+    await stack.grant(MEMBER, [{ actions: ['create'], typeId: COMMENT }]);
+    await expect(stack.asEntity(MEMBER).create(NOTE, { text: 'sneaky' })).rejects.toThrow(
+      StackPermissionError,
+    );
+  });
+
+  test('default grant (null entityId) allows any authenticated entity to create', async () => {
+    await stack.grant(null, [{ actions: ['create'], typeId: COMMENT }]);
+    const record = await stack.asEntity(STRANGER).create(COMMENT, { text: 'hello' });
+    expect(record.entityId).toBe(STRANGER);
+  });
+
+  test('default grant does not apply to anonymous requesters', async () => {
+    await stack.grant(null, [{ actions: ['create'], typeId: COMMENT }]);
+    await expect(stack.asEntity(null).create(COMMENT, { text: 'hello' })).rejects.toThrow(
+      StackPermissionError,
+    );
+  });
+
+  test('entity without a specific grant is not helped by a grant for a different entity', async () => {
+    await stack.grant(MEMBER, [{ actions: ['create'], typeId: COMMENT }]);
+    await expect(stack.asEntity(STRANGER).create(COMMENT, { text: 'hello' })).rejects.toThrow(
+      StackPermissionError,
+    );
+  });
+
+  test('created record always carries the requester entityId', async () => {
+    await stack.grant(MEMBER, [{ actions: ['create'], typeId: COMMENT }]);
+    const record = await stack.asEntity(MEMBER).create(COMMENT, { text: 'hello' });
+    expect(record.entityId).toBe(MEMBER);
+  });
+
+  test('content validation still runs after grant check', async () => {
+    await stack.grant(MEMBER, [{ actions: ['create'], typeId: COMMENT }]);
+    await expect(
+      stack.asEntity(MEMBER).create(COMMENT, {} as { text: string }),
+    ).rejects.toThrow(StackValidationError);
   });
 });

--- a/packages/core/tests/stack.test.ts
+++ b/packages/core/tests/stack.test.ts
@@ -590,6 +590,48 @@ describe('flush / close', () => {
 });
 
 // -------------------------------------------------------
+// grant
+// -------------------------------------------------------
+
+describe('grant', () => {
+  test('creates a grant record for the given entity and type', async () => {
+    const records = await stack.grant('entity-abc', [{ actions: ['create'], typeId: NOTE_V1 }]);
+    expect(records).toHaveLength(1);
+    expect(records[0].entityId).toBe('entity-abc');
+    expect(records[0].content).toEqual({ typeId: NOTE_V1, actions: ['create'] });
+  });
+
+  test('null entityId creates a default grant (no entityId on the record)', async () => {
+    const records = await stack.grant(null, [{ actions: ['create'], typeId: NOTE_V1 }]);
+    expect(records[0].entityId).toBeUndefined();
+  });
+
+  test('creates multiple grant records in one call', async () => {
+    await stack.defineType(NOTE_V2, 'Note v2', {
+      text: { kind: 'text', required: true },
+      title: { kind: 'string' },
+    });
+    const records = await stack.grant('entity-abc', [
+      { actions: ['create'], typeId: NOTE_V1 },
+      { actions: ['create'], typeId: NOTE_V2 },
+    ]);
+    expect(records).toHaveLength(2);
+  });
+
+  test('auto-defines the _grant@1 type on first use', async () => {
+    await stack.grant('entity-abc', [{ actions: ['create'], typeId: NOTE_V1 }]);
+    expect(await stack.getType('_grant@1')).not.toBeNull();
+  });
+
+  test('calling grant twice does not redefine the type', async () => {
+    await stack.grant('entity-abc', [{ actions: ['create'], typeId: NOTE_V1 }]);
+    await expect(
+      stack.grant('entity-def', [{ actions: ['create'], typeId: NOTE_V1 }]),
+    ).resolves.toHaveLength(1);
+  });
+});
+
+// -------------------------------------------------------
 // associate / dissociate
 // -------------------------------------------------------
 

--- a/packages/core/tests/stack.test.ts
+++ b/packages/core/tests/stack.test.ts
@@ -231,9 +231,9 @@ describe('create', () => {
     expect(record.version).toBe(1);
   });
 
-  test('sets entityId from stack ownerEntityId', async () => {
+  test('does not set entityId when none is supplied (owner-created records are implicitly owner-owned)', async () => {
     const record = await stack.create(NOTE_V1, { text: 'hello' });
-    expect(record.entityId).toBe('owner-123');
+    expect(record.entityId).toBeUndefined();
   });
 
   test('allows overriding entityId via options', async () => {

--- a/packages/core/tests/stack.test.ts
+++ b/packages/core/tests/stack.test.ts
@@ -621,13 +621,6 @@ describe('grant', () => {
   test('_grant@1 type is available immediately after Stack.create()', async () => {
     expect(await stack.getType('_grant@1')).not.toBeNull();
   });
-
-  test('calling grant twice does not redefine the type', async () => {
-    await stack.grant('entity-abc', [{ actions: ['create'], typeId: NOTE_V1 }]);
-    await expect(
-      stack.grant('entity-def', [{ actions: ['create'], typeId: NOTE_V1 }]),
-    ).resolves.toHaveLength(1);
-  });
 });
 
 // -------------------------------------------------------

--- a/packages/core/tests/stack.test.ts
+++ b/packages/core/tests/stack.test.ts
@@ -618,8 +618,7 @@ describe('grant', () => {
     expect(records).toHaveLength(2);
   });
 
-  test('auto-defines the _grant@1 type on first use', async () => {
-    await stack.grant('entity-abc', [{ actions: ['create'], typeId: NOTE_V1 }]);
+  test('_grant@1 type is available immediately after Stack.create()', async () => {
     expect(await stack.getType('_grant@1')).not.toBeNull();
   });
 


### PR DESCRIPTION
Addresses issue #1 ("Ensure Stack is a clean, passable interface") and introduces a complementary entity-level permission system via `_grant` records.

## StackClient interface

Extracts a `StackClient` interface covering the full app-facing record API: `create`, `get`, `query`, `update`, `delete`, `associate`, `dissociate`, `setPermissions`, `getVersions`, `getVersion`, `restoreVersion`, and a `features` getter. Both `Stack` and `ScopedStack` implement it, so plugin and extension code can accept either without knowing which concrete class it holds or importing any adapter package.

`StackFeatures` (a type alias for `AdapterCapabilities`) is exposed on `StackClient` rather than `StackAdapter` — stack consumers see a stack-centric name, adapter implementers keep `AdapterCapabilities`.

## System type pre-seeding

All four system types (`_entity@1`, `_app@1`, `_group@1`, `_grant@1`) are now defined automatically when a stack is created via a new private `seedSystemTypes()` method called from the `Stack.create()` static factory. Previously they were informal constants with no registered schema; now they're always available without any extra setup.

`CreateRecordOptions.entityId` accepts `null` as an explicit signal to skip the `ownerEntityId` fallback, allowing records to be created with no `entityId` field. This is used by `Stack.grant()` to store default grants (applying to any authenticated entity) cleanly through the normal `Stack.create()` path.

## _grant system type and Stack.grant()

`_grant` records authorise entities to perform specific actions on records of a given type. `Stack.grant(entityId, grants)` is the owner-facing helper to create them. Design decisions:

- **No wildcard `typeId`**: new types are always default-deny until explicitly granted — opting in per type is safer than opting out.
- **Default grants** (`entityId: null`): a grant with no `entityId` applies to any authenticated entity. Useful for "anyone can comment" scenarios.
- **Entity-specific grants**: scoped to a single grantee's `entityId`.

## ScopedStack — grant-based access control

`ScopedStack` now checks `_grant` records for all access modes. The permission system has two complementary layers:

- **Record-level permissions** (`record.permissions`): the existing `public` / `entity` / `group` model on individual records.
- **Type-level grants** (`_grant` records): apply to all records of a type without touching individual records.

### Actions

| Action | Scope |
|---|---|
| `create` | Create new records of this type |
| `read-own` | Read records where `record.entityId === requester` |
| `read-any` | Read all records of this type |
| `update-own` | Update records where `record.entityId === requester` |
| `update-any` | Update all records of this type |
| `delete-own` | Delete records where `record.entityId === requester` |
| `delete-any` | Delete all records of this type |

Actions are independent — none imply each other. The typical contributor grant is `['create', 'read-own', 'update-own', 'delete-own']`; a moderator grant might be `['read-any', 'update-any', 'delete-any']`.

`ScopedStack.create()` always stamps `entityId: requester` on new records, making `-own` grants immediately applicable to records the entity just created.

For `ScopedStack.query()`, all `_grant@1` records are pre-fetched once before the pagination loop so read grants don't fire a separate grant query per record.