### PR TITLE
fix: clamp query limit to MAX_QUERY_LIMIT (1000) in Stack and ScopedStack

### DIFF
--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -532,7 +532,8 @@ export class Stack implements StackClient {
    * Query records. See StackQuery for filter, sort, and pagination options.
    */
   async query(query: StackQuery = {}): Promise<QueryResult> {
-    return this.adapter.queryRecords(query);
+    const limit = query.limit !== undefined ? Math.min(query.limit, MAX_QUERY_LIMIT) : undefined;
+    return this.adapter.queryRecords(limit !== undefined ? { ...query, limit } : query);
   }
 
   // -------------------------------------------------------
@@ -704,6 +705,7 @@ export class Stack implements StackClient {
 
 /** Default page size used to fill a permission-filtered query result. */
 const DEFAULT_QUERY_LIMIT = 50;
+const MAX_QUERY_LIMIT = 1000;
 
 /**
  * A permission-enforcing view of a Stack for a single requester. Obtained
@@ -862,7 +864,7 @@ export class ScopedStack implements StackClient {
    * grants don't trigger a separate _grant@1 query per record.
    */
   async query(query: StackQuery = {}): Promise<QueryResult> {
-    const limit = query.limit ?? DEFAULT_QUERY_LIMIT;
+    const limit = Math.min(query.limit ?? DEFAULT_QUERY_LIMIT, MAX_QUERY_LIMIT);
     const records: StackRecord[] = [];
     const maxFetched = limit * 10;
     let totalFetched = 0;

--- a/packages/core/tests/scoped-stack.test.ts
+++ b/packages/core/tests/scoped-stack.test.ts
@@ -293,6 +293,14 @@ describe('ScopedStack.query', () => {
     expect(result.records).toHaveLength(3);
     expect(result.cursor).toBeNull();
   });
+
+  test('clamps an oversized limit to MAX_QUERY_LIMIT (1000)', async () => {
+    await adapter.createRecord(makeRecord({ permissions: [{ access: 'public' }] }));
+    const result = await stack.asEntity(null).query({ limit: 9_999_999 });
+    // The limit is silently clamped — no error thrown, results still returned.
+    expect(result.records.length).toBeGreaterThanOrEqual(0);
+    expect(result.records.length).toBeLessThanOrEqual(1000);
+  });
 });
 
 // -------------------------------------------------------


### PR DESCRIPTION
## Summary

`ScopedStack.query()` had a `maxFetched` safety cap on total adapter fetches but never clamped the `limit` value itself. `Stack.query()` had no guard at all. An arbitrarily large limit (e.g. `limit: 9_999_999`) would be passed straight through to the adapter, potentially loading an enormous result set into memory.

Both paths now clamp the limit to `MAX_QUERY_LIMIT = 1000` (defined alongside `DEFAULT_QUERY_LIMIT`). The clamp is silent — no error is thrown, the query just returns at most 1000 records.

Added a test confirming that an oversized limit is accepted without error and results stay within the cap.

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2tdGyLhqTN2baMpaWDet3

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2tdGyLhqTN2baMpaWDet3)_