### PR TITLE
Extract MemoryAdapter to public testing module

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,11 @@ packages/
       index.ts            # Public exports
       types.ts            # All type definitions
       stack.ts            # Stack class
+      access.ts           # Permission and grant checking
       id.ts               # Crockford base-32 ID generation
       schema.ts           # Schema hashing and type compatibility
       validate.ts         # Content validation
+      testing.ts          # MemoryAdapter test helper (@haverstack/core/testing)
     tests/
   adapter-sqlite/         # @haverstack/adapter-sqlite
     src/

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -7,6 +7,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./testing": {
+      "import": "./dist/testing.js",
+      "types": "./dist/testing.d.ts"
     }
   },
   "main": "./dist/index.js",

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -1,0 +1,145 @@
+import type {
+  StackAdapter,
+  StackRecord,
+  StackType,
+  TypeId,
+  RecordVersion,
+  StackQuery,
+  QueryResult,
+  Association,
+  AdapterCapabilities,
+  AttachmentMeta,
+} from './types.js';
+
+/**
+ * Fully functional in-memory StackAdapter with offset-based cursor pagination.
+ * Intended for use in tests — import from `@haverstack/core/testing`.
+ */
+export class MemoryAdapter implements StackAdapter {
+  readonly capabilities: AdapterCapabilities = {
+    fullTextSearch: false,
+    contentFieldQuery: false,
+    sortableFields: ['createdAt', 'updatedAt', 'version'],
+  };
+
+  readonly records = new Map<string, StackRecord>();
+  readonly order: string[] = [];
+  readonly versions = new Map<string, RecordVersion[]>();
+  readonly types = new Map<string, StackType>();
+  readonly config: Map<string, string>;
+
+  constructor(initialConfig: Record<string, string> = {}) {
+    this.config = new Map(Object.entries(initialConfig));
+  }
+
+  async getConfig(key: string) {
+    return this.config.get(key) ?? null;
+  }
+  async setConfig(key: string, value: string) {
+    this.config.set(key, value);
+  }
+
+  async createRecord(record: StackRecord) {
+    this.records.set(record.id, { ...record });
+    this.order.push(record.id);
+    return record;
+  }
+
+  async getRecord(id: string) {
+    return this.records.get(id) ?? null;
+  }
+
+  async updateRecord(id: string, changes: Partial<StackRecord>) {
+    const existing = this.records.get(id);
+    if (!existing) throw new Error(`Not found: ${id}`);
+    const updated = { ...existing, ...changes };
+    this.records.set(id, updated);
+    return updated;
+  }
+
+  async deleteRecord(id: string, opts: { hard?: boolean } = {}) {
+    if (opts.hard) {
+      this.records.delete(id);
+      this.order.splice(this.order.indexOf(id), 1);
+    } else {
+      const record = this.records.get(id);
+      if (record) this.records.set(id, { ...record, deletedAt: new Date() });
+    }
+  }
+
+  /** Cursor is a stringified offset into insertion order. */
+  async queryRecords(query: StackQuery): Promise<QueryResult> {
+    const f = query.filter ?? {};
+    let results = this.order.map((id) => this.records.get(id)!);
+    if (!f.includeDeleted) results = results.filter((r) => !r.deletedAt);
+    if (f.typeId) {
+      const ids = Array.isArray(f.typeId) ? f.typeId : [f.typeId];
+      results = results.filter((r) => ids.includes(r.typeId));
+    }
+    if (f.parentId !== undefined) {
+      results =
+        f.parentId === null
+          ? results.filter((r) => !r.parentId)
+          : results.filter((r) => r.parentId === f.parentId);
+    }
+
+    const limit = query.limit ?? 50;
+    const start = query.cursor ? Number(query.cursor) : 0;
+    const page = results.slice(start, start + limit);
+    const nextStart = start + limit;
+    const cursor = nextStart < results.length ? String(nextStart) : null;
+
+    return { records: page, cursor, total: results.length };
+  }
+
+  async associate(id: string, association: Association) {
+    const record = this.records.get(id);
+    if (!record) throw new Error(`Not found: ${id}`);
+    const assocs = record.associations ?? [];
+    this.records.set(id, { ...record, associations: [...assocs, association] });
+  }
+
+  async dissociate(id: string, association: Association) {
+    const record = this.records.get(id);
+    if (!record) throw new Error(`Not found: ${id}`);
+    const assocs = (record.associations ?? []).filter(
+      (a) => !(a.kind === association.kind && a.label === association.label),
+    );
+    this.records.set(id, { ...record, associations: assocs });
+  }
+
+  async getVersions(id: string) {
+    return this.versions.get(id) ?? [];
+  }
+  async getVersion(id: string, version: number) {
+    return (this.versions.get(id) ?? []).find((v) => v.version === version) ?? null;
+  }
+  async saveVersion(id: string, version: RecordVersion) {
+    const existing = this.versions.get(id) ?? [];
+    this.versions.set(id, [...existing, version]);
+  }
+
+  async saveType(type: StackType) {
+    this.types.set(type.id, type);
+  }
+  async getType(id: TypeId) {
+    return this.types.get(id) ?? null;
+  }
+  async listTypes() {
+    return [...this.types.values()];
+  }
+
+  async putAttachment(_data: Uint8Array, _mimeType: string) {
+    return 'file-123';
+  }
+  async getAttachment(_fileId: string): Promise<Uint8Array> {
+    return new Uint8Array();
+  }
+  async getAttachmentMeta(_fileId: string): Promise<AttachmentMeta | null> {
+    return null;
+  }
+  async deleteAttachment(_fileId: string) {}
+
+  flush?: () => Promise<void>;
+  close?: () => Promise<void>;
+}

--- a/packages/core/tests/scoped-stack.test.ts
+++ b/packages/core/tests/scoped-stack.test.ts
@@ -6,143 +6,8 @@ import {
   StackValidationError,
 } from '../src/stack.js';
 import { generateId } from '../src/id.js';
-import type {
-  StackAdapter,
-  StackRecord,
-  StackType,
-  TypeId,
-  RecordVersion,
-  StackQuery,
-  QueryResult,
-  Association,
-  AdapterCapabilities,
-  AttachmentMeta,
-  Permission,
-} from '../src/types.js';
-
-// -------------------------------------------------------
-// Mock adapter with real cursor-based pagination — needed to exercise
-// ScopedStack.query()'s filter-then-refill loop across multiple pages.
-// -------------------------------------------------------
-
-class PaginatingMockAdapter implements StackAdapter {
-  readonly capabilities: AdapterCapabilities = {
-    fullTextSearch: false,
-    contentFieldQuery: false,
-    sortableFields: ['createdAt', 'updatedAt', 'version'],
-  };
-
-  readonly records = new Map<string, StackRecord>();
-  readonly order: string[] = [];
-  readonly versions = new Map<string, RecordVersion[]>();
-  readonly types = new Map<string, StackType>();
-  readonly config = new Map<string, string>([
-    ['entity_id', 'owner-123'],
-    ['timezone', 'UTC'],
-  ]);
-
-  async getConfig(key: string) {
-    return this.config.get(key) ?? null;
-  }
-  async setConfig(key: string, value: string) {
-    this.config.set(key, value);
-  }
-
-  async createRecord(record: StackRecord) {
-    this.records.set(record.id, { ...record });
-    this.order.push(record.id);
-    return record;
-  }
-
-  async getRecord(id: string) {
-    return this.records.get(id) ?? null;
-  }
-
-  async updateRecord(id: string, changes: Partial<StackRecord>) {
-    const existing = this.records.get(id);
-    if (!existing) throw new Error(`Not found: ${id}`);
-    const updated = { ...existing, ...changes };
-    this.records.set(id, updated);
-    return updated;
-  }
-
-  async deleteRecord(id: string, opts: { hard?: boolean } = {}) {
-    if (opts.hard) {
-      this.records.delete(id);
-      this.order.splice(this.order.indexOf(id), 1);
-    } else {
-      const record = this.records.get(id);
-      if (record) this.records.set(id, { ...record, deletedAt: new Date() });
-    }
-  }
-
-  /** Cursor is just a stringified offset into insertion order — fine for tests. */
-  async queryRecords(query: StackQuery): Promise<QueryResult> {
-    const f = query.filter ?? {};
-    let results = this.order.map((id) => this.records.get(id)!);
-    if (!f.includeDeleted) results = results.filter((r) => !r.deletedAt);
-    if (f.typeId) {
-      const ids = Array.isArray(f.typeId) ? f.typeId : [f.typeId];
-      results = results.filter((r) => ids.includes(r.typeId));
-    }
-
-    const limit = query.limit ?? 50;
-    const start = query.cursor ? Number(query.cursor) : 0;
-    const page = results.slice(start, start + limit);
-    const nextStart = start + limit;
-    const cursor = nextStart < results.length ? String(nextStart) : null;
-
-    return { records: page, cursor, total: results.length };
-  }
-
-  async associate(id: string, association: Association) {
-    const record = this.records.get(id);
-    if (!record) throw new Error(`Not found: ${id}`);
-    const assocs = record.associations ?? [];
-    this.records.set(id, { ...record, associations: [...assocs, association] });
-  }
-
-  async dissociate(id: string, association: Association) {
-    const record = this.records.get(id);
-    if (!record) throw new Error(`Not found: ${id}`);
-    const assocs = (record.associations ?? []).filter(
-      (a) => !(a.kind === association.kind && a.label === association.label),
-    );
-    this.records.set(id, { ...record, associations: assocs });
-  }
-
-  async getVersions(id: string) {
-    return this.versions.get(id) ?? [];
-  }
-  async getVersion(id: string, version: number) {
-    return (this.versions.get(id) ?? []).find((v) => v.version === version) ?? null;
-  }
-  async saveVersion(id: string, version: RecordVersion) {
-    const existing = this.versions.get(id) ?? [];
-    this.versions.set(id, [...existing, version]);
-  }
-
-  async saveType(type: StackType) {
-    this.types.set(type.id, type);
-  }
-  async getType(id: TypeId) {
-    return this.types.get(id) ?? null;
-  }
-  async listTypes() {
-    return [...this.types.values()];
-  }
-
-  async putAttachment(_data: Uint8Array, _mimeType: string) {
-    return 'file-123';
-  }
-  async getAttachment(_fileId: string): Promise<Uint8Array> {
-    return new Uint8Array();
-  }
-  async getAttachmentMeta(_fileId: string): Promise<AttachmentMeta | null> {
-    return null;
-  }
-  async deleteAttachment(_fileId: string) {}
-}
+import { MemoryAdapter } from '../src/testing.js';
+import type { StackRecord, Association, Permission } from '../src/types.js';
 
 // -------------------------------------------------------
 // Test setup
@@ -153,7 +18,7 @@ const OWNER = 'owner-123';
 const MEMBER = 'member-456';
 const STRANGER = 'stranger-789';
 
-let adapter: PaginatingMockAdapter;
+let adapter: MemoryAdapter;
 let stack: Stack;
 
 function makeRecord(overrides: Partial<StackRecord> = {}): StackRecord {
@@ -170,7 +35,7 @@ function makeRecord(overrides: Partial<StackRecord> = {}): StackRecord {
 }
 
 beforeEach(async () => {
-  adapter = new PaginatingMockAdapter();
+  adapter = new MemoryAdapter({ entity_id: OWNER, timezone: 'UTC' });
   stack = await Stack.create(adapter);
   await stack.defineType(NOTE, 'Note', { text: { kind: 'text' } });
 });

--- a/packages/core/tests/stack.test.ts
+++ b/packages/core/tests/stack.test.ts
@@ -1,139 +1,6 @@
 import { describe, test, expect, beforeEach } from 'vitest';
 import { Stack, StackValidationError, StackMigrationError } from '../src/stack.js';
-import type {
-  StackAdapter,
-  StackRecord,
-  StackType,
-  TypeId,
-  RecordVersion,
-  StackQuery,
-  QueryResult,
-  Association,
-  AdapterCapabilities,
-  AttachmentMeta,
-} from '../src/types.js';
-
-// -------------------------------------------------------
-// Mock adapter
-// -------------------------------------------------------
-
-class MockAdapter implements StackAdapter {
-  readonly capabilities: AdapterCapabilities = {
-    fullTextSearch: false,
-    contentFieldQuery: false,
-    sortableFields: ['createdAt', 'updatedAt', 'version'],
-  };
-
-  readonly records = new Map<string, StackRecord>();
-  readonly versions = new Map<string, RecordVersion[]>();
-  readonly types = new Map<string, StackType>();
-  readonly config = new Map<string, string>([
-    ['entity_id', 'owner-123'],
-    ['timezone', 'UTC'],
-  ]);
-
-  async getConfig(key: string) {
-    return this.config.get(key) ?? null;
-  }
-  async setConfig(key: string, value: string) {
-    this.config.set(key, value);
-  }
-
-  async createRecord(record: StackRecord) {
-    this.records.set(record.id, { ...record });
-    return record;
-  }
-
-  async getRecord(id: string) {
-    return this.records.get(id) ?? null;
-  }
-
-  async updateRecord(id: string, changes: Partial<StackRecord>) {
-    const existing = this.records.get(id);
-    if (!existing) throw new Error(`Not found: ${id}`);
-    const updated = { ...existing, ...changes };
-    this.records.set(id, updated);
-    return updated;
-  }
-
-  async deleteRecord(id: string, opts: { hard?: boolean } = {}) {
-    if (opts.hard) {
-      this.records.delete(id);
-      this.versions.delete(id);
-    } else {
-      const record = this.records.get(id);
-      if (record) this.records.set(id, { ...record, deletedAt: new Date() });
-    }
-  }
-
-  async queryRecords(query: StackQuery): Promise<QueryResult> {
-    const f = query.filter ?? {};
-    let results = [...this.records.values()];
-    if (!f.includeDeleted) results = results.filter((r) => !r.deletedAt);
-    if (f.typeId) {
-      const ids = Array.isArray(f.typeId) ? f.typeId : [f.typeId];
-      results = results.filter((r) => ids.includes(r.typeId));
-    }
-    if (f.parentId !== undefined) {
-      results =
-        f.parentId === null
-          ? results.filter((r) => !r.parentId)
-          : results.filter((r) => r.parentId === f.parentId);
-    }
-    return { records: results, cursor: null, total: results.length };
-  }
-
-  async associate(id: string, association: Association) {
-    const record = this.records.get(id);
-    if (!record) throw new Error(`Not found: ${id}`);
-    const assocs = record.associations ?? [];
-    this.records.set(id, { ...record, associations: [...assocs, association] });
-  }
-
-  async dissociate(id: string, association: Association) {
-    const record = this.records.get(id);
-    if (!record) throw new Error(`Not found: ${id}`);
-    const assocs = (record.associations ?? []).filter(
-      (a) => !(a.kind === association.kind && a.label === association.label),
-    );
-    this.records.set(id, { ...record, associations: assocs });
-  }
-
-  async getVersions(id: string) {
-    return this.versions.get(id) ?? [];
-  }
-  async getVersion(id: string, version: number) {
-    return (this.versions.get(id) ?? []).find((v) => v.version === version) ?? null;
-  }
-  async saveVersion(id: string, version: RecordVersion) {
-    const existing = this.versions.get(id) ?? [];
-    this.versions.set(id, [...existing, version]);
-  }
-
-  async saveType(type: StackType) {
-    this.types.set(type.id, type);
-  }
-  async getType(id: TypeId) {
-    return this.types.get(id) ?? null;
-  }
-  async listTypes() {
-    return [...this.types.values()];
-  }
-
-  async putAttachment(_data: Uint8Array, _mimeType: string) {
-    return 'file-123';
-  }
-  async getAttachment(_fileId: string): Promise<Uint8Array> {
-    return new Uint8Array();
-  }
-  async getAttachmentMeta(_fileId: string): Promise<AttachmentMeta | null> {
-    return null;
-  }
-  async deleteAttachment(_fileId: string) {}
-
-  flush?: () => Promise<void>;
-  close?: () => Promise<void>;
-}
+import { MemoryAdapter } from '../src/testing.js';
 
 // -------------------------------------------------------
 // Test setup
@@ -143,11 +10,11 @@ const NOTE_V1 = 'com.example.test/note@1';
 const NOTE_V2 = 'com.example.test/note@2';
 const NOTE_V3 = 'com.example.test/note@3';
 
-let adapter: MockAdapter;
+let adapter: MemoryAdapter;
 let stack: Stack;
 
 beforeEach(async () => {
-  adapter = new MockAdapter();
+  adapter = new MemoryAdapter({ entity_id: 'owner-123', timezone: 'UTC' });
   stack = await Stack.create(adapter);
 
   await stack.defineType(NOTE_V1, 'Note', {
@@ -169,15 +36,13 @@ describe('Stack.create', () => {
   });
 
   test('ownerEntityId is null if not set in config', async () => {
-    const emptyAdapter = new MockAdapter();
-    emptyAdapter.config.delete('entity_id');
+    const emptyAdapter = new MemoryAdapter();
     const s = await Stack.create(emptyAdapter);
     expect(s.ownerEntityId).toBeNull();
   });
 
   test('timezone defaults to UTC if not set in config', async () => {
-    const emptyAdapter = new MockAdapter();
-    emptyAdapter.config.delete('timezone');
+    const emptyAdapter = new MemoryAdapter();
     const s = await Stack.create(emptyAdapter);
     expect(s.timezone).toBe('UTC');
   });


### PR DESCRIPTION
## Summary
Extracted the in-memory `StackAdapter` implementation from test files into a new public `testing` module, making it available for reuse across projects and test suites.

## Key Changes
- Created new `packages/core/src/testing.ts` module exporting `MemoryAdapter` class
  - Fully functional in-memory implementation of `StackAdapter`
  - Supports offset-based cursor pagination via stringified numeric offsets
  - Maintains insertion order for deterministic query results
  - Includes all required adapter methods (CRUD, versioning, types, associations, attachments)
  
- Updated `packages/core/package.json` to export the testing module
  - Added `./testing` export path pointing to `dist/testing.js`
  
- Refactored test files to use the new public module
  - `packages/core/tests/stack.test.ts`: Replaced inline `MockAdapter` with `MemoryAdapter`
  - `packages/core/tests/scoped-stack.test.ts`: Replaced `PaginatingMockAdapter` with `MemoryAdapter`
  - Simplified test setup by passing initial config to constructor instead of manipulating internal state

## Implementation Details
- `MemoryAdapter` uses a `Map` for record storage and an `order` array to track insertion order, enabling proper cursor-based pagination
- Cursor implementation uses stringified offsets into the insertion-order array
- Supports all filter operations: `includeDeleted`, `typeId` (single or array), and `parentId` (including null checks)
- Attachment methods are stubbed (return dummy values) as they're not needed for most tests
- Import path: `@haverstack/core/testing`

https://claude.ai/code/session_017Li3pMXPotPjf3G3CMuaga