### PR TITLE
Fix cursor pagination to work with non-createdAt sort fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,11 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - run: pnpm run build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/cache@v4
         with:
-          name: dist
           path: packages/*/dist
+          key: dist-${{ github.sha }}
+      - run: pnpm run build
 
   typecheck:
     needs: build
@@ -79,7 +79,9 @@ jobs:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - uses: actions/download-artifact@v4
+      - uses: actions/cache/restore@v4
         with:
-          name: dist
+          path: packages/*/dist
+          key: dist-${{ github.sha }}
+          fail-on-cache-miss: true
       - run: pnpm run typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,28 +6,80 @@ on:
   pull_request:
 
 jobs:
-  ci:
+  format:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: pnpm/action-setup@v4
         with:
           version: 10
-
       - uses: actions/setup-node@v4
         with:
           node-version: 22
           cache: pnpm
-
       - run: pnpm install --frozen-lockfile
+      - run: pnpm run format:check
 
-      - run: pnpm run build
-
-      - run: pnpm run typecheck
-
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
       - run: pnpm run lint
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
       - run: pnpm run test
 
-      - run: pnpm run format:check
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: packages/*/dist
+
+  typecheck:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+      - run: pnpm run typecheck

--- a/packages/adapter-api/package.json
+++ b/packages/adapter-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haverstack/adapter-api",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Remote server adapter for Haverstack",
   "type": "module",
   "exports": {

--- a/packages/adapter-sqlite/package.json
+++ b/packages/adapter-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haverstack/adapter-sqlite",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "SQLite storage adapter for Haverstack",
   "type": "module",
   "exports": {

--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -365,9 +365,11 @@ const buildOrderClause = (query: StackQuery): string => {
 
 const makeCursor = (record: StackRecord, field: SortField): string => {
   const value =
-    field === 'updatedAt' ? toMs(record.updatedAt)
-    : field === 'version' ? record.version
-    : toMs(record.createdAt);
+    field === 'updatedAt'
+      ? toMs(record.updatedAt)
+      : field === 'version'
+        ? record.version
+        : toMs(record.createdAt);
   return Buffer.from(`${field}|${value}|${record.id}`).toString('base64');
 };
 

--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -225,6 +225,13 @@ const rowToVersion = (row: Record<string, unknown>): RecordVersion => {
 // Query building
 // -------------------------------------------------------
 
+type SortField = 'createdAt' | 'updatedAt' | 'version';
+
+const getSortField = (query: StackQuery): SortField => query.sort?.field ?? 'createdAt';
+
+const getSortColumn = (field: SortField): string =>
+  field === 'createdAt' ? 'created_at' : field === 'updatedAt' ? 'updated_at' : 'version';
+
 const buildWhereClause = (query: StackQuery): { sql: string; params: unknown[] } => {
   const conditions: string[] = [];
   const params: unknown[] = [];
@@ -329,13 +336,19 @@ const buildWhereClause = (query: StackQuery): { sql: string; params: unknown[] }
     params.push(f.search);
   }
 
-  // Cursor (created_at + id for stable pagination)
+  // Cursor (sort-field value + id for stable pagination)
   if (query.cursor) {
-    const [cursorTs, cursorId] = Buffer.from(query.cursor, 'base64').toString().split('|');
+    const parts = Buffer.from(query.cursor, 'base64').toString().split('|');
+    // New format: field|value|id (3 parts). Legacy format: value|id (2 parts, implies createdAt).
+    const [cursorField, cursorValue, cursorId] =
+      parts.length === 3
+        ? (parts as [string, string, string])
+        : (['createdAt', parts[0], parts[1]] as [string, string, string]);
+    const col = getSortColumn(cursorField as SortField);
     const sortDir = query.sort?.direction ?? 'desc';
     const op = sortDir === 'asc' ? '>' : '<';
-    conditions.push(`(r.created_at ${op} ? OR (r.created_at = ? AND r.id ${op} ?))`);
-    params.push(Number(cursorTs), Number(cursorTs), cursorId);
+    conditions.push(`(r.${col} ${op} ? OR (r.${col} = ? AND r.id ${op} ?))`);
+    params.push(Number(cursorValue), Number(cursorValue), cursorId);
   }
 
   return {
@@ -345,14 +358,18 @@ const buildWhereClause = (query: StackQuery): { sql: string; params: unknown[] }
 };
 
 const buildOrderClause = (query: StackQuery): string => {
-  const field = query.sort?.field ?? 'created_at';
+  const field = getSortField(query);
   const dir = (query.sort?.direction ?? 'desc').toUpperCase();
-  const col = field === 'createdAt' ? 'created_at' : field === 'updatedAt' ? 'updated_at' : field;
-  return `ORDER BY r.${col} ${dir}, r.id ${dir}`;
+  return `ORDER BY r.${getSortColumn(field)} ${dir}, r.id ${dir}`;
 };
 
-const makeCursor = (record: StackRecord): string =>
-  Buffer.from(`${toMs(record.createdAt)}|${record.id}`).toString('base64');
+const makeCursor = (record: StackRecord, field: SortField): string => {
+  const value =
+    field === 'updatedAt' ? toMs(record.updatedAt)
+    : field === 'version' ? record.version
+    : toMs(record.createdAt);
+  return Buffer.from(`${field}|${value}|${record.id}`).toString('base64');
+};
 
 // -------------------------------------------------------
 // SQLite adapter
@@ -626,7 +643,7 @@ export class SQLiteAdapter implements StackAdapter {
     const total = countRows[0]?.total ?? 0;
 
     const lastRecord = records[records.length - 1];
-    const cursor = hasMore && lastRecord ? makeCursor(lastRecord) : null;
+    const cursor = hasMore && lastRecord ? makeCursor(lastRecord, getSortField(query)) : null;
 
     return { records, cursor, total };
   }

--- a/packages/adapter-sqlite/tests/sqlite.test.ts
+++ b/packages/adapter-sqlite/tests/sqlite.test.ts
@@ -560,6 +560,78 @@ describe('records — queries', () => {
     expect([...page1Ids].filter((id) => page2Ids.has(id)).length).toBe(0);
   });
 
+  test('cursor pagination works correctly when sorted by updatedAt', async () => {
+    const adapter = await initAdapter();
+    // createdAt and updatedAt are in opposite order so a cursor keyed on the
+    // wrong field would return the wrong page.
+    // updatedAt asc order: r5(1000), r4(2000), r3(3000), r2(4000), r1(5000)
+    // createdAt asc order: r1(1000), r2(2000), r3(3000), r4(4000), r5(5000)
+    for (let i = 1; i <= 5; i++) {
+      await adapter.createRecord(
+        makeRecord({
+          id: `r${i}`,
+          createdAt: new Date(i * 1000),
+          updatedAt: new Date((6 - i) * 1000),
+        }),
+      );
+    }
+
+    const page1 = await adapter.queryRecords({
+      sort: { field: 'updatedAt', direction: 'asc' },
+      limit: 3,
+    });
+    expect(page1.records.length).toBe(3);
+    expect(page1.cursor).not.toBeNull();
+
+    const page2 = await adapter.queryRecords({
+      sort: { field: 'updatedAt', direction: 'asc' },
+      limit: 3,
+      cursor: page1.cursor!,
+    });
+    expect(page2.records.length).toBe(2);
+    expect(page2.cursor).toBeNull();
+
+    // Together they must cover all 5 records with no overlap or gap.
+    const allIds = new Set([...page1.records, ...page2.records].map((r) => r.id));
+    expect(allIds.size).toBe(5);
+  });
+
+  test('cursor pagination works correctly when sorted by version', async () => {
+    const adapter = await initAdapter();
+    // version and createdAt are in opposite order so a cursor keyed on the
+    // wrong field would return the wrong page.
+    // version asc order: r5(v1), r4(v2), r3(v3), r2(v4), r1(v5)
+    // createdAt asc order: r1, r2, r3, r4, r5
+    for (let i = 1; i <= 5; i++) {
+      await adapter.createRecord(
+        makeRecord({
+          id: `r${i}`,
+          createdAt: new Date(i * 1000),
+          version: 6 - i,
+        }),
+      );
+    }
+
+    const page1 = await adapter.queryRecords({
+      sort: { field: 'version', direction: 'asc' },
+      limit: 3,
+    });
+    expect(page1.records.length).toBe(3);
+    expect(page1.cursor).not.toBeNull();
+
+    const page2 = await adapter.queryRecords({
+      sort: { field: 'version', direction: 'asc' },
+      limit: 3,
+      cursor: page1.cursor!,
+    });
+    expect(page2.records.length).toBe(2);
+    expect(page2.cursor).toBeNull();
+
+    // Together they must cover all 5 records with no overlap or gap.
+    const allIds = new Set([...page1.records, ...page2.records].map((r) => r.id));
+    expect(allIds.size).toBe(5);
+  });
+
   test('sort by createdAt descending (default)', async () => {
     const adapter = await initAdapter();
     await adapter.createRecord(makeRecord({ id: 'r1', createdAt: new Date(1000) }));

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@haverstack/core",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Core library for Haverstack — portable personal data stack",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## Summary
This PR fixes cursor-based pagination in the SQLite adapter to correctly handle sorting by fields other than `createdAt` (specifically `updatedAt` and `version`). Previously, cursors were always keyed on the `createdAt` field regardless of the sort field specified in the query, causing incorrect pagination results.

## Key Changes
- **Cursor format update**: Changed cursor encoding from `value|id` to `field|value|id` to track which field the cursor is based on. Maintains backward compatibility by treating 2-part cursors as legacy `createdAt` cursors.
- **Dynamic sort field handling**: Introduced `getSortField()` and `getSortColumn()` helper functions to consistently map between sort field names and database column names across the codebase.
- **Cursor generation fix**: Updated `makeCursor()` to accept a `SortField` parameter and encode the appropriate field value (createdAt timestamp, updatedAt timestamp, or version number) based on the sort field.
- **Cursor parsing fix**: Updated cursor parsing logic in `buildWhereClause()` to extract and use the field information from the cursor, enabling correct comparison operators and column references.
- **Test coverage**: Added two new test cases to verify cursor pagination works correctly when sorting by `updatedAt` and `version` fields, with records intentionally ordered differently by these fields to catch regressions.
- **CI/CD refactor**: Reorganized GitHub Actions workflow to split the monolithic job into separate focused jobs (format, lint, test, build, typecheck) for better clarity and parallelization.
- **Version bump**: Updated all package versions from 0.1.0 to 0.2.0.

## Implementation Details
The fix ensures that when a query specifies a sort field, the cursor is generated using that field's value rather than always using `createdAt`. The cursor now includes the field name itself, allowing the pagination logic to correctly reconstruct the WHERE clause conditions using the appropriate database column and comparison operators.

https://claude.ai/code/session_01UDDai4QezaSvsVVuqTxbkB