### PR TITLE
fix: throw in Stack.create() if adapter has no entity_id

### DIFF
--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -135,7 +135,7 @@ export class Stack implements StackClient {
 
   private constructor(
     private readonly adapter: StackAdapter,
-    readonly ownerEntityId: string | null,
+    readonly ownerEntityId: string,
     readonly timezone: string,
   ) {}
 
@@ -146,6 +146,12 @@ export class Stack implements StackClient {
    */
   static async create(adapter: StackAdapter): Promise<Stack> {
     const entityId = await adapter.getConfig('entity_id');
+    if (!entityId) {
+      throw new Error(
+        'Stack misconfiguration: adapter has no entity_id. ' +
+          'Initialise the adapter with an entityId before calling Stack.create().',
+      );
+    }
     const timezone = (await adapter.getConfig('timezone')) ?? 'UTC';
     const stack = new Stack(adapter, entityId, timezone);
     await stack.seedSystemTypes();

--- a/packages/core/tests/stack.test.ts
+++ b/packages/core/tests/stack.test.ts
@@ -35,15 +35,17 @@ describe('Stack.create', () => {
     expect(stack.timezone).toBe('UTC');
   });
 
-  test('ownerEntityId is null if not set in config', async () => {
+  test('throws if adapter has no entity_id', async () => {
     const emptyAdapter = new MemoryAdapter();
-    const s = await Stack.create(emptyAdapter);
-    expect(s.ownerEntityId).toBeNull();
+    await expect(Stack.create(emptyAdapter)).rejects.toThrow(
+      'Stack misconfiguration: adapter has no entity_id',
+    );
   });
 
   test('timezone defaults to UTC if not set in config', async () => {
-    const emptyAdapter = new MemoryAdapter();
-    const s = await Stack.create(emptyAdapter);
+    const adapterWithEntity = new MemoryAdapter();
+    await adapterWithEntity.setConfig('entity_id', 'entity-without-timezone');
+    const s = await Stack.create(adapterWithEntity);
     expect(s.timezone).toBe('UTC');
   });
 });


### PR DESCRIPTION
## Summary

- `Stack.create()` now throws a descriptive error if the adapter has no `entity_id` configured, rather than silently returning a stack with `ownerEntityId: null`
- `Stack.ownerEntityId` narrowed from `string | null` to `string`, reflecting the invariant that has always been required
- Updated the `ownerEntityId is null` test to instead assert that `Stack.create()` rejects with a clear message
- Added a proper entity adapter fixture to the `timezone defaults to UTC` test (which previously relied on the same empty-adapter path that now throws)

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2tdGyLhqTN2baMpaWDet3

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2tdGyLhqTN2baMpaWDet3)_