### PR TITLE
docs: Add Schema Commons — namespace policy, governance, first four shared types

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ packages/
 
 The design spec lives in [`docs/spec.md`](./docs/spec.md). It covers the full data model, adapter contract, wire format, and open questions. If you're building an adapter or a server implementation, start there.
 
+Shared, app-neutral record types (note, bookmark, task, contact) live in the [Schema Commons](./docs/commons/README.md) — start there if you want your app's data to interoperate with other Haverstack apps.
+
 ---
 
 ## Related

--- a/docs/commons/README.md
+++ b/docs/commons/README.md
@@ -135,6 +135,13 @@ authority on **any** record, of any type:
   that are occurrences of one recurring thing (materialized [`event`](./event.md)
   occurrences are the motivating case). Reserved now so recurrence proposals build on
   it rather than around it.
+- **`author`** — `{ kind: 'relationship', label: 'author', recordId: <contact> }`
+  attributes any record to a person the stack knows, pointing at a
+  [`contact`](./contact.md) (or `_entity`) record. Complements, never replaces, a
+  displayed-byline string like `article.author`: the string is what the work says
+  about itself (a property, faithful to the work as published); the association is
+  what _you_ know about the world. Multiple `author` associations express
+  co-authorship. Prior art: ActivityStreams `attributedTo`.
 
 Cross-type conventions are governed like fields: proposing one is proposing it for
 every record in every stack, so the bar is correspondingly higher.

--- a/docs/commons/README.md
+++ b/docs/commons/README.md
@@ -186,6 +186,11 @@ make the interop story demonstrable: notes ↔ flashcards, bookmarks ↔ read-la
 articles and pages ↔ any site generator, polls ↔ calendar (a scheduling poll's winning
 slot becomes an event).
 
+Three types carry free-form text and are distinguished by **social contract, not
+shape** — notes are kept, messages are sent, articles are published.
+[Choosing a text type](./text-types.md) is the decision guide, with worked examples
+(comments on a blog post are messages; private marginalia are notes).
+
 | Type                        | File                           | Status   | Read-compat core          |
 | --------------------------- | ------------------------------ | -------- | ------------------------- |
 | `org.haverstack/note@1`     | [`note.md`](./note.md)         | Draft    | `{ text }`                |

--- a/docs/commons/README.md
+++ b/docs/commons/README.md
@@ -110,7 +110,13 @@ these.
    point and mark; they never carry data.** Anything that needs validation, migration,
    or patching lives in content, where the schema machinery can see it — which is why
    there is no text-bearing association kind, and why a contact's phone numbers are
-   labeled content entries rather than associations.
+   labeled content entries rather than associations. One carve-out, for references
+   rather than data: a **constitutive reference** — the record is _about_ exactly one
+   target and is invalid without it — is a schema-required `record-ref`/`file-ref`
+   content field (`vote.pollId`, `photo.image`), so validation can enforce it and
+   read-compat can see it. Organizational references — optional, heterogeneous,
+   legitimately re-parentable — stay native (`parentId`, relationship associations);
+   "no bare ID strings" still holds, since `record-ref` is a typed kind, not a string.
 6. **Well-known association labels are part of the type.** Where a type has a
    conventional attachment or relationship (a contact's `avatar`, a bookmark's
    `snapshot`), the label is specified in the type file with the same authority as a

--- a/docs/commons/README.md
+++ b/docs/commons/README.md
@@ -106,7 +106,11 @@ these.
    associations, not a `tags: string[]` field. Cross-references are relationship
    associations or `parentId`, not bare ID strings in content. Files are attachment
    associations. Authorship is `entityId`; timestamps are `createdAt`/`updatedAt` —
-   never mirrored into content.
+   never mirrored into content. The boundary runs the other way too: **associations
+   point and mark; they never carry data.** Anything that needs validation, migration,
+   or patching lives in content, where the schema machinery can see it — which is why
+   there is no text-bearing association kind, and why a contact's phone numbers are
+   labeled content entries rather than associations.
 6. **Well-known association labels are part of the type.** Where a type has a
    conventional attachment or relationship (a contact's `avatar`, a bookmark's
    `snapshot`), the label is specified in the type file with the same authority as a

--- a/docs/commons/README.md
+++ b/docs/commons/README.md
@@ -33,6 +33,11 @@ org.haverstack/article@1
 org.haverstack/place@1
 org.haverstack/page@1
 org.haverstack/photo@1   (staged — see below)
+org.haverstack/message@1 (proposed — see below)
+org.haverstack/event@1   (proposed)
+org.haverstack/poll@1    (proposed)
+org.haverstack/vote@1    (proposed)
+org.haverstack/folder@1  (proposed)
 ```
 
 Everything outside `org.haverstack` (and the `_`-prefixed system types, which belong to
@@ -123,9 +128,13 @@ authority on **any** record, of any type:
   café, the check-in. Apps that understand places understand every located record for
   free, whatever its type.
 - **`embed`** — `{ kind: 'attachment', label: 'embed', fileId, mimeType }` marks a file
-  referenced from a record's body text (`note`, `article`, `page`). How the body refers
-  to the embed is app territory in v1; a commons syntax is an expected follow-up once
-  `file-ref` fields (#63) land.
+  referenced from a record's body text (`note`, `article`, `page`, `message`). How the
+  body refers to the embed is app territory in v1; a commons syntax is an expected
+  follow-up once `file-ref` fields (#63) land.
+- **`series`** — `{ kind: 'relationship', label: 'series', recordId }` groups records
+  that are occurrences of one recurring thing (materialized [`event`](./event.md)
+  occurrences are the motivating case). Reserved now so recurrence proposals build on
+  it rather than around it.
 
 Cross-type conventions are governed like fields: proposing one is proposing it for
 every record in every stack, so the bar is correspondingly higher.
@@ -166,34 +175,47 @@ rewritten by and for them.
 
 ## The initial set
 
-Two clusters. The **personal-data cluster** covers the shapes nearly every personal app
-re-invents first; the **publishing cluster** covers the personal-web shapes (its
+Three clusters. The **personal-data cluster** covers the shapes nearly every personal
+app re-invents first. The **publishing cluster** covers the personal-web shapes (its
 note/article boundary is the IndieWeb's post-type-discovery rule: a note is an entry
-without a name, an article is an entry with one). Pairs across the set make the interop
-story demonstrable: notes ↔ flashcards, bookmarks ↔ read-later, tasks ↔ agenda, articles
+without a name, an article is an entry with one). The **group cluster** covers the
+small-group workspace — the Basecamp shape: message board, shared calendar, decisions,
+shared drive — built on collaborative group stacks (`_group` with `stackUrl`), where
+`entityId`-as-author and per-type grants do the heavy lifting. Pairs across the set
+make the interop story demonstrable: notes ↔ flashcards, bookmarks ↔ read-later,
+articles and pages ↔ any site generator, polls ↔ calendar (a scheduling poll's winning
+slot becomes an event).
 
-- pages ↔ any site generator.
+| Type                        | File                           | Status   | Read-compat core          |
+| --------------------------- | ------------------------------ | -------- | ------------------------- |
+| `org.haverstack/note@1`     | [`note.md`](./note.md)         | Draft    | `{ text }`                |
+| `org.haverstack/bookmark@1` | [`bookmark.md`](./bookmark.md) | Draft    | `{ url }`                 |
+| `org.haverstack/task@1`     | [`task.md`](./task.md)         | Draft    | `{ title, done }`         |
+| `org.haverstack/contact@1`  | [`contact.md`](./contact.md)   | Draft    | `{ name }`                |
+| `org.haverstack/article@1`  | [`article.md`](./article.md)   | Draft    | `{ title, text }`         |
+| `org.haverstack/place@1`    | [`place.md`](./place.md)       | Draft    | `{ latitude, longitude }` |
+| `org.haverstack/page@1`     | [`page.md`](./page.md)         | Draft    | `{ slug, text }`          |
+| `org.haverstack/photo@1`    | [`photo.md`](./photo.md)       | Staged   | `{ image }` (pending #63) |
+| `org.haverstack/message@1`  | [`message.md`](./message.md)   | Proposed | `{ text }`                |
+| `org.haverstack/event@1`    | [`event.md`](./event.md)       | Proposed | `{ title, startsAt }`     |
+| `org.haverstack/poll@1`     | [`poll.md`](./poll.md)         | Proposed | `{ question, options }`   |
+| `org.haverstack/vote@1`     | [`poll.md`](./poll.md)         | Proposed | `{ pollId, choices }`     |
+| `org.haverstack/folder@1`   | [`folder.md`](./folder.md)     | Proposed | `{ name }`                |
 
-| Type                        | File                           | Status | Read-compat core          |
-| --------------------------- | ------------------------------ | ------ | ------------------------- |
-| `org.haverstack/note@1`     | [`note.md`](./note.md)         | Draft  | `{ text }`                |
-| `org.haverstack/bookmark@1` | [`bookmark.md`](./bookmark.md) | Draft  | `{ url }`                 |
-| `org.haverstack/task@1`     | [`task.md`](./task.md)         | Draft  | `{ title, done }`         |
-| `org.haverstack/contact@1`  | [`contact.md`](./contact.md)   | Draft  | `{ name }`                |
-| `org.haverstack/article@1`  | [`article.md`](./article.md)   | Draft  | `{ title, text }`         |
-| `org.haverstack/place@1`    | [`place.md`](./place.md)       | Draft  | `{ latitude, longitude }` |
-| `org.haverstack/page@1`     | [`page.md`](./page.md)         | Draft  | `{ slug, text }`          |
-| `org.haverstack/photo@1`    | [`photo.md`](./photo.md)       | Staged | `{ image }` (pending #63) |
+**Statuses.** _Draft_: settled enough to build against (still subject to in-place
+change until there's an install base). _Staged_: design recorded, registration blocked
+on a named implementation issue (`photo` waits on #63 so its required image is
+schema-enforced rather than convention-only). _Proposed_: design recorded to fix
+intent, but per the governance rule it stays parked until a concrete intended writer
+exists — the group cluster graduates when a group-tools app or demo is real. The group
+cluster additionally depends on the grant/group reshape (#57/#58) landing as decided.
 
-**Staged** means the design is recorded but the type must not be registered yet —
-`photo` waits on the `file-ref` field kind (#63) so its required image can be
-schema-enforced rather than convention-only.
-
-Deliberately absent from the initial set: `event` (recurrence rules deserve their own
-proposal, not a rushed subset), `message`/`post` (social shapes should be reconciled
-with the ATProto-compat RFC, #15), `file`/`document` (largely covered by the
-attachment machinery plus `note`), and `checkin` (subsumed by the `location`
-cross-type convention plus any record).
+Deliberately absent from the initial set: `post` (public social shapes are reconciled
+with the ATProto-compat RFC, #15 — `message` is the group-scoped shape, not the social
+one), recurrence rules (see `event`: occurrences are materialized in @1),
+`file`/`document` (a first-class `file` type is expected to follow `photo`'s pattern
+once #63 lands; until then a record plus attachment covers it), and `checkin` (subsumed
+by the `location` cross-type convention plus any record).
 
 ---
 

--- a/docs/commons/README.md
+++ b/docs/commons/README.md
@@ -1,0 +1,169 @@
+# Haverstack Schema Commons
+
+> **Status:** Draft. Staged in `haverstack/core` under `docs/commons/`; to be extracted
+> into its own repository once it has users beyond this project. Per the project's
+> evolution policy, definitions here change **in place, without version bumps**, until
+> there is an install base to break.
+
+Namespaced types (`com.example.myapp/note@1`) give every app its own schema authority —
+which is correct, but defaults to silos-within-the-stack. Portability of _bytes_ is
+guaranteed by the stack; portability of _meaning_ is not. If a notes app and a
+flashcards app each invent their own `note` type, the user's data moves between backends
+freely but between apps not at all.
+
+The Schema Commons is the social layer that closes that gap: a small set of well-known,
+neutrally-governed types for the data shapes almost every personal app touches. When two
+apps speak a commons type, "switch apps without export friction" is literally true — the
+second app queries the first app's records and just works.
+
+---
+
+## The commons namespace
+
+The namespace **`org.haverstack`** is reserved for commons types. Every type under it is
+defined in this directory and governed by the process below — no app may mint types in
+this namespace.
+
+```
+org.haverstack/note@1
+org.haverstack/bookmark@1
+org.haverstack/task@1
+org.haverstack/contact@1
+```
+
+Everything outside `org.haverstack` (and the `_`-prefixed system types, which belong to
+the library) remains app territory, exactly as the spec defines: reverse-DNS namespace,
+app author is the authority.
+
+**Canonical definitions.** The schema in each type's file here is the type. Apps must
+register commons types exactly as written — a modified copy under the same ID is schema
+drift and will (correctly) trip the drift guard against other apps sharing the stack.
+Apps never need to extend a commons schema in place:
+
+- **Missing something universal?** Propose the field upstream (see Governance). Additive
+  optional fields land in place, so accepted proposals reach every app without a bump.
+- **Need something app-specific?** Keep it out of the commons record. Put app-private
+  data in the app's own sidecar type and link it with a
+  `{ kind: 'relationship', label: '...' }` association to the commons record. The
+  commons record stays cleanly interoperable; the sidecar travels with it.
+
+---
+
+## How apps use commons types
+
+Three postures, in order of preference:
+
+1. **Write commons types natively.** If your app's core object _is_ a note, a bookmark,
+   a task, or a contact, use the commons type as your storage type. You inherit interop
+   with every other commons-speaking app for free.
+2. **Design for read-compatibility.** If your domain type is richer than the commons
+   type but shares its heart, define your own type such that it satisfies
+   `isCompatible(yourSchema, commonsSchema)` — i.e. it carries the commons type's
+   required fields with matching kinds. Other apps that consume via `isCompatible()`
+   can then read your records even though they've never heard of your type. Each type
+   file documents its **read-compat core** — the minimal shape consumers should code
+   against.
+3. **Migrate in later.** An existing app with its own type can add a lens to the commons
+   type when ready; the library's migration machinery only covers versions of the _same_
+   type, so this is an app-level export/import — which is still a one-time cost paid by
+   the app author, not a per-user export ritual.
+
+Consumers should filter by exact `typeId` when they need commons semantics, and use
+`isCompatible()` with the read-compat core when they want maximum reach.
+
+---
+
+## Design rules for commons types
+
+Distilled from the project's design decisions of record; proposals are evaluated against
+these.
+
+1. **Minimal required core.** A field is `required` only if the type is meaningless
+   without it (`note.text`, `bookmark.url`, `task.title`, `contact.name`). Everything
+   else is optional. The required core doubles as the read-compat contract, so every
+   required field is a tax on compatibility.
+2. **Additive evolution; bumps are rare and semantic.** New optional fields land in
+   place at the current version. A version bump happens only when a field becomes
+   required (with real backfill), changes meaning, or the shape restructures.
+   Accumulating many optionals is the named smell that a consolidating bump is due.
+3. **Properties, not perspectives.** Content fields describe the thing itself. Anything
+   that is one app's or one user's _view_ of the record — pinned, starred, read/unread,
+   sort order, UI state — is not commons content. Use tag associations or app sidecar
+   types.
+4. **Queryable fields are top-level scalars.** Only top-level scalar fields support
+   content filtering, so anything apps will plausibly filter on (`task.done`) must not
+   be nested. Arrays and objects are for data that is only ever read, not queried.
+5. **Use the native machinery, don't duplicate it in content.** Tags are tag
+   associations, not a `tags: string[]` field. Cross-references are relationship
+   associations or `parentId`, not bare ID strings in content. Files are attachment
+   associations. Authorship is `entityId`; timestamps are `createdAt`/`updatedAt` —
+   never mirrored into content.
+6. **Well-known association labels are part of the type.** Where a type has a
+   conventional attachment or relationship (a contact's `avatar`, a bookmark's
+   `snapshot`), the label is specified in the type file with the same authority as a
+   schema field.
+7. **String vocabularies over booleans-in-waiting.** Where a field has a small open set
+   of values (`note.format`), the type file specifies the well-known values and the
+   default meaning of absence; unknown values must be tolerated by readers
+   (treat-as-default), so the vocabulary can grow additively.
+
+---
+
+## Governance
+
+Lightweight by design, sized for a project with one maintainer and zero budget. The
+process is the point — it makes "neutrally governed" true from day one — but it must
+never be heavier than the work it governs.
+
+**Proposing a new type or field.** Open an issue on `haverstack/core` titled
+`Commons: <proposal>` covering:
+
+- **Motivation** — what interop becomes possible; which real app or demo intends to
+  write it. Proposals without a concrete intended writer are parked, not rejected.
+- **Schema** — full `TypeSchema` for new types; the new field for additions.
+- **Semantics** — meaning of each field, defaults on absence, well-known association
+  labels.
+- **Prior art** — the shape this data takes elsewhere (vCard, iCalendar, Netscape
+  bookmarks, todo.txt, ATProto lexicons…). We steal proven shapes; we don't invent.
+- **Evaluation against the design rules above.**
+
+Discussion happens on the issue; the accepted result is a PR to this directory. Each
+type file carries a changelog so decisions stay attached to the schema they shaped.
+
+**Changing an existing type.** Additive optional fields follow the same process and land
+in place. Anything that would bump a version is an `RFC:` issue, per the project's
+convention — expected to be rare enough that each one is an event.
+
+**Authority.** The project maintainer is the final arbiter. This is a bootstrapping
+posture, not a constitution: when multiple independent apps ship commons types, the
+people maintaining those apps are the natural successor body, and this section should be
+rewritten by and for them.
+
+---
+
+## The initial set
+
+Four types, chosen because they are the shapes nearly every personal-software ecosystem
+re-invents first, and because pairs of them make the interop story demonstrable (notes ↔
+flashcards, bookmarks ↔ read-later, tasks ↔ calendar/agenda).
+
+| Type                        | File                           | Read-compat core  |
+| --------------------------- | ------------------------------ | ----------------- |
+| `org.haverstack/note@1`     | [`note.md`](./note.md)         | `{ text }`        |
+| `org.haverstack/bookmark@1` | [`bookmark.md`](./bookmark.md) | `{ url }`         |
+| `org.haverstack/task@1`     | [`task.md`](./task.md)         | `{ title, done }` |
+| `org.haverstack/contact@1`  | [`contact.md`](./contact.md)   | `{ name }`        |
+
+Deliberately absent from the initial set: `event` (recurrence rules deserve their own
+proposal, not a rushed subset), `message`/`post` (social shapes should be reconciled
+with the ATProto-compat RFC, #15), and `file`/`document` (largely covered by the
+attachment machinery plus `note`).
+
+---
+
+## Planned tooling
+
+A `@haverstack/commons` package that exports the canonical schemas as constants and a
+`defineCommonsTypes(stack, [...])` helper, so "register the type exactly as written"
+is a one-liner and drift is structurally impossible. Not started; the definitions in
+this directory are authoritative until it exists.

--- a/docs/commons/README.md
+++ b/docs/commons/README.md
@@ -29,6 +29,10 @@ org.haverstack/note@1
 org.haverstack/bookmark@1
 org.haverstack/task@1
 org.haverstack/contact@1
+org.haverstack/article@1
+org.haverstack/place@1
+org.haverstack/page@1
+org.haverstack/photo@1   (staged — see below)
 ```
 
 Everything outside `org.haverstack` (and the `_`-prefixed system types, which belong to
@@ -109,6 +113,25 @@ these.
 
 ---
 
+## Cross-type conventions
+
+Some semantics belong to no single type. These association labels carry commons
+authority on **any** record, of any type:
+
+- **`location`** — `{ kind: 'relationship', label: 'location', recordId: <place> }`
+  points at a [`place`](./place.md) record: the geotagged photo, the note written at a
+  café, the check-in. Apps that understand places understand every located record for
+  free, whatever its type.
+- **`embed`** — `{ kind: 'attachment', label: 'embed', fileId, mimeType }` marks a file
+  referenced from a record's body text (`note`, `article`, `page`). How the body refers
+  to the embed is app territory in v1; a commons syntax is an expected follow-up once
+  `file-ref` fields (#63) land.
+
+Cross-type conventions are governed like fields: proposing one is proposing it for
+every record in every stack, so the bar is correspondingly higher.
+
+---
+
 ## Governance
 
 Lightweight by design, sized for a project with one maintainer and zero budget. The
@@ -143,21 +166,34 @@ rewritten by and for them.
 
 ## The initial set
 
-Four types, chosen because they are the shapes nearly every personal-software ecosystem
-re-invents first, and because pairs of them make the interop story demonstrable (notes ↔
-flashcards, bookmarks ↔ read-later, tasks ↔ calendar/agenda).
+Two clusters. The **personal-data cluster** covers the shapes nearly every personal app
+re-invents first; the **publishing cluster** covers the personal-web shapes (its
+note/article boundary is the IndieWeb's post-type-discovery rule: a note is an entry
+without a name, an article is an entry with one). Pairs across the set make the interop
+story demonstrable: notes ↔ flashcards, bookmarks ↔ read-later, tasks ↔ agenda, articles
 
-| Type                        | File                           | Read-compat core  |
-| --------------------------- | ------------------------------ | ----------------- |
-| `org.haverstack/note@1`     | [`note.md`](./note.md)         | `{ text }`        |
-| `org.haverstack/bookmark@1` | [`bookmark.md`](./bookmark.md) | `{ url }`         |
-| `org.haverstack/task@1`     | [`task.md`](./task.md)         | `{ title, done }` |
-| `org.haverstack/contact@1`  | [`contact.md`](./contact.md)   | `{ name }`        |
+- pages ↔ any site generator.
+
+| Type                        | File                           | Status | Read-compat core          |
+| --------------------------- | ------------------------------ | ------ | ------------------------- |
+| `org.haverstack/note@1`     | [`note.md`](./note.md)         | Draft  | `{ text }`                |
+| `org.haverstack/bookmark@1` | [`bookmark.md`](./bookmark.md) | Draft  | `{ url }`                 |
+| `org.haverstack/task@1`     | [`task.md`](./task.md)         | Draft  | `{ title, done }`         |
+| `org.haverstack/contact@1`  | [`contact.md`](./contact.md)   | Draft  | `{ name }`                |
+| `org.haverstack/article@1`  | [`article.md`](./article.md)   | Draft  | `{ title, text }`         |
+| `org.haverstack/place@1`    | [`place.md`](./place.md)       | Draft  | `{ latitude, longitude }` |
+| `org.haverstack/page@1`     | [`page.md`](./page.md)         | Draft  | `{ slug, text }`          |
+| `org.haverstack/photo@1`    | [`photo.md`](./photo.md)       | Staged | `{ image }` (pending #63) |
+
+**Staged** means the design is recorded but the type must not be registered yet —
+`photo` waits on the `file-ref` field kind (#63) so its required image can be
+schema-enforced rather than convention-only.
 
 Deliberately absent from the initial set: `event` (recurrence rules deserve their own
 proposal, not a rushed subset), `message`/`post` (social shapes should be reconciled
-with the ATProto-compat RFC, #15), and `file`/`document` (largely covered by the
-attachment machinery plus `note`).
+with the ATProto-compat RFC, #15), `file`/`document` (largely covered by the
+attachment machinery plus `note`), and `checkin` (subsumed by the `location`
+cross-type convention plus any record).
 
 ---
 

--- a/docs/commons/article.md
+++ b/docs/commons/article.md
@@ -1,0 +1,97 @@
+# `org.haverstack/article@1` — Article
+
+> **Status:** Draft.
+
+A titled written work: a blog post, an essay, a book chapter, a newsletter issue. The
+boundary against `note` is the IndieWeb's post-type-discovery rule, adopted here as
+doctrine: **a note is an entry without a name; an article is an entry with one** —
+plus publication semantics (byline, summary, published date, canonical URL).
+
+One type covers both directions the shape flows: **authored** articles (your own
+writing, possibly unpublished) and **captured** articles (a reader-mode save of someone
+else's work). The optional fields are where the two diverge; the required core is what
+they share.
+
+Prior art: JSON Feed items, Atom entries, microformats `h-entry`, schema.org/Article.
+JSON Feed is the closest ancestor — its item shape is nearly this type field-for-field.
+
+## Schema
+
+```ts
+await stack.defineType('org.haverstack/article@1', 'Article', {
+  title: { kind: 'string', required: true },
+  text: { kind: 'text', required: true },
+  format: { kind: 'string' },
+  summary: { kind: 'text' },
+  url: { kind: 'string' },
+  author: { kind: 'string' },
+  publishedAt: { kind: 'date' },
+});
+```
+
+## Field semantics
+
+| Field         | Kind     | Required | Meaning                                                                                                                                                                                                                                                                                   |
+| ------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`       | `string` | yes      | The work's name. What makes it an article rather than a note.                                                                                                                                                                                                                             |
+| `text`        | `text`   | yes      | The body.                                                                                                                                                                                                                                                                                 |
+| `format`      | `string` | no       | Interpretation of `text`. Same vocabulary and defaults as `note`: `"markdown"` (default when absent), `"plain"`; unknown values render as plain.                                                                                                                                          |
+| `summary`     | `text`   | no       | Abstract/deck/excerpt. Authored: written or app-derived-and-saved. Captured: the source's own summary. Readers must not regenerate and write back over a present value.                                                                                                                   |
+| `url`         | `string` | no       | Canonical location of the published work. Authored drafts have none yet; captured articles always carry the source URL. Presence of `url` is what makes an article record read-compatible with `bookmark` consumers in spirit — though formally `bookmark`'s core requires it, see below. |
+| `author`      | `string` | no       | External attribution — the byline as displayed ("Jane Doe"). **Absent means the record's `entityId` (or the stack owner) is the author.** This is deliberately a string, not a reference: a captured work's byline is a property of the work, and its author is rarely a known principal. |
+| `publishedAt` | `date`   | no       | When the work was (or will be) published. **Absent means draft/unpublished.** Distinct from `createdAt` (when the record entered the stack) and `updatedAt` (last edit).                                                                                                                  |
+
+## Conventions
+
+- **Draft state** is `publishedAt` absence — a property of the work, not a perspective.
+  Editorial workflow states beyond draft/published (in-review, scheduled-vs-published
+  nuance) are app sidecar territory.
+- **Cover image**: attachment association with label `cover` (JSON Feed `image`,
+  h-entry `u-featured`).
+- **Embedded media** in `text`: attachment associations with label `embed`, per the
+  cross-type convention in the README.
+- **Series/collections**: `parentId` when the app has a container record; otherwise tag
+  associations.
+- **Captured articles** should also carry `{ kind: 'relationship', label: 'about', … }`
+  associations from any notes annotating them, and may coexist with a `bookmark` record
+  for the same URL (the bookmark is "I saved this link"; the article is "I captured this
+  work") — apps that hold both should link them with a `relationship` labeled `capture`
+  from the bookmark to the article.
+- **Querying published articles**: content filters are exact-match only, so "where
+  `publishedAt` exists, sorted by it" is not expressible as a query. Consumers (e.g. a
+  site generator) fetch articles and filter/sort app-side — the right trade at personal
+  scale (hundreds of posts, not millions), and why this type does not carry a redundant
+  required `draft` boolean. If real usage proves this painful, an additive optional
+  field can follow; starting with redundancy would be starting with the smell.
+
+## Read-compat core
+
+```ts
+{
+  title: { kind: 'string', required: true },
+  text:  { kind: 'text', required: true },
+}
+```
+
+Because `text` is required, every article also satisfies `note`'s core `{ text }` — a
+notes app can display your articles as a degenerate case, which is exactly right.
+Captured articles carry `url`, but since `url` is optional here, `article@1` as a whole
+is _not_ compatible with `bookmark`'s core; capture apps wanting bookmark-consumer reach
+keep the paired bookmark record described above.
+
+## Deliberately excluded
+
+- `tags: string[]` — tag associations.
+- Layout, theme, rendering hints — presentation is the publishing app's concern.
+- `slug` and site-structure fields — that is [`page`](./page.md) territory; an article
+  is a work in a feed, a page is a node in a site tree.
+- Social/microblog `post` semantics (replies, reposts, mentions) — deferred to
+  reconciliation with the ATProto-compat RFC (#15). An article is a work; a post is an
+  utterance.
+- Comments — a future proposal once shared/group stacks settle; likely a `note` with an
+  `about` relationship rather than a new type.
+
+## Changelog
+
+- **Draft** — initial definition: `title`, `text` (required), `format`, `summary`,
+  `url`, `author`, `publishedAt`.

--- a/docs/commons/article.md
+++ b/docs/commons/article.md
@@ -46,6 +46,13 @@ await stack.defineType('org.haverstack/article@1', 'Article', {
 - **Draft state** is `publishedAt` absence — a property of the work, not a perspective.
   Editorial workflow states beyond draft/published (in-review, scheduled-vs-published
   nuance) are app sidecar territory.
+- **Canonical URL write-back**: on authored articles, the _publishing app_ stamps
+  `url` at first publish (a site generator derives the permalink, builds, then writes
+  the canonical location back to the record). `url` present therefore means "this work
+  lives somewhere on the web" — symmetrically for authored and captured articles — and
+  any app can render a "view published" link. Syndicated copies elsewhere never
+  overwrite it: canonical means canonical; other locations are sidecar territory (or
+  future syndication relationships, #15).
 - **Cover image**: attachment association with label `cover` (JSON Feed `image`,
   h-entry `u-featured`).
 - **Embedded media** in `text`: attachment associations with label `embed`, per the

--- a/docs/commons/article.md
+++ b/docs/commons/article.md
@@ -59,6 +59,15 @@ await stack.defineType('org.haverstack/article@1', 'Article', {
   cross-type convention in the README.
 - **Series/collections**: `parentId` when the app has a container record; otherwise tag
   associations.
+- **Known authors** use the cross-type `author` relationship (see README) alongside —
+  never instead of — the `author` string. Three tiers of acquaintance, three
+  mechanisms: a principal writing in this stack is `entityId` (native); someone you
+  know is an `author` relationship to their `contact` record; a stranger's byline is
+  the `author` string alone. When string and association coexist they don't conflict —
+  the association is machine-readable identity ("3 articles by Alice" is a query), the
+  string is the byline as displayed, faithful to the work even if the contact is later
+  renamed. Co-authorship is multiple `author` associations, with the string holding
+  the joint byline ("Alice Smith and Bob Jones").
 - **Captured articles** should also carry `{ kind: 'relationship', label: 'about', … }`
   associations from any notes annotating them, and may coexist with a `bookmark` record
   for the same URL (the bookmark is "I saved this link"; the article is "I captured this

--- a/docs/commons/article.md
+++ b/docs/commons/article.md
@@ -88,8 +88,10 @@ keep the paired bookmark record described above.
 - Social/microblog `post` semantics (replies, reposts, mentions) — deferred to
   reconciliation with the ATProto-compat RFC (#15). An article is a work; a post is an
   utterance.
-- Comments — a future proposal once shared/group stacks settle; likely a `note` with an
-  `about` relationship rather than a new type.
+- Comments — already covered, no new type: a comment is a [`message`](./message.md)
+  whose `parentId` is the article (sent into a shared space, moment-indexed,
+  tamper-evident), while a reader's private marginalia is a `note` with an `about`
+  relationship. See [Choosing a text type](./text-types.md) for the ruling.
 
 ## Changelog
 

--- a/docs/commons/bookmark.md
+++ b/docs/commons/bookmark.md
@@ -1,0 +1,60 @@
+# `org.haverstack/bookmark@1` — Bookmark
+
+> **Status:** Draft.
+
+A saved reference to a URL: browser bookmarks, read-later queues, link collections,
+citation managers' web entries. The type with the longest prior-art trail (Netscape
+bookmark files, del.icio.us, Pinboard, browser sync formats) — and the shape of all of
+them is the same: a URL plus optional human annotation.
+
+## Schema
+
+```ts
+await stack.defineType('org.haverstack/bookmark@1', 'Bookmark', {
+  url: { kind: 'string', required: true },
+  title: { kind: 'string' },
+  description: { kind: 'text' },
+});
+```
+
+## Field semantics
+
+| Field         | Kind     | Required | Meaning                                                                                                                                                                           |
+| ------------- | -------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `url`         | `string` | yes      | The bookmarked URL, as saved. Writers should store it absolute and unmodified beyond safe normalization (scheme/host lowercasing); readers must not assume it is still reachable. |
+| `title`       | `string` | no       | Title at save time — usually the page's `<title>`, possibly user-edited. Absent means the app displays the URL.                                                                   |
+| `description` | `text`   | no       | User's annotation, or an excerpt captured at save time. Markdown by convention (matching `note`'s default).                                                                       |
+
+## Conventions
+
+- **When it was saved** is `createdAt`. There is no separate `savedAt`.
+- **Read-later state** (`unread`, `archived`) is a perspective — tag associations, not
+  content. A read-later app and a bookmarks manager sharing these records is exactly the
+  interop this type exists for, and they will disagree about read-state; tags let them.
+- **Page snapshot**: an archived copy of the page's content is an attachment association
+  with label `snapshot` (one per capture; multiple captures are multiple associations).
+  The attachment's `mimeType` follows the deterministic first-recorded rule (#65); apps
+  should prefer archival-friendly types (PDF, WARC, single-file HTML stored as an
+  attachment — served under the #66 safe-list rules).
+- **Favicon / preview image**: attachment association with label `preview`.
+
+## Read-compat core
+
+```ts
+{ url: { kind: 'string', required: true } }
+```
+
+Anything with a required `url` string — a citation, a feed subscription, a web mention —
+can be surfaced by a bookmark consumer.
+
+## Deliberately excluded
+
+- `tags: string[]` — tag associations.
+- `unread`, `archived`, `favorite` — perspectives.
+- `siteName`, `author`, `publishedAt` page metadata — belongs to a future
+  `article`/`webpage` proposal (the read-later apps' richer shape), which should be
+  read-compatible with this type rather than bloating it.
+
+## Changelog
+
+- **Draft** — initial definition: `url` (required), `title`, `description`.

--- a/docs/commons/bookmark.md
+++ b/docs/commons/bookmark.md
@@ -51,9 +51,10 @@ can be surfaced by a bookmark consumer.
 
 - `tags: string[]` — tag associations.
 - `unread`, `archived`, `favorite` — perspectives.
-- `siteName`, `author`, `publishedAt` page metadata — belongs to a future
-  `article`/`webpage` proposal (the read-later apps' richer shape), which should be
-  read-compatible with this type rather than bloating it.
+- `siteName`, `author`, `publishedAt` page metadata — that is [`article`](./article.md)
+  territory (the read-later apps' richer shape). An app that captures full articles
+  keeps a paired bookmark record for bookmark-consumer reach and links it to the
+  article with `{ kind: 'relationship', label: 'capture', recordId }`.
 
 ## Changelog
 

--- a/docs/commons/contact.md
+++ b/docs/commons/contact.md
@@ -1,0 +1,81 @@
+# `org.haverstack/contact@1` — Contact
+
+> **Status:** Draft.
+
+A person or organization in the user's address book. Distinct from the `_entity` system
+type: an `_entity` is a principal — an authenticated actor in the permission system — while
+a `contact` is a directory entry, with no implied cryptographic identity. Most contacts
+will never be entities; some will be both (see conventions).
+
+Prior art is vCard, and the design here is a deliberately tiny vCard subset: the fields
+people actually fill in, minus the 40 years of accretion.
+
+## Schema
+
+```ts
+await stack.defineType('org.haverstack/contact@1', 'Contact', {
+  name: { kind: 'string', required: true },
+  emails: { kind: 'array', items: { kind: 'string' } },
+  phones: { kind: 'array', items: { kind: 'string' } },
+  urls: { kind: 'array', items: { kind: 'string' } },
+  org: { kind: 'string' },
+  note: { kind: 'text' },
+});
+```
+
+## Field semantics
+
+| Field    | Kind            | Required | Meaning                                                                                                                                                                                                                                                      |
+| -------- | --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`   | `string`        | yes      | Display name, as the user knows them. No given/family split in @1 — name-order and name-structure assumptions are a known internationalization trap; a structured-name addition should arrive as a follow-up optional field, never by reinterpreting `name`. |
+| `emails` | `array<string>` | no       | Email addresses, most-preferred first. Plain addresses, no `mailto:`.                                                                                                                                                                                        |
+| `phones` | `array<string>` | no       | Phone numbers, most-preferred first. Stored as entered; E.164 normalization is app-side display logic.                                                                                                                                                       |
+| `urls`   | `array<string>` | no       | Websites/profiles, most-preferred first.                                                                                                                                                                                                                     |
+| `org`    | `string`        | no       | Organization/affiliation, freeform.                                                                                                                                                                                                                          |
+| `note`   | `text`          | no       | Freeform notes about the contact.                                                                                                                                                                                                                            |
+
+Arrays are ordered but unlabeled in @1 (no `home`/`work` typing) — labels are the first
+candidate follow-up proposal, and per the additive rules they would arrive as a parallel
+optional structure, not a reshape of these arrays. Note that array fields are opaque to
+the query engine; apps filter contacts by `name` or via associations, not by address.
+
+## Conventions
+
+- **Avatar**: attachment association with label `avatar` — the spec's own example of an
+  attachment association, honored here.
+- **Contact ↔ entity linkage**: when a contact _is_ a known principal (they appear in
+  grants, groups, or authorship), link the records with
+  `{ kind: 'relationship', label: 'entity', recordId: <_entity record id> }` on the
+  contact. This keeps the directory entry (mutable, user-owned petname territory) apart
+  from the identity record, in line with the properties-vs-perspectives principle and
+  the DID identity direction (#49): your name for someone is your perspective; their key
+  is a property.
+- **Grouping** (family, team, club): tag associations for casual grouping. A commons
+  position on linking contacts to `_group` records is deferred until the group reshape
+  (#58) settles.
+- **Birthdays**: excluded from @1 — calendar-shaped data (partial dates, year-unknown
+  birthdays, recurrence) belongs with the future `event` proposal.
+
+## Read-compat core
+
+```ts
+{ name: { kind: 'string', required: true } }
+```
+
+Minimal by intent: anything nameable — an `_entity`, an app's `author` type, a CRM
+lead — can be listed by a contacts consumer.
+
+## Deliberately excluded
+
+- Structured names (`givenName`/`familyName`) — i18n trap; future optional addition.
+- Typed/labeled addresses (`home`/`work`) — future proposal.
+- Postal addresses — genuinely structured, rarely shared between apps; future proposal
+  with vCard `ADR` as prior art.
+- `birthday` and dates — see conventions.
+- Any identity/key material — that is `_entity`/#49 territory; a contact asserts
+  nothing cryptographic.
+
+## Changelog
+
+- **Draft** — initial definition: `name` (required), `emails`, `phones`, `urls`, `org`,
+  `note`.

--- a/docs/commons/contact.md
+++ b/docs/commons/contact.md
@@ -13,11 +13,19 @@ people actually fill in, minus the 40 years of accretion.
 ## Schema
 
 ```ts
+const labeledValue = {
+  kind: 'object',
+  properties: {
+    value: { kind: 'string', required: true },
+    label: { kind: 'string' },
+  },
+} as const;
+
 await stack.defineType('org.haverstack/contact@1', 'Contact', {
   name: { kind: 'string', required: true },
-  emails: { kind: 'array', items: { kind: 'string' } },
-  phones: { kind: 'array', items: { kind: 'string' } },
-  urls: { kind: 'array', items: { kind: 'string' } },
+  emails: { kind: 'array', items: labeledValue },
+  phones: { kind: 'array', items: labeledValue },
+  urls: { kind: 'array', items: labeledValue },
   org: { kind: 'string' },
   note: { kind: 'text' },
 });
@@ -25,19 +33,24 @@ await stack.defineType('org.haverstack/contact@1', 'Contact', {
 
 ## Field semantics
 
-| Field    | Kind            | Required | Meaning                                                                                                                                                                                                                                                      |
-| -------- | --------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `name`   | `string`        | yes      | Display name, as the user knows them. No given/family split in @1 — name-order and name-structure assumptions are a known internationalization trap; a structured-name addition should arrive as a follow-up optional field, never by reinterpreting `name`. |
-| `emails` | `array<string>` | no       | Email addresses, most-preferred first. Plain addresses, no `mailto:`.                                                                                                                                                                                        |
-| `phones` | `array<string>` | no       | Phone numbers, most-preferred first. Stored as entered; E.164 normalization is app-side display logic.                                                                                                                                                       |
-| `urls`   | `array<string>` | no       | Websites/profiles, most-preferred first.                                                                                                                                                                                                                     |
-| `org`    | `string`        | no       | Organization/affiliation, freeform.                                                                                                                                                                                                                          |
-| `note`   | `text`          | no       | Freeform notes about the contact.                                                                                                                                                                                                                            |
+| Field    | Kind                     | Required | Meaning                                                                                                                                                                                                                                                      |
+| -------- | ------------------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `name`   | `string`                 | yes      | Display name, as the user knows them. No given/family split in @1 — name-order and name-structure assumptions are a known internationalization trap; a structured-name addition should arrive as a follow-up optional field, never by reinterpreting `name`. |
+| `emails` | `array<{value, label?}>` | no       | Email addresses, most-preferred first. `value` is the plain address (no `mailto:`); `label` is an optional user-facing word.                                                                                                                                 |
+| `phones` | `array<{value, label?}>` | no       | Phone numbers, most-preferred first. `value` stored as entered (E.164 normalization is app-side display logic); `label` as below.                                                                                                                            |
+| `urls`   | `array<{value, label?}>` | no       | Websites/profiles, most-preferred first.                                                                                                                                                                                                                     |
+| `org`    | `string`                 | no       | Organization/affiliation, freeform.                                                                                                                                                                                                                          |
+| `note`   | `text`                   | no       | Freeform notes about the contact.                                                                                                                                                                                                                            |
 
-Arrays are ordered but unlabeled in @1 (no `home`/`work` typing) — labels are the first
-candidate follow-up proposal, and per the additive rules they would arrive as a parallel
-optional structure, not a reshape of these arrays. Note that array fields are opaque to
-the query engine; apps filter contacts by `name` or via associations, not by address.
+**Labels** (vCard's `TYPE` parameter, humanized): an open vocabulary of user-facing
+words. Well-known values: `"home"`, `"work"`, `"mobile"`. Unknown labels are displayed
+verbatim — they are the user's words ("boat phone" is legal and correct), not a
+machine namespace. Absent means unspecified. This is deliberately the same
+labeled-multi-value shape as #15's revised `externalIds` on `EntityContent`, differing
+only in that `label` is for humans where `ns` is for machines.
+
+Note that array fields are opaque to the query engine; apps filter contacts by `name`
+or via associations, not by address.
 
 ## Conventions
 
@@ -68,7 +81,6 @@ lead — can be listed by a contacts consumer.
 ## Deliberately excluded
 
 - Structured names (`givenName`/`familyName`) — i18n trap; future optional addition.
-- Typed/labeled addresses (`home`/`work`) — future proposal.
 - Postal addresses — genuinely structured, rarely shared between apps; future proposal
   with vCard `ADR` as prior art.
 - `birthday` and dates — see conventions.
@@ -79,3 +91,7 @@ lead — can be listed by a contacts consumer.
 
 - **Draft** — initial definition: `name` (required), `emails`, `phones`, `urls`, `org`,
   `note`.
+- **Draft, reshaped in place** — `emails`/`phones`/`urls` items changed from bare
+  strings to `{ value, label? }` objects (vCard `TYPE`, humanized). An in-place item
+  reshape is legal exactly once: pre-install-base, per the project's evolution stance —
+  the cheap window this project's own doctrine says to use.

--- a/docs/commons/event.md
+++ b/docs/commons/event.md
@@ -1,0 +1,89 @@
+# `org.haverstack/event@1` — Event
+
+> **Status:** Proposed — awaiting an intended writer (a group-calendar app). Lives in
+> the group cluster; equally meaningful in personal stacks.
+
+Something at a time: a meeting, a gathering, a deadline with a duration. The shared
+group calendar is the motivating consumer — the thing today delegated to a shared
+Google calendar.
+
+Prior art: iCalendar `VEVENT` (SUMMARY, DTSTART, DTEND, DESCRIPTION, URL),
+schema.org/Event. The design takes VEVENT's universally-used core and explicitly
+excludes its famously hard part (recurrence — see conventions).
+
+## Schema
+
+```ts
+await stack.defineType('org.haverstack/event@1', 'Event', {
+  title: { kind: 'string', required: true },
+  startsAt: { kind: 'date', required: true },
+  endsAt: { kind: 'date' },
+  allDay: { kind: 'boolean' },
+  description: { kind: 'text' },
+  url: { kind: 'string' },
+});
+```
+
+## Field semantics
+
+| Field         | Kind      | Required | Meaning                                                                                                                                                                       |
+| ------------- | --------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`       | `string`  | yes      | What it is ("Monthly meeting", "Spring cleanup day").                                                                                                                         |
+| `startsAt`    | `date`    | yes      | When it begins — an absolute instant (ISO 8601, per #69). An event is meaningless without a time.                                                                             |
+| `endsAt`      | `date`    | no       | When it ends. Absent means unspecified duration (a deadline, a "starts at 7pm" with no stated end).                                                                           |
+| `allDay`      | `boolean` | no       | Absent means `false`. When `true`, times-of-day are ignored: the event occupies the calendar date(s) of `startsAt`(–`endsAt`) interpreted in the stack's configured timezone. |
+| `description` | `text`    | no       | Details. Markdown by convention.                                                                                                                                              |
+| `url`         | `string`  | no       | Where it happens online (video-call link) or a canonical event page.                                                                                                          |
+
+## Conventions
+
+- **Physical location** is the cross-type `location` relationship to a
+  [`place`](./place.md) record — which is what makes "map of everywhere our group
+  meets" a query, not a feature.
+- **Recurrence is excluded from @1, and the @1 answer is materialization.** Writers
+  create the actual occurrence records ("every 2nd Tuesday" → the next N Tuesdays),
+  which keeps every consumer trivially correct — a calendar app that has never heard of
+  recurrence still renders the schedule. The generating rule (RRULE-shaped) lives in
+  the writing app's sidecar on its own anchor record; occurrences link to that anchor
+  with `{ kind: 'relationship', label: 'series', recordId }` (a reserved cross-type
+  label) so any app can group them. A commons recurrence proposal (RRULE prior art) is
+  expected eventually; it must land as an additive companion, not a reinterpretation of
+  occurrence records.
+- **Querying a date range**: content filters are exact-match only, so "events in May"
+  is not a content query. At group scale, consumers fetch events (or filter by
+  `createdAt` coarsely) and range-filter app-side — same honest trade as `article`
+  drafts and `place` proximity.
+- **RSVPs / attendance** are per-member responses — the same shape as
+  [`poll`](./poll.md) votes, and a future proposal should generalize from `vote` rather
+  than inventing a parallel mechanism. Until then, attendance is app territory.
+- **Cancellation** is soft-deletion (recoverable, history preserved), not a status
+  field.
+
+## Read-compat core
+
+```ts
+{
+  title:    { kind: 'string', required: true },
+  startsAt: { kind: 'date', required: true },
+}
+```
+
+Anything titled-and-timed — a task app's scheduled block, a trip leg, a poll's winning
+time slot promoted to a real event — can appear on a calendar consumer's calendar.
+
+## Deliberately excluded
+
+- Recurrence rules — see conventions; materialize occurrences.
+- Attendees/RSVP fields — per-member records, future proposal generalizing `vote`.
+- Reminders/alarms — perspectives (each member wants their own); app-side.
+- Free-text `location` string — use the `location` relationship for real places and
+  `url`/`description` for virtual ones; a freeform field would become the junk drawer
+  that keeps both honest mechanisms unused.
+- Timezone-per-event — @1 events are absolute instants plus the stack-timezone rule
+  for `allDay`; floating times and cross-timezone display are app concerns until a real
+  writer demonstrates the need.
+
+## Changelog
+
+- **Proposed** — initial definition: `title`, `startsAt` (required), `endsAt`,
+  `allDay`, `description`, `url`.

--- a/docs/commons/folder.md
+++ b/docs/commons/folder.md
@@ -1,0 +1,78 @@
+# `org.haverstack/folder@1` — Folder
+
+> **Status:** Proposed — awaiting an intended writer (a shared-drive app). Lives in the
+> group cluster.
+
+A user-created, app-neutral container — the thing that makes a shared drive a drive.
+The stack already provides everything else a "docs & files" tool needs: attachments are
+content-addressed blobs with metadata records, notes/articles are documents, `parentId`
+is indexed containment. What's missing is only a container type every app agrees on.
+
+**Boundary with app containers, stated carefully.** The commons doctrine so far has
+been "containers are app territory" (task lists, photo albums, site containers) — those
+containers carry app-specific semantics (a list's sort order, an album's cover). A
+`folder` is different in kind: it has _no_ semantics beyond named containment, and its
+entire purpose is to be shared structure that no single app owns. The doctrine becomes:
+**app-meaningful containers stay app types; meaning-free shared containment is
+`folder`.** An app may parent its own container record inside a folder tree, and apps
+with folder-shaped needs (a drive, a shared notebook) should use `folder` rather than
+minting a private equivalent.
+
+Prior art: every filesystem; WebDAV collections; the shared-drive folder trees of
+Google Drive/Dropbox.
+
+## Schema
+
+```ts
+await stack.defineType('org.haverstack/folder@1', 'Folder', {
+  name: { kind: 'string', required: true },
+  description: { kind: 'text' },
+});
+```
+
+## Field semantics
+
+| Field         | Kind     | Required | Meaning                                                                                           |
+| ------------- | -------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `name`        | `string` | yes      | The folder's name as displayed. Siblings sharing a name is legal but unkind; writers should warn. |
+| `description` | `text`   | no       | What belongs here — the README taped to the front of the drawer.                                  |
+
+## Conventions
+
+- **Containment is `parentId`**, for both subfolders and contents. Any record type can
+  live in a folder — a drive holding notes, photos, polls, and plain files is the
+  intended picture, not an edge case.
+- **A "file" in the drive** is, today, any record carrying an attachment association —
+  typically a `note` with the file attached and the body as commentary. A first-class
+  `file` type (a required `file-ref` plus name) is expected to follow
+  [`photo`](./photo.md)'s pattern once #63 lands; this file's conventions will be
+  amended then.
+- **Folder-level permissions do not exist** — permissions are per-record and grants are
+  per-type; a folder's `permissions` field governs the folder record itself, **not**
+  its contents. Apps must not present a folder as an access boundary unless they also
+  set permissions on every contained record. Recorded bluntly because every user will
+  assume otherwise; whether reference-implies-access (#51) or a future inherited model
+  changes this is an open question for the permissions work, not something this type
+  can promise.
+- **Moving** is re-parenting — one field write, atomic, history preserved.
+
+## Read-compat core
+
+```ts
+{ name: { kind: 'string', required: true } }
+```
+
+(Shared with `contact`'s core — `isCompatible` reach is deliberately generous here;
+consumers wanting real folders filter by `typeId`.)
+
+## Deliberately excluded
+
+- Sort order, view mode, color, icon — perspectives; app-side or sidecar.
+- Folder-level sharing semantics — see conventions; being honest about this is the
+  feature.
+- Paths/slugs — folders are display structure, not addresses; [`page`](./page.md) is
+  the type whose tree builds URLs.
+
+## Changelog
+
+- **Proposed** — initial definition: `name` (required), `description`.

--- a/docs/commons/message.md
+++ b/docs/commons/message.md
@@ -16,6 +16,10 @@ social shape (reposts, mentions, public replies) belongs to the ATProto-compat R
 (#15) and is still deferred; this type must not foreclose it, and reconciliation is
 expected when #15 lands.
 
+Messages are **sent** — speech addressed to others, whose meaning is indexed to its
+moment and thread. For the boundary with `note` (kept) and `article` (published), see
+[Choosing a text type](./text-types.md).
+
 Prior art: RFC 5322 (email — subject/body/references), Usenet, Discourse topics,
 Basecamp's message board.
 
@@ -42,10 +46,14 @@ write, which is the whole reason this type needs no author field.
 
 ## Conventions
 
-- **Threading is `parentId`, flat.** A thread starter has no message parent; replies
-  set `parentId` to the starter. The thread view is one indexed query
-  (`parentId = <starter>`, sort `createdAt` asc); the board index is another
-  (`typeId = message@1, parentId = null`). Basecamp-style flat threads are the model.
+- **Threading is `parentId`, flat — and any record can anchor a thread.** A board
+  thread's anchor is a message with no parent; a comment section's anchor is the record
+  being discussed — comments on a blog post are messages parented to the `article`,
+  and the same move gives photos, polls, and events their discussions. Replies set
+  `parentId` to the anchor. The thread view is one indexed query
+  (`parentId = <anchor>`, sort `createdAt` asc); the board index is another
+  (`typeId = message@1, parentId = null`, which finds exactly the threads that _are_
+  board threads). Basecamp-style flat threads are the model.
 - **Replying to a specific earlier message** (quoting) adds
   `{ kind: 'relationship', label: 'reply-to', recordId }` on top of `parentId` — the
   spec's own example association, used here for precision, not structure.
@@ -59,6 +67,10 @@ write, which is the whole reason this type needs no author field.
 - **Email-list bridging** is a motivating consumer: subject/body/threading map 1:1 to
   RFC 5322, so a bridge app can mirror a listserv into a group stack (and out), giving
   a group a searchable, owned archive without asking anyone to switch tools on day one.
+- **Comments across trust boundaries**: a public blog's comment section is this same
+  shape living in the author's personal stack — commenters are entities holding a
+  `create` grant on `message@1`. Webmention-grade interop with real primitives
+  underneath; making that practical for strangers depends on the identity work (#49).
 
 ## Read-compat core
 
@@ -81,3 +93,5 @@ discussion.
 ## Changelog
 
 - **Proposed** — initial definition: `text` (required), `subject`, `format`.
+- **Proposed, amended** — threads may be anchored by any record (comments on articles,
+  photos, polls); text-type contract guide cross-referenced.

--- a/docs/commons/message.md
+++ b/docs/commons/message.md
@@ -1,0 +1,83 @@
+# `org.haverstack/message@1` — Message
+
+> **Status:** Proposed — awaiting an intended writer (a group-discussion app or an
+> email-list bridge). Lives in the group cluster: designed for collaborative group
+> stacks, meaningful in personal stacks too.
+
+A message on a group's board: a thread starter or a reply. The model is deliberately
+**message-board-shaped, not chat-shaped** — subject + body + flat replies, the way
+small groups actually use Slack (as a slow message board) and the way email lists have
+worked for fifty years. Presence, typing indicators, and ephemerality are chat-app
+concerns and have no representation here.
+
+**This is not the social post.** A `message` is addressed to a group by living in that
+group's stack; a social post is broadcast to the world under a public identity. The
+social shape (reposts, mentions, public replies) belongs to the ATProto-compat RFC
+(#15) and is still deferred; this type must not foreclose it, and reconciliation is
+expected when #15 lands.
+
+Prior art: RFC 5322 (email — subject/body/references), Usenet, Discourse topics,
+Basecamp's message board.
+
+## Schema
+
+```ts
+await stack.defineType('org.haverstack/message@1', 'Message', {
+  text: { kind: 'text', required: true },
+  subject: { kind: 'string' },
+  format: { kind: 'string' },
+});
+```
+
+## Field semantics
+
+| Field     | Kind     | Required | Meaning                                                                                                                                |
+| --------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `text`    | `text`   | yes      | The body.                                                                                                                              |
+| `subject` | `string` | no       | Thread subject. Conventionally present on thread starters, absent on replies (a reply that sets one is a subject change, as in email). |
+| `format`  | `string` | no       | Same vocabulary and defaults as `note`: `"markdown"` (default), `"plain"`.                                                             |
+
+The author is `entityId` — set natively by `ScopedStack.create()` for every member
+write, which is the whole reason this type needs no author field.
+
+## Conventions
+
+- **Threading is `parentId`, flat.** A thread starter has no message parent; replies
+  set `parentId` to the starter. The thread view is one indexed query
+  (`parentId = <starter>`, sort `createdAt` asc); the board index is another
+  (`typeId = message@1, parentId = null`). Basecamp-style flat threads are the model.
+- **Replying to a specific earlier message** (quoting) adds
+  `{ kind: 'relationship', label: 'reply-to', recordId }` on top of `parentId` — the
+  spec's own example association, used here for precision, not structure.
+- **Attachments**: attachment associations, any label; `embed` for files referenced
+  from the body, per the cross-type convention.
+- **Edits** are ordinary updates — version history is the edit trail, for free.
+  Deletions are soft, recoverable by the group owner per the recoverability model.
+- **Read/unread** is each member's perspective — app-side state, never on the record.
+- **Boards/categories** beyond one board per stack: app container records as parents of
+  thread starters, or a [`folder`](./folder.md).
+- **Email-list bridging** is a motivating consumer: subject/body/threading map 1:1 to
+  RFC 5322, so a bridge app can mirror a listserv into a group stack (and out), giving
+  a group a searchable, owned archive without asking anyone to switch tools on day one.
+
+## Read-compat core
+
+```ts
+{ text: { kind: 'text', required: true } }
+```
+
+Note-compatible, deliberately: a notes app pointed at a group stack can read the
+discussion.
+
+## Deliberately excluded
+
+- Social-post semantics — #15 territory (see above).
+- Reactions — a future micro-proposal (likely tag associations by non-authors — which
+  needs the association-permission rules from the #57/#58 reshape to settle first).
+- Chat features (presence, ephemerality, delivery/read receipts) — out of scope by
+  design posture, not by omission.
+- `to`/`cc` addressing — presence in the group's stack is the addressing.
+
+## Changelog
+
+- **Proposed** — initial definition: `text` (required), `subject`, `format`.

--- a/docs/commons/note.md
+++ b/docs/commons/note.md
@@ -1,0 +1,62 @@
+# `org.haverstack/note@1` — Note
+
+> **Status:** Draft.
+
+A piece of free-form written content: a note, a journal entry, a draft, a text snippet.
+The most universal shape in personal software, and the anchor of the commons — the
+spec's own `isCompatible()` example ("any Type with `{ text: string }`") is this type's
+read-compat core.
+
+## Schema
+
+```ts
+await stack.defineType('org.haverstack/note@1', 'Note', {
+  text: { kind: 'text', required: true },
+  title: { kind: 'string' },
+  format: { kind: 'string' },
+});
+```
+
+## Field semantics
+
+| Field    | Kind     | Required | Meaning                                                                                                                                                                                                                                               |
+| -------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `text`   | `text`   | yes      | The body. What the note _is_.                                                                                                                                                                                                                         |
+| `title`  | `string` | no       | Display title. Absent means untitled; readers may derive one from `text` (e.g. first line) for display, but must not write the derivation back.                                                                                                       |
+| `format` | `string` | no       | How `text` should be interpreted. Well-known values: `"markdown"` (CommonMark), `"plain"`. **Absent means `"markdown"`.** Readers encountering an unknown value must fall back to rendering as `"plain"` — never guess a richer format than declared. |
+
+## Conventions
+
+- **Organization**: `parentId` for containment (notebook/folder records, when an app has
+  them); tag associations for flat labels. Pinning, starring, and read-state are
+  perspectives — tags, not content.
+- **Embedded files**: images and other media referenced from `text` are attachment
+  associations with label `embed`. How the body refers to an embedded file (e.g. a
+  markdown image reference) is app territory in @1; a commons convention here is an
+  expected follow-up proposal once `file-ref` fields (#63) land.
+- **Cross-references**: a note that is _about_ another record (annotating a bookmark, a
+  contact) uses `{ kind: 'relationship', label: 'about', recordId }`.
+
+## Read-compat core
+
+```ts
+{ text: { kind: 'text', required: true } }
+```
+
+Consumers wanting maximum reach should accept any type compatible with this shape and
+treat `title`/`format` as optional enrichments. Note that `text` ⇄ `string` are mutually
+readable under the strengthened `isCompatible` relation (#54), so short-string types
+also qualify.
+
+## Deliberately excluded
+
+- `createdAt`/`updatedAt`/author fields — native record fields cover these.
+- `tags: string[]` — tag associations exist.
+- `pinned`, `archived`, `color` — perspectives; app sidecar or tags.
+- Rich-text formats beyond markdown/plain (HTML in particular) — HTML notes are an
+  XSS-shaped liability the dangerous-type work (#66) exists to avoid; apps holding HTML
+  should convert on write.
+
+## Changelog
+
+- **Draft** — initial definition: `text` (required), `title`, `format`.

--- a/docs/commons/note.md
+++ b/docs/commons/note.md
@@ -7,6 +7,11 @@ The most universal shape in personal software, and the anchor of the commons —
 spec's own `isCompatible()` example ("any Type with `{ text: string }`") is this type's
 read-compat core.
 
+Notes are **kept** — working material written by and for the writer, where the writer
+may be a group (a shared stack's collectively maintained minutes and how-tos are still
+notes). For the boundary with `article` (published) and `message` (sent), see
+[Choosing a text type](./text-types.md).
+
 ## Schema
 
 ```ts

--- a/docs/commons/note.md
+++ b/docs/commons/note.md
@@ -31,9 +31,10 @@ await stack.defineType('org.haverstack/note@1', 'Note', {
   them); tag associations for flat labels. Pinning, starring, and read-state are
   perspectives — tags, not content.
 - **Embedded files**: images and other media referenced from `text` are attachment
-  associations with label `embed`. How the body refers to an embedded file (e.g. a
-  markdown image reference) is app territory in @1; a commons convention here is an
-  expected follow-up proposal once `file-ref` fields (#63) land.
+  associations with label `embed` — see the cross-type conventions in the
+  [README](./README.md). How the body refers to an embedded file (e.g. a markdown
+  image reference) is app territory in @1; a commons convention here is an expected
+  follow-up proposal once `file-ref` fields (#63) land.
 - **Cross-references**: a note that is _about_ another record (annotating a bookmark, a
   contact) uses `{ kind: 'relationship', label: 'about', recordId }`.
 

--- a/docs/commons/page.md
+++ b/docs/commons/page.md
@@ -29,18 +29,27 @@ await stack.defineType('org.haverstack/page@1', 'Page', {
   title: { kind: 'string' },
   format: { kind: 'string' },
   publishedAt: { kind: 'date' },
+  collection: {
+    kind: 'object',
+    properties: {
+      typeId: { kind: 'string', required: true },
+      tag: { kind: 'string' },
+      order: { kind: 'string' },
+    },
+  },
 });
 ```
 
 ## Field semantics
 
-| Field         | Kind     | Required | Meaning                                                                                                                                                                                                              |
-| ------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `slug`        | `string` | yes      | This page's **path segment** — not the full path. URL-safe, lowercase, no slashes. The full path is derived by walking `parentId` ancestors (see conventions). The page's structural identity: what makes it a page. |
-| `text`        | `text`   | yes      | The body.                                                                                                                                                                                                            |
-| `title`       | `string` | no       | Display/`<title>` text. Absent means the app derives one (from `slug`, or none for a homepage).                                                                                                                      |
-| `format`      | `string` | no       | Same vocabulary and defaults as `note`/`article`: `"markdown"` (default), `"plain"`.                                                                                                                                 |
-| `publishedAt` | `date`   | no       | Absent means draft — same convention as `article`. Generators skip drafts by default.                                                                                                                                |
+| Field         | Kind     | Required | Meaning                                                                                                                                                                                                                                                                                                                                                                                               |
+| ------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `slug`        | `string` | yes      | This page's **path segment** — not the full path. URL-safe, lowercase, no slashes. The full path is derived by walking `parentId` ancestors (see conventions). The page's structural identity: what makes it a page.                                                                                                                                                                                  |
+| `text`        | `text`   | yes      | The body.                                                                                                                                                                                                                                                                                                                                                                                             |
+| `title`       | `string` | no       | Display/`<title>` text. Absent means the app derives one (from `slug`, or none for a homepage).                                                                                                                                                                                                                                                                                                       |
+| `format`      | `string` | no       | Same vocabulary and defaults as `note`/`article`: `"markdown"` (default), `"plain"`.                                                                                                                                                                                                                                                                                                                  |
+| `publishedAt` | `date`   | no       | Absent means draft — same convention as `article`. Generators skip drafts by default.                                                                                                                                                                                                                                                                                                                 |
+| `collection`  | `object` | no       | Present means this page is a **collection root** — it renders its own `text` as intro, then the records its query selects (see conventions). `typeId` names the member type; `tag` optionally narrows to records carrying that tag; `order` is `"newest"` (default), `"oldest"`, or `"title"` — newest/oldest by the type's meaningful date (`publishedAt` where the type has one, else `createdAt`). |
 
 ## Conventions
 
@@ -62,14 +71,24 @@ await stack.defineType('org.haverstack/page@1', 'Page', {
   chronological collection (permalinks derived from `publishedAt`/`title` are the
   generator's business) and pages → the site tree. If a post genuinely needs a
   hand-placed path, that's the generator's permalink override — sidecar, not commons.
-- **Collection membership is a query, not a field.** For the common single-site case,
-  the generator's collection is simply every `article` with `publishedAt` set —
-  publishing _is_ setting `publishedAt`; nothing else is recorded. When selection must
-  be narrower (multiple sites from one stack, guest posts published elsewhere), the
-  generator narrows its query — by `parentId` to its site record, or by a tag its
-  config names. A stored "on this site" flag would be a stale-able cache of that
-  query, so none exists. The generator stamps the article's canonical `url` at first
-  publish (see `article.md`).
+- **Collection membership is a query, not a field — and `collection` stores the
+  query, never the members.** Same split as `poll`: store the question, compute the
+  answer. A page with `collection` is a collection root, and the rule travels with the
+  site instead of dying in one generator's config — which is the type's whole
+  anti-lock-in purpose applied to its most important structural fact ("where the blog
+  lives"). Members are records of `typeId` (narrowed by `tag` if present) that the
+  member type's own draft convention admits — for `article`, `publishedAt` present;
+  for types without one, all records. Member permalinks default to paths under the
+  root (`/blog/my-post/`), overridable in the sidecar. Examples: the blog is
+  `{ slug: 'blog', collection: { typeId: 'org.haverstack/article@1' } }`; a tag
+  archive adds `tag: 'travel'`; a gallery is `typeId: 'org.haverstack/photo@1'`; a
+  linkroll is `typeId: 'org.haverstack/bookmark@1'`. The shape is deliberately a
+  restricted, schema-validated vocabulary rather than a stored full `Query` object —
+  it covers what site structure actually needs, grows additively (`limit`,
+  `parentId`-scoping are anticipated), and anything more exotic is generator sidecar
+  territory. A stored "on this site" membership flag remains banned as a stale-able
+  cache. The generator stamps each member article's canonical `url` at first publish
+  (see `article.md`).
 
 ## Read-compat core
 
@@ -96,3 +115,6 @@ your site's about page in your notes app is a legitimate and intended consequenc
 
 - **Draft** — initial definition: `slug`, `text` (required), `title`, `format`,
   `publishedAt`.
+- **Draft, amended** — optional `collection` field added (additive, in place):
+  collection roots carry their selection rule so site structure survives switching
+  generators.

--- a/docs/commons/page.md
+++ b/docs/commons/page.md
@@ -62,6 +62,14 @@ await stack.defineType('org.haverstack/page@1', 'Page', {
   chronological collection (permalinks derived from `publishedAt`/`title` are the
   generator's business) and pages → the site tree. If a post genuinely needs a
   hand-placed path, that's the generator's permalink override — sidecar, not commons.
+- **Collection membership is a query, not a field.** For the common single-site case,
+  the generator's collection is simply every `article` with `publishedAt` set —
+  publishing _is_ setting `publishedAt`; nothing else is recorded. When selection must
+  be narrower (multiple sites from one stack, guest posts published elsewhere), the
+  generator narrows its query — by `parentId` to its site record, or by a tag its
+  config names. A stored "on this site" flag would be a stale-able cache of that
+  query, so none exists. The generator stamps the article's canonical `url` at first
+  publish (see `article.md`).
 
 ## Read-compat core
 

--- a/docs/commons/page.md
+++ b/docs/commons/page.md
@@ -1,0 +1,90 @@
+# `org.haverstack/page@1` — Page
+
+> **Status:** Draft. Intended writer: a static-site-generator integration reading a
+> stack (in progress by the project maintainer — either a standalone generator or an
+> Eleventy data source).
+
+A node in a website's structure: the about page, the colophon, the landing page. The
+boundary against [`article`](./article.md): **an article is a work in a feed
+(chronological, canonical URL, stands alone); a page is a location in a site tree**
+(structural identity via slug and hierarchy). A typical personal site is a handful of
+`page` records plus a stream of `article` records.
+
+The interop this type exists for is escaping static-site-generator lock-in: today a
+site's content is trapped in one generator's front-matter dialect and directory layout;
+as stack records, the same site content can be built by any generator with a stack
+integration.
+
+Prior art: every SSG's front matter (Jekyll/Hugo/Eleventy), WordPress's page-vs-post
+distinction, CMS content models. The design keeps what they agree on (slug, title,
+body, published state) and pushes what they fight about (layout, templates, navigation
+order) to app sidecars.
+
+## Schema
+
+```ts
+await stack.defineType('org.haverstack/page@1', 'Page', {
+  slug: { kind: 'string', required: true },
+  text: { kind: 'text', required: true },
+  title: { kind: 'string' },
+  format: { kind: 'string' },
+  publishedAt: { kind: 'date' },
+});
+```
+
+## Field semantics
+
+| Field         | Kind     | Required | Meaning                                                                                                                                                                                                              |
+| ------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `slug`        | `string` | yes      | This page's **path segment** — not the full path. URL-safe, lowercase, no slashes. The full path is derived by walking `parentId` ancestors (see conventions). The page's structural identity: what makes it a page. |
+| `text`        | `text`   | yes      | The body.                                                                                                                                                                                                            |
+| `title`       | `string` | no       | Display/`<title>` text. Absent means the app derives one (from `slug`, or none for a homepage).                                                                                                                      |
+| `format`      | `string` | no       | Same vocabulary and defaults as `note`/`article`: `"markdown"` (default), `"plain"`.                                                                                                                                 |
+| `publishedAt` | `date`   | no       | Absent means draft — same convention as `article`. Generators skip drafts by default.                                                                                                                                |
+
+## Conventions
+
+- **Hierarchy is `parentId`.** A page whose parent is another page is nested under it:
+  `slug: "history"` under a page with `slug: "about"` builds at `/about/history/`. A
+  page with no page ancestor is at the site root. Homepages use slug `index` by
+  convention, mapping to the tree position's own path.
+- **The site container is app territory** — same posture as task lists and photo
+  albums. An app managing multiple sites parents each site's root pages to its own
+  site record; single-site setups need no container at all. What interops is the pages.
+- **Uniqueness of paths** (no two siblings sharing a slug) is a writer obligation, not
+  schema-enforceable; generators should fail loudly on collision rather than pick one.
+- **Layout, template, navigation order, front-matter extras** — the fields generators
+  disagree on — live in the generating app's sidecar type, linked by a `relationship`
+  association. A page with no sidecar must still build sensibly (default template).
+- **Embedded media**: attachment associations with label `embed`, per the cross-type
+  convention.
+- **Blog posts are `article`, not `page`.** A generator maps articles → the
+  chronological collection (permalinks derived from `publishedAt`/`title` are the
+  generator's business) and pages → the site tree. If a post genuinely needs a
+  hand-placed path, that's the generator's permalink override — sidecar, not commons.
+
+## Read-compat core
+
+```ts
+{
+  slug: { kind: 'string', required: true },
+  text: { kind: 'text', required: true },
+}
+```
+
+Also satisfies `note`'s `{ text }` core, so notes apps can read pages too — editing
+your site's about page in your notes app is a legitimate and intended consequence.
+
+## Deliberately excluded
+
+- `layout`/`template` — the most app-specific field in every front-matter dialect.
+- Navigation order/menus — a perspective of the site structure; sidecar.
+- Full-path slugs — deriving the path from the tree keeps moves (re-parenting) atomic
+  and collision rules local; a denormalized full path would go stale.
+- Redirects/aliases — future additive candidate once a real generator needs it
+  (`aliases: array<string>` is the likely shape, prior art in Hugo/Jekyll).
+
+## Changelog
+
+- **Draft** — initial definition: `slug`, `text` (required), `title`, `format`,
+  `publishedAt`.

--- a/docs/commons/photo.md
+++ b/docs/commons/photo.md
@@ -1,0 +1,63 @@
+# `org.haverstack/photo@1` — Photo
+
+> **Status:** Staged — blocked on `file-ref` fields (#63). The design is recorded now
+> so intent is fixed; **do not register this type until #63 lands** and this file is
+> promoted to Draft.
+
+An image as a first-class object — the photo-library / Tumblr-photo-post shape — as
+opposed to an image illustrating some other record (which is just an attachment
+association on that record). A photo record is "this image is in my library": the
+binary plus caption, alt text, and capture time.
+
+## Why staged
+
+The essential field of a photo is the image itself, but type schemas validate `content`
+only: a "required attachment association" would be a convention the schema can't
+enforce and `isCompatible()` can't see. Issue #63's `file-ref` field kind fixes exactly
+this — making `photo` its first and motivating consumer. Shipping earlier with a
+convention-only image, then making a `file-ref` field required later, would force a
+version bump for no gain; waiting means `photo@1` is right from day one.
+
+## Schema (pending #63)
+
+```ts
+await stack.defineType('org.haverstack/photo@1', 'Photo', {
+  image: { kind: 'file-ref', required: true },
+  caption: { kind: 'text' },
+  alt: { kind: 'string' },
+  takenAt: { kind: 'date' },
+});
+```
+
+## Field semantics
+
+| Field     | Kind       | Required | Meaning                                                                                                                             |
+| --------- | ---------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `image`   | `file-ref` | yes      | The original image bytes (content-addressed). The photo _is_ this file.                                                             |
+| `caption` | `text`     | no       | What the user says about it. Markdown by convention.                                                                                |
+| `alt`     | `string`   | no       | Accessibility description of the image content — a property of the image (describes the bytes), not a perspective; travels with it. |
+| `takenAt` | `date`     | no       | Capture time (typically from EXIF). Distinct from `createdAt`, which is when the record entered the stack (import time).            |
+
+## Conventions (to finalize at promotion)
+
+- **Geotag**: the cross-type `location` relationship to a [`place`](./place.md)
+  record — not raw coordinates in content.
+- **Albums**: `parentId` to an app's album/container record — same posture as task
+  lists and site containers; the photos interop, the album doesn't.
+- **Variants** (thumbnails, resizes, edited versions): derived data, not commons
+  content — apps regenerate them. A destructive edit is a new photo record; link it
+  `{ kind: 'relationship', label: 'derived-from', recordId }`.
+- **EXIF beyond `takenAt`** (camera, lens, exposure): excluded from @1; a future
+  additive optional `object` field or sidecar, decided when a real writer needs it.
+- **Video/audio**: sibling proposals, not a generalized `media` type — photo-specific
+  prior art (EXIF, photo libraries) is too good to dilute.
+
+## Read-compat core (pending #63)
+
+```ts
+{ image: { kind: 'file-ref', required: true } }
+```
+
+## Changelog
+
+- **Staged** — design recorded; registration blocked on #63 (`file-ref` field kind).

--- a/docs/commons/place.md
+++ b/docs/commons/place.md
@@ -1,0 +1,78 @@
+# `org.haverstack/place@1` — Place
+
+> **Status:** Draft.
+
+A point on Earth the user cares about: a venue, a saved spot, a dropped pin. The durable
+half of the check-in pattern — the venue directory — modeled as its own type, while "I
+was here" is deliberately _not_ a type (see conventions): any record can be located by
+pointing at a place.
+
+Prior art: geo URI (RFC 5870), GeoJSON, vCard `GEO`, schema.org/Place. Coordinates are
+named fields rather than a GeoJSON-style array precisely because GeoJSON's
+`[longitude, latitude]` ordering is one of software's most reliably fumbled conventions.
+
+## Schema
+
+```ts
+await stack.defineType('org.haverstack/place@1', 'Place', {
+  latitude: { kind: 'number', required: true },
+  longitude: { kind: 'number', required: true },
+  name: { kind: 'string' },
+  address: { kind: 'string' },
+  url: { kind: 'string' },
+});
+```
+
+## Field semantics
+
+| Field       | Kind     | Required | Meaning                                                                                                                                                                             |
+| ----------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `latitude`  | `number` | yes      | WGS 84 decimal degrees, −90 to 90. A place is meaningless without coordinates.                                                                                                      |
+| `longitude` | `number` | yes      | WGS 84 decimal degrees, −180 to 180.                                                                                                                                                |
+| `name`      | `string` | no       | What the user calls it ("Café Grumpy", "Mom's house"). Absent means an unnamed dropped pin. Names are the user's — a perspective they own — not authoritative venue-database names. |
+| `address`   | `string` | no       | Freeform, as the user or source formatted it. Structured postal addresses follow the same deferral as `contact`'s.                                                                  |
+| `url`       | `string` | no       | The place's website or a canonical map/venue link.                                                                                                                                  |
+
+## Conventions
+
+- **Locating any record — the `location` relationship.** The check-in, the geotagged
+  photo, the note written at a café are all the same move:
+  `{ kind: 'relationship', label: 'location', recordId: <place record id> }` on the
+  located record. This is a cross-type convention (see README): a check-in app is just
+  place records plus (possibly caption-less) records pointing at them, and every other
+  app's records get geotagging for free. A bare check-in — nothing to say beyond "I was
+  here" — is an empty-text `note` with a `location` association; its `createdAt` is the
+  check-in time.
+- **Deduplication** is app-side: two records with the same coordinates are two records.
+  An app importing venues should query by exact coordinates before creating.
+- **No geo queries.** The query engine has no spatial capability and content filters
+  are exact-match only, so "places near me" is app-side computation over fetched
+  records. Fine at personal scale; recorded here so nobody discovers it by surprise.
+- **Altitude, radius/extent, bounding shapes** — excluded from @1; additive candidates
+  if a real writer needs them (geo URI's third coordinate is the prior art for
+  altitude).
+
+## Read-compat core
+
+```ts
+{
+  latitude:  { kind: 'number', required: true },
+  longitude: { kind: 'number', required: true },
+}
+```
+
+Anything with required numeric coordinates — a weather station, a photo spot, a transit
+stop from some richer app type — can appear on a map consumer's map.
+
+## Deliberately excluded
+
+- Check-in as a type — it's the `location` convention plus any record (see above).
+- Venue-database identifiers (OSM node IDs, Foursquare venue IDs, Google place IDs) —
+  app sidecar territory; the commons place is the _user's_ place, not a mirror of
+  someone's database row.
+- Visit history, ratings, favorites — perspectives; tags and sidecars.
+
+## Changelog
+
+- **Draft** — initial definition: `latitude`, `longitude` (required), `name`,
+  `address`, `url`.

--- a/docs/commons/place.md
+++ b/docs/commons/place.md
@@ -40,9 +40,13 @@ await stack.defineType('org.haverstack/place@1', 'Place', {
   `{ kind: 'relationship', label: 'location', recordId: <place record id> }` on the
   located record. This is a cross-type convention (see README): a check-in app is just
   place records plus (possibly caption-less) records pointing at them, and every other
-  app's records get geotagging for free. A bare check-in — nothing to say beyond "I was
-  here" — is an empty-text `note` with a `location` association; its `createdAt` is the
-  check-in time.
+  app's records get geotagging for free. **A check-in's type follows its contract**
+  (see [Choosing a text type](./text-types.md)): the private location-diary entry —
+  "I was here," addressed to no one — is a (possibly empty-text) `note` with a
+  `location` association, its `createdAt` the check-in time; "I'm at the café, come
+  join me" sent to a group is a `message` with one; the Foursquare-style public
+  check-in is the future broadcast `post` (#15) with one. The `location` association
+  is the invariant; the contract varies with the act.
 - **Deduplication** is app-side: two records with the same coordinates are two records.
   An app importing venues should query by exact coordinates before creating.
 - **No geo queries.** The query engine has no spatial capability and content filters

--- a/docs/commons/poll.md
+++ b/docs/commons/poll.md
@@ -1,0 +1,122 @@
+# `org.haverstack/poll@1` + `org.haverstack/vote@1` — Poll & Vote
+
+> **Status:** Proposed — awaiting an intended writer (a group-decisions app). Lives in
+> the group cluster. Defined as a pair in one file because neither type means anything
+> without the other.
+
+Group decision-making: the one-off voting platform and the when-to-meet scheduler are
+the same primitive — a question with options, answered per-member. A scheduling poll is
+simply a poll whose options carry time slots; the winning slot gets promoted to a real
+[`event`](./event.md).
+
+The design leans on the stack's native machinery harder than any other commons type:
+each member's ballot is a **record they author** (`entityId` = voter, set natively),
+revising a ballot is an ordinary update (version history = a free audit trail), and
+who-may-vote is a grant on `vote@1` — the permission system is the election official.
+
+Prior art: ActivityStreams `Question` (Mastodon polls), Doodle/when2meet, Loomio,
+Condorcet/approval balloting literature for the method vocabulary.
+
+## Schema
+
+```ts
+await stack.defineType('org.haverstack/poll@1', 'Poll', {
+  question: { kind: 'string', required: true },
+  options: {
+    kind: 'array',
+    required: true,
+    items: {
+      kind: 'object',
+      properties: {
+        id: { kind: 'string', required: true },
+        label: { kind: 'string', required: true },
+        startsAt: { kind: 'date' },
+        endsAt: { kind: 'date' },
+      },
+    },
+  },
+  method: { kind: 'string' },
+  closesAt: { kind: 'date' },
+  details: { kind: 'text' },
+});
+
+await stack.defineType('org.haverstack/vote@1', 'Vote', {
+  pollId: { kind: 'record-ref', required: true },
+  choices: {
+    kind: 'array',
+    required: true,
+    items: {
+      kind: 'object',
+      properties: {
+        optionId: { kind: 'string', required: true },
+        response: { kind: 'string' },
+      },
+    },
+  },
+});
+```
+
+## Field semantics — `poll@1`
+
+| Field      | Kind     | Required | Meaning                                                                                                                                                                                                                                                                                                            |
+| ---------- | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `question` | `string` | yes      | What's being decided.                                                                                                                                                                                                                                                                                              |
+| `options`  | `array`  | yes      | The choices. Each has a stable `id` (identity — never reused or repurposed), a `label`, and optionally `startsAt`/`endsAt` when the option is a time slot (the when-to-meet case).                                                                                                                                 |
+| `method`   | `string` | no       | How ballots are counted. Well-known values: `"single"` (default when absent — pick one) and `"multiple"` (pick any). An open vocabulary by design (`"ranked"`, `"score"` are anticipated proposals). Consumers seeing an unknown method must display raw ballots and refuse to compute a result rather than guess. |
+| `closesAt` | `date`   | no       | Voting deadline. Absent means open until the poll is soft-deleted or superseded.                                                                                                                                                                                                                                   |
+| `details`  | `text`   | no       | Context for the decision. Markdown by convention.                                                                                                                                                                                                                                                                  |
+
+## Field semantics — `vote@1`
+
+| Field     | Kind         | Required | Meaning                                                                                                                                                                                                                                                                                                                               |
+| --------- | ------------ | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pollId`  | `record-ref` | yes      | The poll this ballot answers. A top-level scalar, so "all ballots for poll X" is one exact-match content query.                                                                                                                                                                                                                       |
+| `choices` | `array`      | yes      | The endorsed options, **most-preferred first** (ordering is significant now so ranked methods can arrive without a version bump). Each entry names an `optionId` and optionally a `response`: well-known values `"yes"` (default when absent) and `"maybe"` (the when-to-meet "if need be"). An option absent from `choices` is a no. |
+
+## Conventions
+
+- **One ballot per member per poll.** Revoting is updating your existing `vote` record,
+  not creating a second — a writer obligation (query `pollId` + own `entityId` before
+  creating), with version history preserving every revision. Duplicate ballots from a
+  buggy writer: latest `updatedAt` wins, consumers warn.
+- **Results are computed, never stored.** Any member's app tallies by reading ballots;
+  a stored result would go stale and would have an author.
+- **Option lists may grow while open** (append-only, new `id`s); changing or removing
+  voted-on options is the poll author starting over with a new poll. `closesAt`
+  enforcement is a writer obligation — consumers must ignore ballots whose `updatedAt`
+  postdates it.
+- **Ballot visibility is the grant system, and @1 is honest about it: polls are open
+  ballot by default.** Members with read access to the group's records see who voted
+  for what — right for when-to-meet and most small-group decisions. A semi-secret
+  ballot already falls out of the primitives: grant members `create`/`read-own`/
+  `update-own` (but not `read-any`) on `vote@1`, and only the group owner can tally and
+  post results. True secret ballots (nobody, including the owner, learns individual
+  votes) are cryptographic territory the commons does not pretend to cover.
+- **When-to-meet, end to end**: poll with `method: "multiple"` and time-slot options;
+  members respond with `"yes"`/`"maybe"` per slot; the organizer promotes the winning
+  slot to an `event@1` and links it
+  `{ kind: 'relationship', label: 'decided-by', recordId: <poll> }`.
+
+## Read-compat cores
+
+```ts
+// poll
+{ question: { kind: 'string', required: true }, options: { kind: 'array', required: true } }
+// vote
+{ pollId: { kind: 'record-ref', required: true }, choices: { kind: 'array', required: true } }
+```
+
+## Deliberately excluded
+
+- Stored results/tallies — computed, see conventions.
+- Anonymous ballots — `ScopedStack.create()` always stamps the requester's `entityId`,
+  and pretending otherwise would be a lie; see ballot visibility above.
+- Quorum/threshold rules — the deciding app's policy (sidecar on the poll), not ballot
+  data.
+- Delegation/proxy voting (liquid democracy) — real prior art (Loomio, LiquidFeedback)
+  but a method + trust model, not a field; future proposal.
+
+## Changelog
+
+- **Proposed** — initial definition: `poll@1` (`question`, `options` required;
+  `method`, `closesAt`, `details`), `vote@1` (`pollId`, `choices` required).

--- a/docs/commons/poll.md
+++ b/docs/commons/poll.md
@@ -75,6 +75,17 @@ await stack.defineType('org.haverstack/vote@1', 'Vote', {
 
 ## Conventions
 
+- **Why `pollId` is content, not `parentId`.** A ballot's poll is a _constitutive_
+  reference (see README rule 5): required — schema validation rejects a poll-less vote
+  at write time, which `parentId` (native, unrequirable) never could — homogeneous
+  (always a poll, unlike a `message`'s anchor, which is optional and can be any
+  record), and immutable in spirit: re-parenting is legal, ordinary behavior elsewhere
+  in the commons, but a re-targeted ballot is fraud-shaped, so the reference lives
+  where repointing is a visible, versioned content edit. The honest trade: `parentId`
+  filtering is natively indexed on every adapter, while `content: { pollId }` needs
+  the `contentFieldQuery` capability — on adapters without it, tallying degrades to
+  fetch-and-scan of `vote@1` records, which is fine at this project's stated scale
+  (small cohesive groups) and recorded here so nobody discovers it by surprise.
 - **One ballot per member per poll.** Revoting is updating your existing `vote` record,
   not creating a second — a writer obligation (query `pollId` + own `entityId` before
   creating), with version history preserving every revision. Duplicate ballots from a

--- a/docs/commons/task.md
+++ b/docs/commons/task.md
@@ -1,0 +1,66 @@
+# `org.haverstack/task@1` — Task
+
+> **Status:** Draft.
+
+A to-do item: something with a description and a done-ness. Prior art (todo.txt,
+iCalendar VTODO, every task app's export format) agrees on remarkably little beyond
+that pair — so that pair is the required core, and the rest is optional.
+
+## Schema
+
+```ts
+await stack.defineType('org.haverstack/task@1', 'Task', {
+  title: { kind: 'string', required: true },
+  done: { kind: 'boolean', required: true },
+  notes: { kind: 'text' },
+  due: { kind: 'date' },
+  completedAt: { kind: 'date' },
+});
+```
+
+## Field semantics
+
+| Field         | Kind      | Required | Meaning                                                                                                                                                                                                      |
+| ------------- | --------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `title`       | `string`  | yes      | What needs doing. Single line by convention.                                                                                                                                                                 |
+| `done`        | `boolean` | yes      | Whether it's complete. Required (not optional-absent-means-open) so that it is a top-level scalar every adapter can filter on: `content: { done: false }` is _the_ query of every task app.                  |
+| `notes`       | `text`    | no       | Longer description. Markdown by convention.                                                                                                                                                                  |
+| `due`         | `date`    | no       | When it's due. A deadline, not a calendar block — tasks with rich scheduling belong to a future `event` proposal.                                                                                            |
+| `completedAt` | `date`    | no       | When it was completed. Writers should set it when setting `done: true` and clear it (write `null`, per the #69 merge-patch semantics) when un-completing. If `done` and `completedAt` disagree, `done` wins. |
+
+## Conventions
+
+- **Lists and subtasks**: `parentId`. A task whose parent is another task is a subtask;
+  a task whose parent is a non-task record (an app's list/project record) is grouped
+  under it. Commons deliberately does not define a `list` type in @1 — apps' project
+  containers differ too much; what interops is the tasks themselves.
+- **Ordering** within a list is a perspective (every app sorts differently) — app
+  sidecar, not content.
+- **Priority** is deliberately not in @1: prior-art vocabularies conflict (P1–P4,
+  high/medium/low, 0–9) and most shared tasks don't carry one. Expected as a follow-up
+  proposal with a single well-known string vocabulary, landing additively.
+- **Blocking relationships**: `{ kind: 'relationship', label: 'blocked-by', recordId }`.
+
+## Read-compat core
+
+```ts
+{
+  title: { kind: 'string', required: true },
+  done:  { kind: 'boolean', required: true },
+}
+```
+
+## Deliberately excluded
+
+- `status` string vocabularies (`open`/`in-progress`/`blocked`/…) — richer workflow
+  states vary per app; `done` is the interoperable bit. An app with a status field keeps
+  it in a sidecar and projects it to `done`.
+- Recurrence — recurrence rules are the hardest part of iCalendar for a reason; they go
+  with the future `event` proposal, not here.
+- `assignee` — `entityId` is the author; assignment semantics inside a shared stack
+  should be designed alongside the group/grant reshape (#57/#58), not guessed at now.
+
+## Changelog
+
+- **Draft** — initial definition: `title`, `done` (required), `notes`, `due`,
+  `completedAt`.

--- a/docs/commons/text-types.md
+++ b/docs/commons/text-types.md
@@ -146,6 +146,39 @@ relationship shape (`recordId`). Commons labels (`reply-to`, `about`, `location`
 `series`, …) are orthogonal to #16's `target` union and ride on it unchanged — no
 commons redesign is implied by that RFC landing.
 
+## On the names
+
+Two serious prior-art bodies use "note" for the public short utterance — the IndieWeb's
+post-type taxonomy, and ActivityStreams 2.0, where a Mastodon toot is literally a `Note`
+object on the wire. That collision was considered, and the commons keeps its names
+anyway, for reasons worth recording so the question isn't reopened by every reader who
+arrives with fediverse reflexes:
+
+- **Their choice is principled — for a universe this commons doesn't live in.** Both
+  vocabularies describe only published/social content. On the IndieWeb, "post" is the
+  _superclass_ (every entry on your site is a post; post-type discovery subdivides
+  posts into article, note, photo, reply, …), so "note" was the available name for the
+  small unnamed kind — and since everything in that universe is already public, no
+  private meaning competed for the word. Haverstack's defining axis is exactly the one
+  those vocabularies lack: records are private by default, and most never leave the
+  stack. In this universe "note" reverts to what it means in the software users touch
+  daily — Apple Notes, OneNote, Evernote, Obsidian: the kept, private thing — which
+  outweighs the fediverse usage by orders of magnitude of humans. Meanwhile "post" as
+  the broadcast utterance is what the rest of the world says, and what ATProto itself
+  uses (`app.bsky.feed.post`).
+- **The verb test.** Each name conjugates with its own contract: you _keep_ notes,
+  _send_ messages, _publish_ articles, _broadcast_ posts. Names that verb correctly
+  get used correctly without consulting this guide; "note" for a public utterance fails
+  the test inside this system.
+- **The collision cost is one translation line, at the layer built for translation.**
+  Microformats never put a type name on the wire (post-type is discovered from
+  properties), so there is no IndieWeb wire collision at all. The AS2 collision
+  surfaces exactly once — a future ActivityPub bridge maps `post` → AS2 `Note` in its
+  translation table, the same mechanism as #15's `lexiconId`.
+- **The word was never stable anyway.** Facebook "Notes" was a _long-form articles_
+  feature — a third, opposite usage. There is no uncontested name to find; the defense
+  is precise contracts here and explicit mappings at the bridges.
+
 ## Consequences for app authors
 
 - **Consumers key UX on `typeId`.** A reading app renders articles with bylines and

--- a/docs/commons/text-types.md
+++ b/docs/commons/text-types.md
@@ -84,14 +84,64 @@ So a comment is a **`message` whose `parentId` is the article** — which is why
 superficially resembles a comment but fails the test — a reader's private annotation —
 is a `note` with an `about` relationship. Both exist; the test separates them.
 
-## The fourth contract, deliberately not covered here
+## The fourth contract: posts are broadcast
 
-Public broadcast — speech addressed to whoever listens, rather than to a bounded
-audience that a stack's membership defines — is a distinct contract (**posts are
-broadcast**), and it is deliberately outside this guide. It is the territory of the
-ATProto-compat RFC (#15): a broadcast utterance needs self-certified authorship (#49)
-and cross-stack reference, neither of which bounded-audience `message` records require.
-Neither `message` nor `article` should absorb it.
+A social media post _is_ speech — moment-indexed, conversational, tamper-evident,
+unnamed — so the instinct "a tweet is a message" is right about its nature. But the
+contracts encode two things, and speech-ness is only one. The other is **audience
+shape**: a `message`'s audience is defined by a boundary (presence in the stack _is_
+the addressing — the reason `message` has no `to`/`cc`), while a post's audience is
+whoever listens: unbounded and unenumerable. That completes a 2×2, and the fourth cell
+is deliberately outside this guide:
+
+|              | Bounded audience              | Unbounded audience                 |
+| ------------ | ----------------------------- | ---------------------------------- |
+| **Artifact** | `note` (kept — self or group) | `article` / `page` (published)     |
+| **Speech**   | `message` (sent)              | **`post` (broadcast)** — see below |
+
+(Naming trap from prior art: the IndieWeb's "note" post-type is a public short
+utterance — _their_ note is our `post`, not our `note`.)
+
+`post` must be its own type rather than a `message` with `{ access: 'public' }`, for
+four mechanical reasons, not just taxonomy:
+
+1. **Sync blast radius.** Outbound bridges map _types_ to external shapes (#15's
+   `lexiconId` maps a type to an ATProto `$type`), so the type is the sync boundary.
+   "Everything of type `post` is meant for the world" is an invariant a bridge can
+   enforce; "messages whose permissions happen to be public" puts a group's private
+   thread one permission bug away from the public firehose.
+2. **Different threading fabric.** A message thread is `parentId` — within-stack, one
+   trust domain, one indexed query. A post's conversation is inherently cross-stack:
+   a reply lives in the replier's stack, referencing a record in someone else's, which
+   `parentId` cannot express and #16's `target` union
+   (`{ scope: 'internal', recordId, stackUrl }` / `{ scope: 'external', id, ns }`)
+   exists to express. Posts-as-messages would hand board apps threads whose parents
+   they structurally cannot traverse.
+3. **Different deletion physics.** Inside a stack, recoverability is real: "anything a
+   write-holder does, the owner can undo" (#59). Broadcast breaks it — the network has
+   copies; deletion is a request (ATProto's tombstones exist because of this). The type
+   boundary keeps the commons honest about which text lives under which physics.
+4. **Different authorship requirements.** In-stack, `entityId` means author because
+   the stack is a trust domain. A broadcast utterance travels _without_ its stack, so
+   authorship must be self-certifying — the #49 DID work, surfaced in #15's revised
+   `externalIds` on `EntityContent`. `message` needs none of it; `post` can't exist
+   without it.
+
+The dependency chain is therefore: **#16** (cross-stack/cross-protocol reference
+fabric, plus its `relatedTo`/capability follow-up so external references are
+queryable) → **#49** (self-certified identity) → **#15 as revised** (protocol-neutral
+core hooks; ATProto-specific machinery in `adapter-atproto`) → a `post@1` proposal
+here, as the _protocol-neutral_ broadcast utterance: the canonical copy lives in your
+stack; bridges syndicate it (`adapter-atproto` maps it to `app.bsky.feed.post`, an
+ActivityPub bridge to a `Note`) and replies come home as external-target
+relationships. That is the IndieWeb's POSSE pattern — publish on your own site,
+syndicate elsewhere — with real primitives underneath: Bluesky and Mastodon become
+views of a record you own.
+
+One forward-compatibility note: `message`'s quote-reply convention uses today's flat
+relationship shape (`recordId`). Commons labels (`reply-to`, `about`, `location`,
+`series`, …) are orthogonal to #16's `target` union and ride on it unchanged — no
+commons redesign is implied by that RFC landing.
 
 ## Consequences for app authors
 

--- a/docs/commons/text-types.md
+++ b/docs/commons/text-types.md
@@ -72,6 +72,9 @@ that being read as a finished work is its purpose.
 | Recipe in your kitchen file                  | `note`                       | Kept.                                                                                    |
 | Same recipe on your blog                     | `article`                    | Published. The type records the act, not the text.                                       |
 | Sharing a link into the group ("read this!") | `message` (+ rel.)           | The commentary is speech; the shared bookmark/article stays an artifact, linked.         |
+| Check-in, private location diary             | `note` (+ `location`)        | A journal entry with coordinates — addressed to no one.                                  |
+| "I'm at the café — come join me" (group)     | `message` (+ `location`)     | Speech; the `location` association is the invariant across every check-in contract.      |
+| Foursquare-style public check-in             | _deferred (#15)_             | Broadcast speech — `post` + `location` once the fourth contract lands.                   |
 | Social media post                            | _deferred (#15)_             | A fourth contract — public broadcast — see below.                                        |
 
 ## Comments are messages; marginalia are notes

--- a/docs/commons/text-types.md
+++ b/docs/commons/text-types.md
@@ -1,0 +1,108 @@
+# Choosing a text type — note, article, message
+
+> **Status:** Draft guide. Companion to [`note.md`](./note.md), [`article.md`](./article.md),
+> and [`message.md`](./message.md); this document is the tiebreaker when a text record
+> could plausibly be more than one of them.
+
+Three commons types carry free-form text, and their schemas are nearly identical —
+`note` and `message` differ by one optional string; `article` adds a required title.
+That is not a gap to be closed with more fields, because the distinction between them
+was never structural. **The `typeId` records the social contract: what was _done_ with
+the text, not what the text is.** The same paragraph can legitimately exist under all
+three types, and the type is what tells every other app how to treat it.
+
+## The three contracts
+
+> **Notes are kept. Messages are sent. Articles are published.**
+
+- A **note** is _working material_: kept by and for the writer. Its current state is
+  the record; editing forever is its normal mode; nobody receives it. In a group stack
+  **the group is the writer** — collectively maintained documents (meeting minutes, a
+  "how to open the clubhouse" how-to) are still notes, because they are the group's own
+  working material.
+- A **message** is _speech_: addressed to others as a move in a conversation. Its
+  meaning is indexed to its moment and its thread — `createdAt` is part of the content's
+  meaning ("when you said it") — and editing after others have read it is tampering
+  (edits are corrections, and versioning keeps them honest).
+- An **article** is _a work_: composed to be read as a standalone, named thing, with a
+  publication lifecycle (draft → published). Its published state is what matters; the
+  byline and canonical URL exist because a work is _presented_ to readers, not sent to
+  recipients.
+
+## The test — ordered, which is what resolves the hard cases
+
+1. **Was it sent into a conversation?** → `message`
+2. **Is it published, or meant to be, as a named work?** → `article`
+3. **Otherwise** → `note`
+
+The ordering does real work. A journal entry is time-indexed and never edited —
+message-_like_ — but it is addressed to no one, so step 1 fails and it lands at `note`:
+temporality alone doesn't make speech; **address does**. A newsletter issue is
+literally _sent_, but not conversationally — recipients are not parties to a thread and
+its meaning doesn't depend on a position in one — so it passes through step 1 and lands
+at `article`: sending-as-distribution is not sending-as-speech.
+
+Likewise, "has a title" is necessary for `article` but not sufficient: a note may be
+titled ("2026-07 meeting minutes") without becoming a work. What makes an article is
+that being read as a finished work is its purpose.
+
+## What the clock and the edit button mean
+
+|           | Meaningful time                    | What editing means               |
+| --------- | ---------------------------------- | -------------------------------- |
+| `note`    | none — current state is the record | the point                        |
+| `message` | `createdAt` — when it was said     | correction; visible via versions |
+| `article` | `publishedAt` — deliberate         | revision/errata once published   |
+
+## Worked examples
+
+| Case                                         | Type                         | Why                                                                                      |
+| -------------------------------------------- | ---------------------------- | ---------------------------------------------------------------------------------------- |
+| Comment on a blog post                       | `message`                    | Sent into a shared space, anchored to the post (`parentId` → the article), time-indexed. |
+| Private marginalia while reading             | `note` (+ `about` rel.)      | Kept, not sent — your annotation, invisible to the conversation.                         |
+| Draft blog post                              | `article` (no `publishedAt`) | Already a work-in-becoming; drafthood is a lifecycle stage, not a different type.        |
+| Scribbled idea for a post                    | `note`                       | Working material; promote to `article` later (new record, `derived-from` relationship).  |
+| Journal / diary entry                        | `note`                       | Time-indexed but addressed to no one — address, not temporality, makes speech.           |
+| Memoir chapter it becomes                    | `article`                    | Now a named work for readers.                                                            |
+| Newsletter issue                             | `article`                    | Distributed, not conversational; archive-space, not conversation-space.                  |
+| Announcement ("practice canceled tomorrow")  | `message`                    | Addressed and moment-indexed even though one-way; its meaning decays with its moment.    |
+| Meeting minutes                              | `note`                       | The group's own working record; optionally _announced_ with a `message` linking to it.   |
+| Group how-to ("opening the clubhouse")       | `note`                       | Living document, current state matters, collectively maintained.                         |
+| Same how-to on the club's public website     | `page`                       | Same text, different act: now a node in a published site.                                |
+| Recipe in your kitchen file                  | `note`                       | Kept.                                                                                    |
+| Same recipe on your blog                     | `article`                    | Published. The type records the act, not the text.                                       |
+| Sharing a link into the group ("read this!") | `message` (+ rel.)           | The commentary is speech; the shared bookmark/article stays an artifact, linked.         |
+| Social media post                            | _deferred (#15)_             | A fourth contract — public broadcast — see below.                                        |
+
+## Comments are messages; marginalia are notes
+
+The blog-comment case is recorded here because it sharpened the whole framing. A
+comment passes the speech test on every axis: addressed to the author and other
+readers, a move in a conversation anchored to the post, moment-indexed, tamper-evident.
+So a comment is a **`message` whose `parentId` is the article** — which is why
+`message`'s threading convention lets _any_ record anchor a thread. The thing that
+superficially resembles a comment but fails the test — a reader's private annotation —
+is a `note` with an `about` relationship. Both exist; the test separates them.
+
+## The fourth contract, deliberately not covered here
+
+Public broadcast — speech addressed to whoever listens, rather than to a bounded
+audience that a stack's membership defines — is a distinct contract (**posts are
+broadcast**), and it is deliberately outside this guide. It is the territory of the
+ATProto-compat RFC (#15): a broadcast utterance needs self-certified authorship (#49)
+and cross-stack reference, neither of which bounded-audience `message` records require.
+Neither `message` nor `article` should absorb it.
+
+## Consequences for app authors
+
+- **Consumers key UX on `typeId`.** A reading app renders articles with bylines and
+  publication dates; a board app renders messages chronologically with authors and
+  reply affordances; a notes app renders an editable current state. Mis-typing a record
+  puts it in the wrong UX in _every other app_, which is why this guide exists.
+- **All three share the `{ text }` read-compat core** — deliberately. Generic text
+  consumers reach everything via `isCompatible()`; the `typeId` is the contract signal
+  for consumers that need to honor it. Reach and semantics are separate mechanisms.
+- **Contracts don't convert in place.** A note becoming an article (or a message being
+  written up into a note) is a _new record_ linked with a `derived-from` relationship —
+  never a retype of the existing record, whose history belongs to its original
+  contract.


### PR DESCRIPTION
Establishes the org.haverstack commons namespace with canonical
definitions for note@1, bookmark@1, task@1, and contact@1, plus the
design rules (minimal required core, additive evolution, properties
vs perspectives, read-compat cores) and a lightweight proposal
process. Staged under docs/commons/ for later extraction into its
own repository.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HCboUGBrzqQw98QkvwHrh7