### PR TITLE
fix: restrict setPermissions to record creator or stack owner

### DIFF
--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -899,7 +899,13 @@ export class ScopedStack implements StackClient {
   }
 
   async setPermissions(id: string, permissions: Permission[]): Promise<void> {
-    await this.requireUpdatable(id);
+    const record = await this.stack.get(id, { migrate: false });
+    if (!record) throw new StackNotFoundError(`Record not found: "${id}"`);
+
+    const isOwner = this.requesterEntityId === this.stack.ownerEntityId;
+    const isCreator = this.requesterEntityId === record.entityId;
+    if (!isOwner && !isCreator) throw new StackPermissionError();
+
     return this.stack.setPermissions(id, permissions);
   }
 

--- a/packages/core/tests/scoped-stack.test.ts
+++ b/packages/core/tests/scoped-stack.test.ts
@@ -184,6 +184,22 @@ describe('ScopedStack — write access', () => {
     expect((await adapter.getRecord(record.id))?.associations).toContainEqual(tag);
   });
 
+  test('setPermissions rejects write-access holder that is not creator or stack owner', async () => {
+    const record = await adapter.createRecord(
+      makeRecord({
+        entityId: OWNER,
+        permissions: [{ access: 'entity', entityId: MEMBER, read: true, write: true }],
+      }),
+    );
+    const perms: Permission[] = [{ access: 'public' }];
+    await expect(stack.asEntity(MEMBER).setPermissions(record.id, perms)).rejects.toThrow(
+      StackPermissionError,
+    );
+    // Stack owner and record creator can still manage permissions.
+    await stack.asEntity(OWNER).setPermissions(record.id, perms);
+    expect((await adapter.getRecord(record.id))?.permissions).toEqual(perms);
+  });
+
   test('write methods throw StackNotFoundError (not StackPermissionError) for a missing record', async () => {
     await expect(stack.asEntity(OWNER).update('nonexistent', {})).rejects.toThrow(
       StackNotFoundError,


### PR DESCRIPTION
## Summary

`ScopedStack.setPermissions()` previously delegated to `requireUpdatable()`, meaning any entity with write access could manage permissions on a record. This allowed privilege escalation: a write-access holder could make a private record public, grant third parties access, or revoke the owner's visibility.

The fix checks that the requester is either the stack owner or the record's creator before proceeding. Write-only access alone is no longer sufficient to mutate permissions.

A new test asserts that a write-access holder who is neither creator nor stack owner is rejected with `StackPermissionError`, while the stack owner can still manage permissions freely.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2tdGyLhqTN2baMpaWDet3

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2tdGyLhqTN2baMpaWDet3)_