### PR TITLE
Add @haverstack/wire-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "format:check": "prettier --check .",
     "publish:core": "pnpm --filter @haverstack/core publish --access public",
     "publish:sqlite": "pnpm --filter @haverstack/adapter-sqlite publish --access public",
-    "publish:api": "pnpm --filter @haverstack/adapter-api publish --access public"
+    "publish:api": "pnpm --filter @haverstack/adapter-api publish --access public",
+    "publish:wire-types": "pnpm --filter @haverstack/wire-types publish --access public"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/packages/wire-types/README.md
+++ b/packages/wire-types/README.md
@@ -1,0 +1,50 @@
+# @haverstack/wire-types
+
+HTTP wire types and serialization utilities for the Haverstack API.
+
+This package defines the JSON-safe representations of Haverstack's core domain types — `Date` fields become ISO strings — and provides functions to serialize domain objects into that format and parse dates back out. It is the shared contract between `haverstack/server` (which serializes responses) and `@haverstack/adapter-api` (which parses them).
+
+> **Status:** Early development. APIs are unstable.
+
+## Installation
+
+```sh
+npm install @haverstack/wire-types
+```
+
+## Wire types
+
+Each wire type mirrors a domain type from `@haverstack/core` with `Date` fields replaced by ISO 8601 strings.
+
+| Wire type | Domain type |
+|-----------|-------------|
+| `WireRecord` | `StackRecord` |
+| `WireType` | `StackType` |
+| `WireVersion` | `RecordVersion` |
+
+## Serialization
+
+```ts
+import {
+  serializeRecord,
+  serializeType,
+  serializeVersion,
+  parseDate,
+} from '@haverstack/wire-types';
+
+// Server side — convert domain objects before sending as JSON
+const body = JSON.stringify(serializeRecord(record));
+
+// Client side — convert ISO strings back to Dates after parsing JSON
+const createdAt = parseDate(raw.createdAt); // Date | undefined
+```
+
+`parseDate` accepts `unknown` and returns `undefined` for missing or unparseable values, making it safe to use directly on unvalidated response fields.
+
+## License
+
+[CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/) — public domain.
+
+## Monorepo
+
+Part of [haverstack/core](https://github.com/haverstack/core).

--- a/packages/wire-types/package.json
+++ b/packages/wire-types/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@haverstack/wire-types",
+  "version": "0.5.0",
+  "description": "HTTP wire types and serialization for Haverstack",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prepublishOnly": "pnpm run build",
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src"
+  },
+  "dependencies": {
+    "@haverstack/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/packages/wire-types/src/index.ts
+++ b/packages/wire-types/src/index.ts
@@ -1,0 +1,89 @@
+import type {
+  StackRecord,
+  StackType,
+  RecordVersion,
+  Association,
+  Permission,
+} from '@haverstack/core';
+
+export type WireRecord = {
+  id: string;
+  typeId: string;
+  createdAt: string;
+  updatedAt: string;
+  content: Record<string, unknown>;
+  version: number;
+  parentId?: string;
+  entityId?: string;
+  appId?: string;
+  deletedAt?: string;
+  permissions?: Permission[];
+  associations?: Association[];
+};
+
+export type WireType = {
+  id: string;
+  baseId: string;
+  version: number;
+  name: string;
+  schema: Record<string, unknown>;
+  schemaHash: string;
+  migratesFrom?: string;
+  createdAt: string;
+};
+
+export type WireVersion = {
+  version: number;
+  content: Record<string, unknown>;
+  updatedAt: string;
+  entityId?: string;
+};
+
+export function serializeRecord(r: StackRecord): WireRecord {
+  const w: WireRecord = {
+    id: r.id,
+    typeId: r.typeId,
+    createdAt: r.createdAt.toISOString(),
+    updatedAt: r.updatedAt.toISOString(),
+    content: r.content,
+    version: r.version,
+  };
+  if (r.parentId !== undefined) w.parentId = r.parentId;
+  if (r.entityId !== undefined) w.entityId = r.entityId;
+  if (r.appId !== undefined) w.appId = r.appId;
+  if (r.deletedAt !== undefined) w.deletedAt = r.deletedAt.toISOString();
+  if (r.permissions !== undefined) w.permissions = r.permissions;
+  if (r.associations !== undefined) w.associations = r.associations;
+  return w;
+}
+
+export function serializeType(t: StackType): WireType {
+  const w: WireType = {
+    id: t.id,
+    baseId: t.baseId,
+    version: t.version,
+    name: t.name,
+    schema: t.schema as Record<string, unknown>,
+    schemaHash: t.schemaHash,
+    createdAt: t.createdAt.toISOString(),
+  };
+  if (t.migratesFrom !== undefined) w.migratesFrom = t.migratesFrom;
+  return w;
+}
+
+export function serializeVersion(v: RecordVersion): WireVersion {
+  const w: WireVersion = {
+    version: v.version,
+    content: v.content,
+    updatedAt: v.updatedAt.toISOString(),
+  };
+  if (v.entityId !== undefined) w.entityId = v.entityId;
+  return w;
+}
+
+/** Parse an ISO date string from a wire body, returns undefined if absent or invalid. */
+export function parseDate(val: unknown): Date | undefined {
+  if (typeof val !== 'string') return undefined;
+  const d = new Date(val);
+  return isNaN(d.getTime()) ? undefined : d;
+}

--- a/packages/wire-types/tsconfig.build.json
+++ b/packages/wire-types/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "noEmit": false
+  }
+}

--- a/packages/wire-types/tsconfig.json
+++ b/packages/wire-types/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,19 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@22.19.17)
 
+  packages/wire-types:
+    dependencies:
+      '@haverstack/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+
 packages:
 
   '@esbuild/aix-ppc64@0.21.5':


### PR DESCRIPTION
## Summary

- Adds a new `@haverstack/wire-types` package to the monorepo
- Defines `WireRecord`, `WireType`, and `WireVersion` — JSON-safe versions of the core domain types with `Date` fields as ISO strings
- Exports `serializeRecord`, `serializeType`, `serializeVersion`, and `parseDate` utilities
- Depends only on `@haverstack/core`; picked up automatically by the existing `packages/*` workspace glob

## Motivation

The wire format for the Haverstack HTTP API was previously defined implicitly: `haverstack/server` owned the types and serialization functions in `src/lib/serialize.ts`, while `adapter-api` had matching parsing logic with no formal type contract between them. This package makes that contract explicit and shared, so neither repo owns it and drift becomes a compile error rather than a runtime surprise.

## Follow-up

Once this is published, `haverstack/server` can replace its `src/lib/serialize.ts` with imports from `@haverstack/wire-types`, and `adapter-api` can import the wire types directly instead of relying on implicit shapes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCyNoPE5sGw6CvfrJJk9Hr)_