### PR TITLE
fix: address security audit findings (issue #30)

### DIFF
--- a/packages/adapter-api/src/index.ts
+++ b/packages/adapter-api/src/index.ts
@@ -278,7 +278,9 @@ export class APIAdapter implements StackAdapter {
     const url = `${this.baseUrl}${path}`;
     const headers: Record<string, string> = { 'Content-Type': mimeType };
     if (this.token) headers['Authorization'] = `Bearer ${this.token}`;
-    if (filename) headers['Content-Disposition'] = `attachment; filename*=UTF-8''${encodeURIComponent(filename)}`;
+    if (filename)
+      headers['Content-Disposition'] =
+        `attachment; filename*=UTF-8''${encodeURIComponent(filename)}`;
 
     let res: Response;
     try {

--- a/packages/adapter-api/src/index.ts
+++ b/packages/adapter-api/src/index.ts
@@ -278,7 +278,7 @@ export class APIAdapter implements StackAdapter {
     const url = `${this.baseUrl}${path}`;
     const headers: Record<string, string> = { 'Content-Type': mimeType };
     if (this.token) headers['Authorization'] = `Bearer ${this.token}`;
-    if (filename) headers['Content-Disposition'] = `attachment; filename="${filename}"`;
+    if (filename) headers['Content-Disposition'] = `attachment; filename*=UTF-8''${encodeURIComponent(filename)}`;
 
     let res: Response;
     try {

--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -229,6 +229,66 @@ const rowToVersion = (row: Record<string, unknown>): RecordVersion => {
 };
 
 // -------------------------------------------------------
+// FTS4 query sanitization
+// -------------------------------------------------------
+
+/**
+ * Sanitizes user input for safe use in an FTS4 MATCH clause.
+ *
+ * FTS4's query language supports operators (AND/OR/NOT, phrases, NEAR, wildcards)
+ * that can be expensive or cause parse errors with untrusted input.
+ * This function removes the dangerous operators while preserving useful ones:
+ *   kept:    AND/OR/NOT (with a left operand), phrase queries ("…"), implicit AND
+ *   removed: wildcards (*), NEAR/N, bare NOT (no left operand)
+ *   capped:  parenthesis nesting depth (default: 2)
+ *
+ * A query timeout is not implementable here: sql.js runs SQLite as synchronous
+ * WASM that blocks the JS event loop, and db.interrupt() is not exposed. Moving
+ * sql.js into a Worker thread would enable a timeout via interrupt() but is out
+ * of scope for this change.
+ */
+const sanitizeFts4Query = (query: string, maxDepth = 2): string => {
+  if (!query) return '';
+
+  // Remove wildcards
+  let clean = query.replace(/\*/g, '');
+
+  // Remove NEAR operator (handles NEAR and NEAR/N variants)
+  clean = clean.replace(/\bNEAR(?:\/\d+)?\b/gi, '');
+
+  // Strip bare NOT with no left operand — FTS4 requires "term NOT term", not "NOT term"
+  clean = clean.replace(/(?:^|\(\s*)NOT\s+/gi, (m) => m.replace(/NOT\s+/i, ''));
+
+  // Enforce max nesting depth; replace excess ( with a space and discard unmatched )
+  let currentDepth = 0;
+  let result = '';
+  for (const char of clean) {
+    if (char === '(') {
+      if (currentDepth < maxDepth) { currentDepth++; result += char; }
+      else result += ' ';
+    } else if (char === ')') {
+      if (currentDepth > 0) { currentDepth--; result += char; }
+      else result += ' ';
+    } else {
+      result += char;
+    }
+  }
+
+  // Auto-close any unclosed parens
+  if (currentDepth > 0) result += ')'.repeat(currentDepth);
+
+  // Iteratively remove empty paren pairs left behind by NEAR/NOT stripping
+  let prev: string;
+  do { prev = result; result = result.replace(/\(\s*\)/g, ' '); } while (result !== prev);
+
+  return result
+    .replace(/\s+/g, ' ')
+    .replace(/\(\s+/g, '(')
+    .replace(/\s+\)/g, ')')
+    .trim();
+};
+
+// -------------------------------------------------------
 // Query building
 // -------------------------------------------------------
 
@@ -337,10 +397,12 @@ const buildWhereClause = (query: StackQuery): { sql: string; params: unknown[] }
     }
   }
 
-  // Full-text search — wrap in double-quotes for literal matching to prevent FTS operator injection
   if (f.search) {
-    conditions.push(`r.rowid IN (SELECT rowid FROM records_fts WHERE records_fts MATCH ?)`);
-    params.push(`"${f.search.replace(/"/g, '""')}"`);
+    const sanitized = sanitizeFts4Query(f.search);
+    if (sanitized) {
+      conditions.push(`r.rowid IN (SELECT rowid FROM records_fts WHERE records_fts MATCH ?)`);
+      params.push(sanitized);
+    }
   }
 
   // Cursor (sort-field value + id for stable pagination)

--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -148,6 +148,18 @@ const SCHEMA_SQL = `
 `;
 
 // -------------------------------------------------------
+// Helpers
+// -------------------------------------------------------
+
+const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
+
+const assertFileId = (fileId: string): void => {
+  if (!SHA256_HEX_RE.test(fileId)) {
+    throw new Error(`Invalid fileId: expected 64-character lowercase hex string`);
+  }
+};
+
+// -------------------------------------------------------
 // Row <-> domain object mapping
 // -------------------------------------------------------
 
@@ -325,10 +337,10 @@ const buildWhereClause = (query: StackQuery): { sql: string; params: unknown[] }
     }
   }
 
-  // Full-text search
+  // Full-text search — wrap in double-quotes for literal matching to prevent FTS operator injection
   if (f.search) {
     conditions.push(`r.rowid IN (SELECT rowid FROM records_fts WHERE records_fts MATCH ?)`);
-    params.push(f.search);
+    params.push(`"${f.search.replace(/"/g, '""')}"`);
   }
 
   // Cursor (sort-field value + id for stable pagination)
@@ -339,11 +351,19 @@ const buildWhereClause = (query: StackQuery): { sql: string; params: unknown[] }
       parts.length === 3
         ? (parts as [string, string, string])
         : (['createdAt', parts[0], parts[1]] as [string, string, string]);
+    const validSortFields: SortField[] = ['createdAt', 'updatedAt', 'version'];
+    if (!validSortFields.includes(cursorField as SortField)) {
+      throw new Error(`Invalid cursor: unknown sort field "${cursorField}"`);
+    }
+    const numericValue = Number(cursorValue);
+    if (!isFinite(numericValue)) {
+      throw new Error(`Invalid cursor: non-numeric sort value`);
+    }
     const col = getSortColumn(cursorField as SortField);
     const sortDir = query.sort?.direction ?? 'desc';
     const op = sortDir === 'asc' ? '>' : '<';
     conditions.push(`(r.${col} ${op} ? OR (r.${col} = ? AND r.id ${op} ?))`);
-    params.push(Number(cursorValue), Number(cursorValue), cursorId);
+    params.push(numericValue, numericValue, cursorId);
   }
 
   return {
@@ -736,6 +756,7 @@ export class SQLiteAdapter implements StackAdapter {
   }
 
   async getAttachment(fileId: string): Promise<Uint8Array> {
+    assertFileId(fileId);
     const exists = this.execQuery<Record<string, unknown>>(
       'SELECT 1 FROM attachments WHERE file_id = ?',
       [fileId],
@@ -745,6 +766,7 @@ export class SQLiteAdapter implements StackAdapter {
   }
 
   async deleteAttachment(fileId: string): Promise<void> {
+    assertFileId(fileId);
     this.db.run('DELETE FROM attachments WHERE file_id = ?', [fileId]);
     this.persist();
     try {

--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -264,11 +264,15 @@ const sanitizeFts4Query = (query: string, maxDepth = 2): string => {
   let result = '';
   for (const char of clean) {
     if (char === '(') {
-      if (currentDepth < maxDepth) { currentDepth++; result += char; }
-      else result += ' ';
+      if (currentDepth < maxDepth) {
+        currentDepth++;
+        result += char;
+      } else result += ' ';
     } else if (char === ')') {
-      if (currentDepth > 0) { currentDepth--; result += char; }
-      else result += ' ';
+      if (currentDepth > 0) {
+        currentDepth--;
+        result += char;
+      } else result += ' ';
     } else {
       result += char;
     }
@@ -279,13 +283,12 @@ const sanitizeFts4Query = (query: string, maxDepth = 2): string => {
 
   // Iteratively remove empty paren pairs left behind by NEAR/NOT stripping
   let prev: string;
-  do { prev = result; result = result.replace(/\(\s*\)/g, ' '); } while (result !== prev);
+  do {
+    prev = result;
+    result = result.replace(/\(\s*\)/g, ' ');
+  } while (result !== prev);
 
-  return result
-    .replace(/\s+/g, ' ')
-    .replace(/\(\s+/g, '(')
-    .replace(/\s+\)/g, ')')
-    .trim();
+  return result.replace(/\s+/g, ' ').replace(/\(\s+/g, '(').replace(/\s+\)/g, ')').trim();
 };
 
 // -------------------------------------------------------

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -256,8 +256,13 @@ export class Stack implements StackClient {
 
     const fns: MigrationFn[] = [];
     let current = fromId;
+    const visited = new Set<TypeId>();
 
     while (current !== toId) {
+      if (visited.has(current)) {
+        throw new StackMigrationError(`Migration cycle detected at "${current}"`);
+      }
+      visited.add(current);
       const migration = this.migrations.get(current);
       if (!migration) return null;
       fns.push(migration.migrate);
@@ -273,7 +278,12 @@ export class Stack implements StackClient {
    */
   private latestTypeId(fromId: TypeId): TypeId {
     let current = fromId;
+    const visited = new Set<TypeId>();
     while (this.migrations.has(current)) {
+      if (visited.has(current)) {
+        throw new StackMigrationError(`Migration cycle detected at "${current}"`);
+      }
+      visited.add(current);
       current = this.migrations.get(current)!.to;
     }
     return current;
@@ -848,6 +858,8 @@ export class ScopedStack implements StackClient {
   async query(query: StackQuery = {}): Promise<QueryResult> {
     const limit = query.limit ?? DEFAULT_QUERY_LIMIT;
     const records: StackRecord[] = [];
+    const maxFetched = limit * 10;
+    let totalFetched = 0;
 
     const prefetchedGrants = this.requesterEntityId
       ? (await this.stack.query({ filter: { typeId: `${SYSTEM_TYPES.GRANT}@1` } })).records
@@ -856,10 +868,11 @@ export class ScopedStack implements StackClient {
     let page: QueryResult = { records: [], cursor: query.cursor ?? null, total: null };
     do {
       page = await this.stack.query({ ...query, cursor: page.cursor ?? undefined });
+      totalFetched += page.records.length;
       for (const record of page.records) {
         if (await this.canRead(record, prefetchedGrants)) records.push(record);
       }
-    } while (records.length < limit && page.cursor);
+    } while (records.length < limit && page.cursor && totalFetched < maxFetched);
 
     return { records, cursor: page.cursor, total: null };
   }

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -10,6 +10,8 @@
 
 import type { TypeSchema, FieldDef, ScalarFieldKind } from './types.js';
 
+const MAX_VALIDATION_DEPTH = 32;
+
 // -------------------------------------------------------
 // Validation errors
 // -------------------------------------------------------
@@ -43,13 +45,19 @@ const validateField = (
   def: FieldDef,
   path: string,
   errors: ValidationError[],
+  depth = 0,
 ): void => {
+  if (depth > MAX_VALIDATION_DEPTH) {
+    errors.push({ path, message: `Schema nesting exceeds maximum depth of ${MAX_VALIDATION_DEPTH}` });
+    return;
+  }
+
   if (def.kind === 'array') {
     if (!Array.isArray(value)) {
       errors.push({ path, message: `Expected array, got ${typeof value}` });
       return;
     }
-    value.forEach((item, i) => validateField(item, def.items, `${path}[${i}]`, errors));
+    value.forEach((item, i) => validateField(item, def.items, `${path}[${i}]`, errors, depth + 1));
     return;
   }
 
@@ -58,7 +66,7 @@ const validateField = (
       errors.push({ path, message: `Expected object, got ${typeof value}` });
       return;
     }
-    validateContent(value as Record<string, unknown>, def.properties, path, errors);
+    validateContent(value as Record<string, unknown>, def.properties, path, errors, depth + 1);
     return;
   }
 
@@ -98,7 +106,13 @@ export const validateContent = (
   schema: TypeSchema,
   prefix = '',
   errors: ValidationError[] = [],
+  depth = 0,
 ): ValidationError[] => {
+  if (depth > MAX_VALIDATION_DEPTH) {
+    errors.push({ path: prefix || '(root)', message: `Schema nesting exceeds maximum depth of ${MAX_VALIDATION_DEPTH}` });
+    return errors;
+  }
+
   // Check all schema fields
   for (const [key, def] of Object.entries(schema)) {
     const path = prefix ? `${prefix}.${key}` : key;
@@ -111,7 +125,7 @@ export const validateContent = (
       continue;
     }
 
-    validateField(value, def, path, errors);
+    validateField(value, def, path, errors, depth);
   }
 
   return errors;

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -48,7 +48,10 @@ const validateField = (
   depth = 0,
 ): void => {
   if (depth > MAX_VALIDATION_DEPTH) {
-    errors.push({ path, message: `Schema nesting exceeds maximum depth of ${MAX_VALIDATION_DEPTH}` });
+    errors.push({
+      path,
+      message: `Schema nesting exceeds maximum depth of ${MAX_VALIDATION_DEPTH}`,
+    });
     return;
   }
 
@@ -109,7 +112,10 @@ export const validateContent = (
   depth = 0,
 ): ValidationError[] => {
   if (depth > MAX_VALIDATION_DEPTH) {
-    errors.push({ path: prefix || '(root)', message: `Schema nesting exceeds maximum depth of ${MAX_VALIDATION_DEPTH}` });
+    errors.push({
+      path: prefix || '(root)',
+      message: `Schema nesting exceeds maximum depth of ${MAX_VALIDATION_DEPTH}`,
+    });
     return errors;
   }
 


### PR DESCRIPTION
## Summary

Addresses all code-fix findings from the security audit in #30. Documentation-only items (error message exposure, rate limiting guidance) are out of scope for this PR.

- **FTS injection/DoS** (`adapter-sqlite`): Replaced literal-quoting with a proper `sanitizeFts4Query()` function that strips wildcards (`*`) and NEAR operators, caps parenthesis nesting depth at 2, strips bare `NOT` (which causes a FTS4 parse error without a left operand), and iteratively removes empty paren pairs. Preserves AND/OR/NOT-with-operand and phrase queries, which are all bounded in cost.
- **Content-Disposition injection** (`adapter-api`): Switched from `filename="…"` to RFC 5987 `filename*=UTF-8''<percent-encoded>`, so filenames containing `"` or `;` cannot break out of the header value.
- **Migration cycle → infinite loop** (`core/stack`): Both `resolveMigrationPath` and `latestTypeId` now track visited nodes in a `Set` and throw `StackMigrationError` on a repeated visit.
- **Cursor validation** (`adapter-sqlite`): `cursorField` is validated against the known `SortField` values and `cursorValue` must parse to a finite number; invalid cursors throw instead of silently producing `NaN` in SQL.
- **Unbounded pagination loop** (`core/stack`): `ScopedStack.query()` now caps the refill loop at `limit × 10` total fetched records.
- **Validation recursion depth** (`core/validate`): A `depth` counter is threaded through `validateField` and `validateContent`; nesting beyond 32 levels produces a validation error instead of a stack overflow.
- **fileId path assertion** (`adapter-sqlite`): `assertFileId()` (validates `/^[0-9a-f]{64}$/`) is called in `getAttachment` and `deleteAttachment` as defense-in-depth against path traversal if fileId generation ever changes.

## Notes on FTS query timeout

A query timeout was considered as additional defense-in-depth for the FTS case. It isn't implementable within the current architecture: sql.js runs SQLite as synchronous WASM that blocks the JS event loop, and `db.interrupt()` is not exposed by the library. A real timeout would require moving sql.js into a Worker thread. This is noted in a comment in `sanitizeFts4Query`.

## Test plan

- [ ] `npm test` passes (308 tests across all packages)
- [ ] `npm run lint` passes
- [ ] `npm run format` produces no changes

---
_Generated by [Claude Code](https://claude.ai/code/session_011A56DL7cPWPDqYJZdseHXA)_