### PR TITLE
fix(core): make hard delete owner-only in ScopedStack

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -571,6 +571,8 @@ stack.delete(recordId); // soft delete — reversible
 stack.delete(recordId, { hard: true }); // hard delete — permanent
 ```
 
+**Hard delete is owner-only under `ScopedStack`.** Neither the record-level `write` bit nor `delete-own`/`delete-any` grants reach it — a non-owner requesting `{ hard: true }` gets `StackPermissionError`, regardless of what would otherwise authorize a delete. It's irreversible and destroys version history, so it stays outside every delegated-access vocabulary; only the owner can invoke it. Non-owners are always limited to soft delete, which remains recoverable. (Plain `Stack` is unscoped and trusted-by-definition, so this restriction applies only to the `asEntity()` wrapper.)
+
 Queries exclude soft-deleted Records by default. Opt in with:
 
 ```ts

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -962,8 +962,16 @@ export class ScopedStack implements StackClient {
     return this.stack.setPermissions(id, permissions);
   }
 
+  /**
+   * Hard delete is owner-only: it is irreversible and destroys version
+   * history, so neither the write bit nor delete-own/delete-any grants
+   * reach it. Non-owners are always limited to soft delete.
+   */
   async delete(id: string, opts: DeleteRecordOptions = {}): Promise<void> {
     await this.requireDeletable(id);
+    if (opts.hard && this.requesterEntityId !== this.stack.ownerEntityId) {
+      throw new StackPermissionError('Hard delete is owner-only');
+    }
     return this.stack.delete(id, opts);
   }
 

--- a/packages/core/tests/scoped-stack.test.ts
+++ b/packages/core/tests/scoped-stack.test.ts
@@ -165,6 +165,27 @@ describe('ScopedStack — write access', () => {
     expect((await adapter.getRecord(record.id))?.deletedAt).toBeDefined();
   });
 
+  test('write:true holder can soft-delete but not hard-delete', async () => {
+    const record = await adapter.createRecord(
+      makeRecord({
+        permissions: [{ access: 'entity', entityId: MEMBER, read: true, write: true }],
+      }),
+    );
+    await expect(stack.asEntity(MEMBER).delete(record.id, { hard: true })).rejects.toThrow(
+      StackPermissionError,
+    );
+    expect(await adapter.getRecord(record.id)).not.toBeNull();
+
+    await stack.asEntity(MEMBER).delete(record.id);
+    expect((await adapter.getRecord(record.id))?.deletedAt).toBeDefined();
+  });
+
+  test('owner can hard-delete', async () => {
+    const record = await adapter.createRecord(makeRecord());
+    await stack.asEntity(OWNER).delete(record.id, { hard: true });
+    expect(await adapter.getRecord(record.id)).toBeNull();
+  });
+
   test('associate/dissociate/setPermissions enforce write access', async () => {
     const record = await adapter.createRecord(makeRecord());
     const tag: Association = { kind: 'tag', label: 'starred' };
@@ -491,6 +512,15 @@ describe('ScopedStack — grant-based update/delete', () => {
     const record = await stack.create(COMMENT, { text: 'hello' }, { entityId: STRANGER });
     await stack.asEntity(MEMBER).delete(record.id);
     expect((await adapter.getRecord(record.id))?.deletedAt).toBeDefined();
+  });
+
+  test('delete-any grant does not allow hard delete', async () => {
+    await stack.grant(MEMBER, [{ actions: ['delete-any'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT, { text: 'hello' }, { entityId: STRANGER });
+    await expect(stack.asEntity(MEMBER).delete(record.id, { hard: true })).rejects.toThrow(
+      StackPermissionError,
+    );
+    expect(await adapter.getRecord(record.id)).not.toBeNull();
   });
 
   test('update grant does not allow delete', async () => {


### PR DESCRIPTION
## Summary

Closes the first, unblocked work item from #59.

`ScopedStack.delete()` called `requireDeletable()` (checks the record-level `write` bit or a `delete-own`/`delete-any` grant) and then forwarded `opts` straight to the adapter — so a `write: true` holder, or a `delete-any` grant holder, could pass `{ hard: true }` and permanently destroy the record **and its version history**. There was no test exercising this path.

Per #59's stated trust model — "anything a write-holder does, the owner can undo" — hard delete has no undo, so it doesn't belong behind any delegated-access mechanism. This PR makes hard delete owner-only:

- `ScopedStack.delete()` now throws `StackPermissionError` when a non-owner passes `{ hard: true }`, regardless of whether they'd otherwise be authorized to delete (write bit or grant).
- Non-owners remain able to soft-delete, which stays recoverable.
- Spec note added under **Deletion** stating the owner-only restriction and that it applies only to the `asEntity()`/`ScopedStack` wrapper (plain `Stack` is unscoped and trusted-by-definition per #45).

### Out of scope (tracked separately)

#59 has other work items — an undelete API, versioned/audited association changes, and the full "recoverability trust model" spec writeup — that are genuine prerequisites tracked as their own open issues (#60, #61) and don't exist in code yet. This PR only lands the carve-out that #59 itself flags as having no dependencies.

## Test plan

- [x] Added tests: write-bit holder can soft-delete but not hard-delete; owner can hard-delete; `delete-any` grant holder cannot hard-delete
- [x] `pnpm --filter @haverstack/core test` — 192 tests passing
- [x] `pnpm --filter @haverstack/core typecheck` — clean
- [x] `pnpm --filter @haverstack/core lint` — clean
- [x] `prettier --check` on changed files — clean

Refs #59, #60, #61, #45


---
_Generated by [Claude Code](https://claude.ai/code/session_01XFt42EuMJxjzZVyyb5nsvP)_