### PR TITLE
Add native SQLite record adapter (node:sqlite, FTS5, WAL) — #46 native adapter

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,6 +63,8 @@ export type {
   StackRecordAdapter,
   StackBlobAdapter,
   StackAdapter,
+  StackTokenStore,
+  TokenInfo,
   EntityContent,
   AppContent,
   GroupContent,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -428,3 +428,39 @@ export interface StackBlobAdapter {
  * want different backends for records and blobs (e.g. SQLite + S3).
  */
 export type StackAdapter = StackRecordAdapter & StackBlobAdapter;
+
+export type TokenInfo = {
+  id: string;
+  entityId: string;
+  label?: string;
+  createdAt: Date;
+  expiresAt?: Date;
+};
+
+/**
+ * Bearer-token issuance and lookup for server implementations. Neither
+ * `Stack` nor `StackClient` touches this — it's server-side tooling, not
+ * part of the record/blob adapter contract, so it's a standalone
+ * interface rather than a slot on `StackAdapter`. Server implementations
+ * accept storage and tokens as separate parts (`{ adapter, tokens }`)
+ * rather than sniffing an adapter for token methods.
+ *
+ * Token storage is deliberately decoupled from record storage: the
+ * portable stack file is "your data, take it with you," and auth
+ * material shouldn't travel with it (an export/backup shouldn't also
+ * hand over — or resurrect — bearer tokens). Implementations SHOULD
+ * default to storing tokens outside the stack's own file, treating
+ * in-file storage as an explicit opt-in at most.
+ */
+export interface StackTokenStore {
+  createToken(
+    entityId: string,
+    opts?: { label?: string; expiresAt?: Date },
+  ): Promise<{
+    id: string;
+    token: string;
+  }>;
+  lookupToken(token: string): Promise<{ entityId: string } | null>;
+  listTokens(): Promise<TokenInfo[]>;
+  revokeToken(id: string): Promise<void>;
+}

--- a/packages/record-adapter-sqlite/package.json
+++ b/packages/record-adapter-sqlite/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@haverstack/record-adapter-sqlite",
+  "version": "0.1.0",
+  "description": "Native SQLite (node:sqlite) record adapter for Haverstack — Node's built-in engine, no native compilation",
+  "type": "module",
+  "engines": {
+    "node": ">=22.5.0"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/haverstack/core",
+    "directory": "packages/record-adapter-sqlite"
+  },
+  "license": "CC0-1.0",
+  "keywords": [
+    "haverstack",
+    "sqlite",
+    "node:sqlite",
+    "record",
+    "adapter",
+    "personal data",
+    "storage"
+  ],
+  "scripts": {
+    "prepublishOnly": "pnpm run build",
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src tests"
+  },
+  "dependencies": {
+    "@haverstack/core": "workspace:*",
+    "@haverstack/sqlite-shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/record-adapter-sqlite/src/executor.ts
+++ b/packages/record-adapter-sqlite/src/executor.ts
@@ -1,0 +1,23 @@
+import type { SqlExecutor } from '@haverstack/sqlite-shared';
+import { DatabaseSync } from './node-sqlite.js';
+
+/** Normalizes node:sqlite's spread-args run/get/all calls to SqlExecutor. */
+export class NativeSqliteExecutor implements SqlExecutor {
+  constructor(private readonly db: DatabaseSync) {}
+
+  exec(sql: string): void {
+    this.db.exec(sql);
+  }
+
+  run(sql: string, params: readonly unknown[] = []): void {
+    this.db.prepare(sql).run(...(params as (string | number | null)[]));
+  }
+
+  get<T = Record<string, unknown>>(sql: string, params: readonly unknown[] = []): T | undefined {
+    return this.db.prepare(sql).get(...(params as (string | number | null)[])) as T | undefined;
+  }
+
+  all<T = Record<string, unknown>>(sql: string, params: readonly unknown[] = []): T[] {
+    return this.db.prepare(sql).all(...(params as (string | number | null)[])) as T[];
+  }
+}

--- a/packages/record-adapter-sqlite/src/index.ts
+++ b/packages/record-adapter-sqlite/src/index.ts
@@ -23,47 +23,47 @@
  * package, which implements @haverstack/core's StackTokenStore against
  * its own file rather than this adapter's records database.
  *
- * Schema DDL, WHERE/ORDER building, cursor codec, row mappers, and the
- * storage-ownership lock live in @haverstack/sqlite-shared — shared
- * with record-adapter-sqljs so the two engines can't drift on
- * engine-independent logic.
+ * This class itself is a thin node:sqlite binding: schema setup,
+ * pragmas, the storage-ownership lock, and the FTS4->FTS5 migration are
+ * genuinely engine-specific and live here. The actual
+ * StackRecordAdapter logic lives once in @haverstack/sqlite-shared's
+ * SharedSqlRecordLogic, shared with record-adapter-sqljs via the
+ * SqlExecutor interface (NativeSqliteExecutor here normalizes
+ * node:sqlite's spread-args run/get/all calls to it).
  */
 
 import { DatabaseSync } from './node-sqlite.js';
 import { existsSync } from 'fs';
 import type {
   StackRecordAdapter,
-  StackRecord,
   StackType,
   TypeId,
   RecordId,
   FileId,
   RecordVersion,
+} from '@haverstack/core';
+import type {
+  StackRecord,
   StackQuery,
   QueryResult,
   Association,
   Permission,
   AdapterCapabilities,
 } from '@haverstack/core';
-import { applyMergePatch, StackConflictError, StackNotFoundError } from '@haverstack/core';
 import {
   RECORD_SCHEMA_SQL,
   FTS5_SCHEMA_SQL,
   PRAGMA_FOREIGN_KEYS_ON,
   PRAGMA_JOURNAL_MODE_WAL,
-  buildWhereClause,
-  buildOrderClause,
-  getSortField,
-  makeCursor,
-  rowToRecord,
-  rowToAssociation,
-  rowToType,
-  rowToVersion,
-  toMs,
   sanitizeFts5Query,
+  fts5Strategy,
   acquireLock,
   releaseLock,
+  insertConfigRecord,
+  readStackConfig,
+  SharedSqlRecordLogic,
 } from '@haverstack/sqlite-shared';
+import { NativeSqliteExecutor } from './executor.js';
 
 // -------------------------------------------------------
 // Types
@@ -91,14 +91,6 @@ export type NativeRecordOpenOptions = {
    */
   force?: boolean;
 };
-
-// -------------------------------------------------------
-// Foreign key enforcement
-// -------------------------------------------------------
-
-/** node:sqlite reports FK violations as an Error with this message (code ERR_SQLITE_ERROR). */
-const isForeignKeyViolation = (err: unknown): boolean =>
-  err instanceof Error && err.message.includes('FOREIGN KEY constraint failed');
 
 // -------------------------------------------------------
 // FTS4 -> FTS5 migration
@@ -140,8 +132,18 @@ export class NativeSQLiteRecordAdapter implements StackRecordAdapter {
   timezone!: string;
 
   private db!: DatabaseSync;
+  private record!: SharedSqlRecordLogic;
 
   private constructor(private readonly path: string) {}
+
+  private wire(): void {
+    const exec = new NativeSqliteExecutor(this.db);
+    this.record = new SharedSqlRecordLogic({
+      exec,
+      fts: fts5Strategy,
+      sanitizeSearch: sanitizeFts5Query,
+    });
+  }
 
   /**
    * Initialize a new stack database. Fails if the file already exists —
@@ -161,13 +163,8 @@ export class NativeSQLiteRecordAdapter implements StackRecordAdapter {
     adapter.db.exec(PRAGMA_JOURNAL_MODE_WAL);
     adapter.db.exec(RECORD_SCHEMA_SQL);
     adapter.db.exec(FTS5_SCHEMA_SQL);
-    const now = Date.now();
-    adapter.db
-      .prepare(
-        `INSERT INTO records (id, type_id, created_at, updated_at, content, version)
-         VALUES ('_config', '_config@1', ?, ?, ?, 1)`,
-      )
-      .run(now, now, JSON.stringify({ entityId: opts.entityId, timezone: opts.timezone }));
+    adapter.wire();
+    insertConfigRecord(new NativeSqliteExecutor(adapter.db), opts.entityId, opts.timezone);
     adapter.ownerEntityId = opts.entityId;
     adapter.timezone = opts.timezone;
     return adapter;
@@ -192,404 +189,103 @@ export class NativeSQLiteRecordAdapter implements StackRecordAdapter {
     adapter.db.exec(PRAGMA_JOURNAL_MODE_WAL);
     adapter.db.exec(RECORD_SCHEMA_SQL);
     migrateFtsIfNeeded(adapter.db);
-    adapter.readConfig();
+    adapter.wire();
+    const config = readStackConfig(new NativeSqliteExecutor(adapter.db));
+    adapter.ownerEntityId = config.entityId;
+    adapter.timezone = config.timezone;
     return adapter;
-  }
-
-  private readConfig(): void {
-    const row = this.db.prepare(`SELECT content FROM records WHERE id = '_config'`).get() as
-      | { content: string }
-      | undefined;
-    if (!row) throw new Error('Stack database is missing its config record.');
-    const content = JSON.parse(row.content) as { entityId: string; timezone?: string };
-    this.ownerEntityId = content.entityId;
-    this.timezone = content.timezone ?? 'UTC';
   }
 
   // -------------------------------------------------------
   // Records
   // -------------------------------------------------------
 
-  async createRecord(record: StackRecord): Promise<StackRecord> {
-    this.db
-      .prepare(
-        `INSERT INTO records
-          (id, type_id, created_at, updated_at, content, version,
-           parent_id, entity_id, app_id, deleted_at, permissions)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        record.id,
-        record.typeId,
-        toMs(record.createdAt),
-        toMs(record.updatedAt),
-        JSON.stringify(record.content),
-        record.version,
-        record.parentId ?? null,
-        record.entityId ?? null,
-        record.appId ?? null,
-        record.deletedAt ? toMs(record.deletedAt) : null,
-        record.permissions ? JSON.stringify(record.permissions) : null,
-      );
-
-    if (record.associations?.length) {
-      this.insertAssociations(record.id, record.associations);
-    }
-
-    this.insertFts(record.id, JSON.stringify(record.content));
-    return record;
+  createRecord(record: StackRecord): Promise<StackRecord> {
+    return this.record.createRecord(record);
   }
 
-  async getRecord(id: string): Promise<StackRecord | null> {
-    const row = this.db.prepare('SELECT * FROM records WHERE id = ?').get(id) as
-      | Record<string, unknown>
-      | undefined;
-    if (!row) return null;
-    const associations = this.getAssociationsForRecord(id);
-    return rowToRecord(row, associations);
+  getRecord(id: string): Promise<StackRecord | null> {
+    return this.record.getRecord(id);
   }
 
-  async patchContent(id: string, patch: Record<string, unknown | null>): Promise<StackRecord> {
-    const existing = await this.getRecord(id);
-    if (!existing) throw new Error(`Record not found: "${id}"`);
-
-    const merged = applyMergePatch(existing.content, patch);
-    this.removeFts(id);
-    this.db
-      .prepare('UPDATE records SET content = ?, version = version + 1, updated_at = ? WHERE id = ?')
-      .run(JSON.stringify(merged), toMs(new Date()), id);
-    this.insertFts(id, JSON.stringify(merged));
-
-    const updated = await this.getRecord(id);
-    if (!updated) throw new Error(`Record not found after patchContent: "${id}"`);
-    return updated;
+  patchContent(id: string, patch: Record<string, unknown | null>): Promise<StackRecord> {
+    return this.record.patchContent(id, patch);
   }
 
-  async deleteRecord(id: string, opts: { hard?: boolean } = {}): Promise<void> {
-    if (opts.hard) {
-      this.hardDeleteRecord(id);
-    } else {
-      this.db
-        .prepare(
-          'UPDATE records SET deleted_at = ?, version = version + 1, updated_at = ? WHERE id = ?',
-        )
-        .run(toMs(new Date()), toMs(new Date()), id);
-    }
+  deleteRecord(id: string, opts?: { hard?: boolean }): Promise<void> {
+    return this.record.deleteRecord(id, opts);
   }
 
-  /** Deletes a record's associations, versions, FTS entry, and row. */
-  private hardDeleteRecord(id: string): void {
-    this.removeFts(id);
-    this.db.prepare('DELETE FROM associations WHERE record_id = ?').run(id);
-    this.db.prepare('DELETE FROM versions WHERE record_id = ?').run(id);
-    this.db.prepare('DELETE FROM records WHERE id = ?').run(id);
+  undeleteRecord(id: string): Promise<StackRecord> {
+    return this.record.undeleteRecord(id);
   }
 
-  async undeleteRecord(id: string): Promise<StackRecord> {
-    this.db
-      .prepare(
-        'UPDATE records SET deleted_at = NULL, version = version + 1, updated_at = ? WHERE id = ?',
-      )
-      .run(toMs(new Date()), id);
-
-    const updated = await this.getRecord(id);
-    if (!updated) throw new Error(`Record not found after undelete: "${id}"`);
-    return updated;
+  setPermissions(id: string, permissions: Permission[]): Promise<void> {
+    return this.record.setPermissions(id, permissions);
   }
 
-  async setPermissions(id: string, permissions: Permission[]): Promise<void> {
-    this.db
-      .prepare(
-        'UPDATE records SET permissions = ?, version = version + 1, updated_at = ? WHERE id = ?',
-      )
-      .run(permissions.length ? JSON.stringify(permissions) : null, toMs(new Date()), id);
+  restoreVersion(id: string, version: number): Promise<StackRecord> {
+    return this.record.restoreVersion(id, version);
   }
 
-  async restoreVersion(id: string, version: number): Promise<StackRecord> {
-    const target = await this.getVersion(id, version);
-    if (!target) throw new Error(`Version not found: ${id}@${version}`);
-
-    this.removeFts(id);
-    this.db
-      .prepare('UPDATE records SET content = ?, version = version + 1, updated_at = ? WHERE id = ?')
-      .run(JSON.stringify(target.content), toMs(new Date()), id);
-    if (target.associations !== undefined) {
-      this.db.prepare('DELETE FROM associations WHERE record_id = ?').run(id);
-      if (target.associations.length) this.insertAssociations(id, target.associations);
-    }
-    this.insertFts(id, JSON.stringify(target.content));
-
-    const updated = await this.getRecord(id);
-    if (!updated) throw new Error(`Record not found after restoreVersion: "${id}"`);
-    return updated;
-  }
-
-  async commitMigration(
+  commitMigration(
     id: string,
     toTypeId: TypeId,
     content: Record<string, unknown>,
   ): Promise<StackRecord> {
-    this.removeFts(id);
-    this.db
-      .prepare(
-        'UPDATE records SET type_id = ?, content = ?, version = version + 1, updated_at = ? WHERE id = ?',
-      )
-      .run(toTypeId, JSON.stringify(content), toMs(new Date()), id);
-    this.insertFts(id, JSON.stringify(content));
-
-    const updated = await this.getRecord(id);
-    if (!updated) throw new Error(`Record not found after commitMigration: "${id}"`);
-    return updated;
+    return this.record.commitMigration(id, toTypeId, content);
   }
 
-  async queryRecords(query: StackQuery): Promise<QueryResult> {
-    const { sql: where, params } = buildWhereClause(query, sanitizeFts5Query);
-    const order = buildOrderClause(query);
-    const limit = query.limit ?? 50;
-
-    // Fetch one extra to determine if there's a next page
-    const rows = this.execQuery<Record<string, unknown>>(
-      `SELECT r.* FROM records r ${where} ${order} LIMIT ?`,
-      [...params, limit + 1],
-    );
-
-    const hasMore = rows.length > limit;
-    const page = hasMore ? rows.slice(0, limit) : rows;
-
-    const records = page.map((row) => {
-      const associations = this.getAssociationsForRecord(row.id as string);
-      return rowToRecord(row, associations);
-    });
-
-    // Total count (without pagination)
-    const countRows = this.execQuery<{ total: number }>(
-      `SELECT COUNT(*) as total FROM records r ${where}`,
-      params,
-    );
-    const total = countRows[0]?.total ?? 0;
-
-    const lastRecord = records[records.length - 1];
-    const cursor = hasMore && lastRecord ? makeCursor(lastRecord, getSortField(query)) : null;
-
-    return { records, cursor, total };
+  queryRecords(query: StackQuery): Promise<QueryResult> {
+    return this.record.queryRecords(query);
   }
 
-  /**
-   * Atomically verify fileId is unreferenced, then hard-delete every
-   * metadataTypeId record whose content.fileId matches it. See
-   * StackRecordAdapter.deleteUnreferencedAttachmentRecords(). Runs as a
-   * real SQL transaction and, being entirely synchronous SQLite calls
-   * with no `await` in between, nothing else can interleave between the
-   * reference check and the deletes.
-   */
-  async deleteUnreferencedAttachmentRecords(
-    fileId: FileId,
-    metadataTypeId: TypeId,
-  ): Promise<RecordId[]> {
-    this.db.exec('BEGIN');
-    try {
-      const referenced = this.execQuery<{ found: number }>(
-        `SELECT 1 as found FROM associations WHERE kind = 'attachment' AND file_id = ? LIMIT 1`,
-        [fileId],
-      );
-      if (referenced.length) {
-        throw new StackConflictError('Attachment is still referenced by one or more records');
-      }
-
-      const metaRows = this.execQuery<{ id: string }>(
-        `SELECT id FROM records WHERE type_id = ? AND json_extract(content, '$.fileId') = ?`,
-        [metadataTypeId, fileId],
-      );
-      const deletedIds = metaRows.map((row) => row.id);
-      for (const id of deletedIds) {
-        this.hardDeleteRecord(id);
-      }
-
-      this.db.exec('COMMIT');
-      return deletedIds;
-    } catch (err) {
-      this.db.exec('ROLLBACK');
-      throw err;
-    }
+  deleteUnreferencedAttachmentRecords(fileId: FileId, metadataTypeId: TypeId): Promise<RecordId[]> {
+    return this.record.deleteUnreferencedAttachmentRecords(fileId, metadataTypeId);
   }
 
   // -------------------------------------------------------
   // Versions
   // -------------------------------------------------------
 
-  async getVersions(id: string): Promise<RecordVersion[]> {
-    const rows = this.execQuery<Record<string, unknown>>(
-      'SELECT * FROM versions WHERE record_id = ? ORDER BY version DESC',
-      [id],
-    );
-    return rows.map(rowToVersion);
+  getVersions(id: string): Promise<RecordVersion[]> {
+    return this.record.getVersions(id);
   }
 
-  async getVersion(id: string, version: number): Promise<RecordVersion | null> {
-    const rows = this.execQuery<Record<string, unknown>>(
-      'SELECT * FROM versions WHERE record_id = ? AND version = ?',
-      [id, version],
-    );
-    return rows.length ? rowToVersion(rows[0]) : null;
+  getVersion(id: string, version: number): Promise<RecordVersion | null> {
+    return this.record.getVersion(id, version);
   }
 
-  async saveVersion(id: string, version: RecordVersion): Promise<void> {
-    this.db
-      .prepare(
-        `INSERT OR IGNORE INTO versions
-          (record_id, version, content, updated_at, entity_id, associations, permissions)
-         VALUES (?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        id,
-        version.version,
-        JSON.stringify(version.content),
-        toMs(version.updatedAt),
-        version.entityId ?? null,
-        version.associations ? JSON.stringify(version.associations) : null,
-        version.permissions ? JSON.stringify(version.permissions) : null,
-      );
+  saveVersion(id: string, version: RecordVersion): Promise<void> {
+    return this.record.saveVersion(id, version);
   }
 
   // -------------------------------------------------------
   // Types
   // -------------------------------------------------------
 
-  async saveType(type: StackType): Promise<void> {
-    this.db
-      .prepare(
-        `INSERT OR REPLACE INTO types
-          (id, base_id, version, name, schema, schema_hash, migrates_from, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        type.id,
-        type.baseId,
-        type.version,
-        type.name,
-        JSON.stringify(type.schema),
-        type.schemaHash,
-        type.migratesFrom ?? null,
-        toMs(type.createdAt),
-      );
+  saveType(type: StackType): Promise<void> {
+    return this.record.saveType(type);
   }
 
-  async getType(id: TypeId): Promise<StackType | null> {
-    const rows = this.execQuery<Record<string, unknown>>('SELECT * FROM types WHERE id = ?', [id]);
-    return rows.length ? rowToType(rows[0]) : null;
+  getType(id: TypeId): Promise<StackType | null> {
+    return this.record.getType(id);
   }
 
-  async listTypes(): Promise<StackType[]> {
-    const rows = this.execQuery<Record<string, unknown>>(
-      'SELECT * FROM types ORDER BY base_id, version',
-    );
-    return rows.map(rowToType);
+  listTypes(): Promise<StackType[]> {
+    return this.record.listTypes();
   }
 
   // -------------------------------------------------------
   // Associations
   // -------------------------------------------------------
 
-  async associate(recordId: string, association: Association): Promise<void> {
-    this.insertAssociations(recordId, [association]);
-    this.bumpVersion(recordId);
+  associate(recordId: string, association: Association): Promise<void> {
+    return this.record.associate(recordId, association);
   }
 
-  async dissociate(recordId: string, association: Association): Promise<void> {
-    this.db
-      .prepare(
-        `DELETE FROM associations
-         WHERE record_id = ?
-           AND kind = ?
-           AND label = ?
-           AND file_id    = ?
-           AND related_id = ?`,
-      )
-      .run(
-        recordId,
-        association.kind,
-        association.label,
-        association.kind === 'attachment' ? association.fileId : '',
-        association.kind === 'relationship' ? association.recordId : '',
-      );
-    this.bumpVersion(recordId);
-  }
-
-  private bumpVersion(id: string): void {
-    this.db
-      .prepare('UPDATE records SET version = version + 1, updated_at = ? WHERE id = ?')
-      .run(toMs(new Date()), id);
-  }
-
-  /**
-   * FK enforcement (PRAGMA_FOREIGN_KEYS_ON) means inserting an
-   * association against a record that doesn't exist throws — mapped
-   * here to StackNotFoundError so associate() on a nonexistent record
-   * fails loudly instead of silently creating an orphan row.
-   */
-  private insertAssociations(recordId: string, associations: Association[]): void {
-    for (const assoc of associations) {
-      try {
-        this.db
-          .prepare(
-            `INSERT OR IGNORE INTO associations
-              (record_id, kind, label, file_id, mime_type, related_id)
-             VALUES (?, ?, ?, ?, ?, ?)`,
-          )
-          .run(
-            recordId,
-            assoc.kind,
-            assoc.label,
-            assoc.kind === 'attachment' ? assoc.fileId : '',
-            assoc.kind === 'attachment' ? assoc.mimeType : null,
-            assoc.kind === 'relationship' ? assoc.recordId : '',
-          );
-      } catch (err) {
-        if (isForeignKeyViolation(err)) {
-          throw new StackNotFoundError(`Record not found: "${recordId}"`);
-        }
-        throw err;
-      }
-    }
-  }
-
-  private getAssociationsForRecord(recordId: string): Association[] {
-    const rows = this.execQuery<Record<string, unknown>>(
-      'SELECT * FROM associations WHERE record_id = ?',
-      [recordId],
-    );
-    return rows.map(rowToAssociation);
-  }
-
-  /** Index a record that has no FTS entry yet (used right after an INSERT). */
-  private insertFts(recordId: string, content: string): void {
-    this.db
-      .prepare(`INSERT INTO records_fts(rowid, content) SELECT rowid, ? FROM records WHERE id = ?`)
-      .run(content, recordId);
-  }
-
-  /**
-   * Remove a record's FTS entry via FTS5's special 'delete' command,
-   * which — for an external-content table — needs the *old* rowid and
-   * content to correctly unindex it; a plain `DELETE FROM records_fts`
-   * leaves stale, still-searchable index entries behind. MUST be called
-   * before the records row's content changes or the row is deleted, since
-   * it reads the current content to build that command. No-op if the
-   * record has no FTS entry (shouldn't happen in practice, but a missing
-   * row is not this method's problem to raise).
-   */
-  private removeFts(recordId: string): void {
-    const row = this.db.prepare('SELECT rowid, content FROM records WHERE id = ?').get(recordId) as
-      | { rowid: number; content: string }
-      | undefined;
-    if (!row) return;
-    this.db
-      .prepare(`INSERT INTO records_fts(records_fts, rowid, content) VALUES('delete', ?, ?)`)
-      .run(row.rowid, row.content);
-  }
-
-  private execQuery<T>(sql: string, params: unknown[] = []): T[] {
-    return this.db.prepare(sql).all(...(params as (string | number | null)[])) as T[];
+  dissociate(recordId: string, association: Association): Promise<void> {
+    return this.record.dissociate(recordId, association);
   }
 
   // -------------------------------------------------------

--- a/packages/record-adapter-sqlite/src/index.ts
+++ b/packages/record-adapter-sqlite/src/index.ts
@@ -1,41 +1,38 @@
 /**
- * Haverstack — SQLite Record Adapter
+ * Haverstack — Native SQLite Record Adapter
  * -------------------------------------------------------
- * Implements StackRecordAdapter using sql.js (SQLite compiled
- * to WebAssembly). Runs in Node, browsers, and other runtimes
- * without native compilation.
+ * Implements StackRecordAdapter using node:sqlite (Node's built-in
+ * SQLite binding, Node >= 22.5). No native compilation, no node-gyp,
+ * no prebuilt binaries — same "just works" property that motivated
+ * sql.js, without sql.js's costs on the Node path: writes go straight
+ * to the file via normal SQLite journaling (WAL mode), so there's no
+ * whole-database export/rewrite on every write, no in-memory copy of
+ * the whole store, and real OS-level file locking.
  *
- * The database is held in memory and flushed to disk on every
- * write, atomically (temp file + rename). Stack config
- * (ownerEntityId, timezone) is stored as a singleton _config@1
- * record with id='_config' in the records table.
+ * Uses FTS5 for full-text search. A database created by
+ * record-adapter-sqljs (FTS4) opens here transparently — open()
+ * detects an FTS4 records_fts table and rebuilds it as FTS5 once,
+ * automatically.
  *
  * A stack file is owned by exactly one process at a time (see
- * docs/spec.md § Concurrency & storage ownership). open()/
- * initialize() acquire a PID-stamped lock file beside the
- * database and reject if another live process already holds
- * it; close() releases it.
+ * docs/spec.md § Concurrency & storage ownership). open()/initialize()
+ * acquire a PID-stamped lock file beside the database and reject if
+ * another live process already holds it; close() releases it.
  *
- * Also exposes token management methods (createToken,
- * lookupToken, listTokens, revokeToken) used by server
- * implementations to issue and validate bearer tokens.
+ * Token storage is a separate concern — see NativeTokenStore in this
+ * package, which implements @haverstack/core's StackTokenStore against
+ * its own file rather than this adapter's records database.
  *
- * Schema DDL, WHERE/ORDER building, cursor codec, row mappers,
- * the FTS4 sanitizer, and the storage-ownership lock all live in
- * @haverstack/sqlite-shared — shared with the native
- * record-adapter-sqlite so the two engines can't drift on
+ * Schema DDL, WHERE/ORDER building, cursor codec, row mappers, and the
+ * storage-ownership lock live in @haverstack/sqlite-shared — shared
+ * with record-adapter-sqljs so the two engines can't drift on
  * engine-independent logic.
  */
 
-import initSqlJs from 'sql.js';
-import type { Database, SqlJsStatic } from 'sql.js';
-import { createHash, randomBytes } from 'node:crypto';
-import { readFileSync, writeFileSync, existsSync, renameSync } from 'fs';
-import { dirname, basename, join } from 'path';
+import { DatabaseSync } from './node-sqlite.js';
+import { existsSync } from 'fs';
 import type {
   StackRecordAdapter,
-  StackTokenStore,
-  TokenInfo,
   StackRecord,
   StackType,
   TypeId,
@@ -49,12 +46,11 @@ import type {
   AdapterCapabilities,
 } from '@haverstack/core';
 import { applyMergePatch, StackConflictError, StackNotFoundError } from '@haverstack/core';
-export type { TokenInfo } from '@haverstack/core';
 import {
   RECORD_SCHEMA_SQL,
-  TOKENS_SCHEMA_SQL,
-  FTS4_SCHEMA_SQL,
+  FTS5_SCHEMA_SQL,
   PRAGMA_FOREIGN_KEYS_ON,
+  PRAGMA_JOURNAL_MODE_WAL,
   buildWhereClause,
   buildOrderClause,
   getSortField,
@@ -64,8 +60,7 @@ import {
   rowToType,
   rowToVersion,
   toMs,
-  fromMs,
-  sanitizeFts4Query,
+  sanitizeFts5Query,
   acquireLock,
   releaseLock,
 } from '@haverstack/sqlite-shared';
@@ -74,18 +69,18 @@ import {
 // Types
 // -------------------------------------------------------
 
-export type SQLiteRecordInitializeOptions = {
+export type NativeRecordInitializeOptions = {
   /** Absolute path to the .db file. Must not already exist. */
   path: string;
   /** IANA timezone string e.g. "America/New_York". */
   timezone: string;
   /** Entity ID of the stack owner. */
   entityId: string;
-  /** Bypass the storage-ownership lock check. See SQLiteRecordOpenOptions.force. */
+  /** Bypass the storage-ownership lock check. See NativeRecordOpenOptions.force. */
   force?: boolean;
 };
 
-export type SQLiteRecordOpenOptions = {
+export type NativeRecordOpenOptions = {
   /** Absolute path to an existing .db file. */
   path: string;
   /**
@@ -97,21 +92,44 @@ export type SQLiteRecordOpenOptions = {
   force?: boolean;
 };
 
-const SCHEMA_SQL = `${RECORD_SCHEMA_SQL}\n${TOKENS_SCHEMA_SQL}\n${FTS4_SCHEMA_SQL}`;
-
 // -------------------------------------------------------
 // Foreign key enforcement
 // -------------------------------------------------------
 
-/** sql.js's SQLite build reports FK violations as a plain Error with this message. */
+/** node:sqlite reports FK violations as an Error with this message (code ERR_SQLITE_ERROR). */
 const isForeignKeyViolation = (err: unknown): boolean =>
   err instanceof Error && err.message.includes('FOREIGN KEY constraint failed');
 
 // -------------------------------------------------------
-// SQLiteRecordAdapter
+// FTS4 -> FTS5 migration
 // -------------------------------------------------------
 
-export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore {
+/**
+ * A database created by record-adapter-sqljs has an FTS4 records_fts
+ * table. Detect it via sqlite_master (which stores the verbatim CREATE
+ * statement for virtual tables) and rebuild as FTS5 — one-time, cheap,
+ * transparent. No-op if the table is already FTS5 (or absent, in which
+ * case FTS5_SCHEMA_SQL's IF NOT EXISTS creates it fresh).
+ */
+const migrateFtsIfNeeded = (db: DatabaseSync): void => {
+  const existing = db
+    .prepare(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'records_fts'`)
+    .get() as { sql: string } | undefined;
+
+  if (existing && /\busing\s+fts4\b/i.test(existing.sql)) {
+    db.exec('DROP TABLE records_fts');
+    db.exec(FTS5_SCHEMA_SQL);
+    db.exec(`INSERT INTO records_fts(rowid, content) SELECT rowid, content FROM records`);
+    return;
+  }
+  db.exec(FTS5_SCHEMA_SQL);
+};
+
+// -------------------------------------------------------
+// NativeSQLiteRecordAdapter
+// -------------------------------------------------------
+
+export class NativeSQLiteRecordAdapter implements StackRecordAdapter {
   readonly capabilities: AdapterCapabilities = {
     fullTextSearch: true,
     contentFieldQuery: true,
@@ -121,94 +139,69 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
   ownerEntityId!: string;
   timezone!: string;
 
-  private db!: Database;
+  private db!: DatabaseSync;
 
-  private constructor(
-    private readonly SQL: SqlJsStatic,
-    private readonly path: string,
-  ) {}
+  private constructor(private readonly path: string) {}
 
   /**
    * Initialize a new stack database. Fails if the file already exists —
    * use open() for existing databases.
    */
-  static async initialize(opts: SQLiteRecordInitializeOptions): Promise<SQLiteRecordAdapter> {
+  static async initialize(opts: NativeRecordInitializeOptions): Promise<NativeSQLiteRecordAdapter> {
     if (existsSync(opts.path)) {
       throw new Error(
         `Cannot initialize: database already exists at "${opts.path}". ` +
-          `Use SQLiteRecordAdapter.open() instead.`,
+          `Use NativeSQLiteRecordAdapter.open() instead.`,
       );
     }
     acquireLock(opts.path, opts.force);
-    const SQL = await initSqlJs();
-    const adapter = new SQLiteRecordAdapter(SQL, opts.path);
-    adapter.db = new SQL.Database();
-    adapter.db.run(PRAGMA_FOREIGN_KEYS_ON);
-    adapter.db.run(SCHEMA_SQL);
+    const adapter = new NativeSQLiteRecordAdapter(opts.path);
+    adapter.db = new DatabaseSync(opts.path);
+    adapter.db.exec(PRAGMA_FOREIGN_KEYS_ON);
+    adapter.db.exec(PRAGMA_JOURNAL_MODE_WAL);
+    adapter.db.exec(RECORD_SCHEMA_SQL);
+    adapter.db.exec(FTS5_SCHEMA_SQL);
     const now = Date.now();
-    adapter.db.run(
-      `INSERT INTO records (id, type_id, created_at, updated_at, content, version)
-       VALUES ('_config', '_config@1', ?, ?, ?, 1)`,
-      [now, now, JSON.stringify({ entityId: opts.entityId, timezone: opts.timezone })],
-    );
+    adapter.db
+      .prepare(
+        `INSERT INTO records (id, type_id, created_at, updated_at, content, version)
+         VALUES ('_config', '_config@1', ?, ?, ?, 1)`,
+      )
+      .run(now, now, JSON.stringify({ entityId: opts.entityId, timezone: opts.timezone }));
     adapter.ownerEntityId = opts.entityId;
     adapter.timezone = opts.timezone;
-    adapter.persist();
     return adapter;
   }
 
   /**
    * Open an existing stack database. Fails if the file does not exist —
-   * use initialize() for new databases.
+   * use initialize() for new databases. Transparently migrates an FTS4
+   * records_fts table (from record-adapter-sqljs) to FTS5.
    */
-  static async open(opts: SQLiteRecordOpenOptions): Promise<SQLiteRecordAdapter> {
+  static async open(opts: NativeRecordOpenOptions): Promise<NativeSQLiteRecordAdapter> {
     if (!existsSync(opts.path)) {
       throw new Error(
         `Cannot open: no database found at "${opts.path}". ` +
-          `Use SQLiteRecordAdapter.initialize() to create one.`,
+          `Use NativeSQLiteRecordAdapter.initialize() to create one.`,
       );
     }
     acquireLock(opts.path, opts.force);
-    const SQL = await initSqlJs();
-    const adapter = new SQLiteRecordAdapter(SQL, opts.path);
-    const fileBuffer = readFileSync(opts.path);
-    adapter.db = new SQL.Database(fileBuffer);
-    adapter.db.run(PRAGMA_FOREIGN_KEYS_ON);
-    adapter.db.run(SCHEMA_SQL);
+    const adapter = new NativeSQLiteRecordAdapter(opts.path);
+    adapter.db = new DatabaseSync(opts.path);
+    adapter.db.exec(PRAGMA_FOREIGN_KEYS_ON);
+    adapter.db.exec(PRAGMA_JOURNAL_MODE_WAL);
+    adapter.db.exec(RECORD_SCHEMA_SQL);
+    migrateFtsIfNeeded(adapter.db);
     adapter.readConfig();
     return adapter;
   }
 
-  // -------------------------------------------------------
-  // Persistence
-  // -------------------------------------------------------
-
-  /**
-   * Flush the in-memory database to disk. Called after every write.
-   * Writes to a temp file in the same directory and renames it over
-   * the target — rename is atomic on POSIX, so a crash mid-write can
-   * never leave a torn, unreadable database file.
-   */
-  private persist(): void {
-    const data = this.db.export();
-    // sql.js quirk: export() resets connection-level pragmas (including
-    // foreign_keys) on the live Database object — reapply immediately so
-    // FK enforcement doesn't silently go stale after the first write.
-    this.db.run(PRAGMA_FOREIGN_KEYS_ON);
-    const tmpPath = join(
-      dirname(this.path),
-      `.${basename(this.path)}.tmp-${randomBytes(6).toString('hex')}`,
-    );
-    writeFileSync(tmpPath, Buffer.from(data));
-    renameSync(tmpPath, this.path);
-  }
-
   private readConfig(): void {
-    const rows = this.execQuery<{ content: string }>(
-      `SELECT content FROM records WHERE id = '_config'`,
-    );
-    if (!rows.length) throw new Error('Stack database is missing its config record.');
-    const content = JSON.parse(rows[0].content) as { entityId: string; timezone?: string };
+    const row = this.db.prepare(`SELECT content FROM records WHERE id = '_config'`).get() as
+      | { content: string }
+      | undefined;
+    if (!row) throw new Error('Stack database is missing its config record.');
+    const content = JSON.parse(row.content) as { entityId: string; timezone?: string };
     this.ownerEntityId = content.entityId;
     this.timezone = content.timezone ?? 'UTC';
   }
@@ -218,12 +211,14 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
   // -------------------------------------------------------
 
   async createRecord(record: StackRecord): Promise<StackRecord> {
-    this.db.run(
-      `INSERT INTO records
-        (id, type_id, created_at, updated_at, content, version,
-         parent_id, entity_id, app_id, deleted_at, permissions)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      [
+    this.db
+      .prepare(
+        `INSERT INTO records
+          (id, type_id, created_at, updated_at, content, version,
+           parent_id, entity_id, app_id, deleted_at, permissions)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
         record.id,
         record.typeId,
         toMs(record.createdAt),
@@ -235,27 +230,21 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
         record.appId ?? null,
         record.deletedAt ? toMs(record.deletedAt) : null,
         record.permissions ? JSON.stringify(record.permissions) : null,
-      ],
-    );
+      );
 
     if (record.associations?.length) {
       this.insertAssociations(record.id, record.associations);
     }
 
-    this.updateFts(record.id, JSON.stringify(record.content));
-    this.persist();
+    this.insertFts(record.id, JSON.stringify(record.content));
     return record;
   }
 
   async getRecord(id: string): Promise<StackRecord | null> {
-    const stmt = this.db.prepare('SELECT * FROM records r WHERE r.id = ?');
-    stmt.bind([id]);
-    if (!stmt.step()) {
-      stmt.free();
-      return null;
-    }
-    const row = stmt.getAsObject();
-    stmt.free();
+    const row = this.db.prepare('SELECT * FROM records WHERE id = ?').get(id) as
+      | Record<string, unknown>
+      | undefined;
+    if (!row) return null;
     const associations = this.getAssociationsForRecord(id);
     return rowToRecord(row, associations);
   }
@@ -265,12 +254,11 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
     if (!existing) throw new Error(`Record not found: "${id}"`);
 
     const merged = applyMergePatch(existing.content, patch);
-    this.db.run(
-      'UPDATE records SET content = ?, version = version + 1, updated_at = ? WHERE id = ?',
-      [JSON.stringify(merged), toMs(new Date()), id],
-    );
-    this.updateFts(id, JSON.stringify(merged));
-    this.persist();
+    this.removeFts(id);
+    this.db
+      .prepare('UPDATE records SET content = ?, version = version + 1, updated_at = ? WHERE id = ?')
+      .run(JSON.stringify(merged), toMs(new Date()), id);
+    this.insertFts(id, JSON.stringify(merged));
 
     const updated = await this.getRecord(id);
     if (!updated) throw new Error(`Record not found after patchContent: "${id}"`);
@@ -281,30 +269,28 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
     if (opts.hard) {
       this.hardDeleteRecord(id);
     } else {
-      this.db.run(
-        'UPDATE records SET deleted_at = ?, version = version + 1, updated_at = ? WHERE id = ?',
-        [toMs(new Date()), toMs(new Date()), id],
-      );
+      this.db
+        .prepare(
+          'UPDATE records SET deleted_at = ?, version = version + 1, updated_at = ? WHERE id = ?',
+        )
+        .run(toMs(new Date()), toMs(new Date()), id);
     }
-    this.persist();
   }
 
-  /** Deletes a record's associations, versions, FTS entry, and row — no persist(). */
+  /** Deletes a record's associations, versions, FTS entry, and row. */
   private hardDeleteRecord(id: string): void {
-    this.db.run('DELETE FROM associations WHERE record_id = ?', [id]);
-    this.db.run('DELETE FROM versions WHERE record_id = ?', [id]);
-    this.db.run(`DELETE FROM records_fts WHERE docid = (SELECT rowid FROM records WHERE id = ?)`, [
-      id,
-    ]);
-    this.db.run('DELETE FROM records WHERE id = ?', [id]);
+    this.removeFts(id);
+    this.db.prepare('DELETE FROM associations WHERE record_id = ?').run(id);
+    this.db.prepare('DELETE FROM versions WHERE record_id = ?').run(id);
+    this.db.prepare('DELETE FROM records WHERE id = ?').run(id);
   }
 
   async undeleteRecord(id: string): Promise<StackRecord> {
-    this.db.run(
-      'UPDATE records SET deleted_at = NULL, version = version + 1, updated_at = ? WHERE id = ?',
-      [toMs(new Date()), id],
-    );
-    this.persist();
+    this.db
+      .prepare(
+        'UPDATE records SET deleted_at = NULL, version = version + 1, updated_at = ? WHERE id = ?',
+      )
+      .run(toMs(new Date()), id);
 
     const updated = await this.getRecord(id);
     if (!updated) throw new Error(`Record not found after undelete: "${id}"`);
@@ -312,27 +298,26 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
   }
 
   async setPermissions(id: string, permissions: Permission[]): Promise<void> {
-    this.db.run(
-      'UPDATE records SET permissions = ?, version = version + 1, updated_at = ? WHERE id = ?',
-      [permissions.length ? JSON.stringify(permissions) : null, toMs(new Date()), id],
-    );
-    this.persist();
+    this.db
+      .prepare(
+        'UPDATE records SET permissions = ?, version = version + 1, updated_at = ? WHERE id = ?',
+      )
+      .run(permissions.length ? JSON.stringify(permissions) : null, toMs(new Date()), id);
   }
 
   async restoreVersion(id: string, version: number): Promise<StackRecord> {
     const target = await this.getVersion(id, version);
     if (!target) throw new Error(`Version not found: ${id}@${version}`);
 
-    this.db.run(
-      'UPDATE records SET content = ?, version = version + 1, updated_at = ? WHERE id = ?',
-      [JSON.stringify(target.content), toMs(new Date()), id],
-    );
+    this.removeFts(id);
+    this.db
+      .prepare('UPDATE records SET content = ?, version = version + 1, updated_at = ? WHERE id = ?')
+      .run(JSON.stringify(target.content), toMs(new Date()), id);
     if (target.associations !== undefined) {
-      this.db.run('DELETE FROM associations WHERE record_id = ?', [id]);
+      this.db.prepare('DELETE FROM associations WHERE record_id = ?').run(id);
       if (target.associations.length) this.insertAssociations(id, target.associations);
     }
-    this.updateFts(id, JSON.stringify(target.content));
-    this.persist();
+    this.insertFts(id, JSON.stringify(target.content));
 
     const updated = await this.getRecord(id);
     if (!updated) throw new Error(`Record not found after restoreVersion: "${id}"`);
@@ -344,12 +329,13 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
     toTypeId: TypeId,
     content: Record<string, unknown>,
   ): Promise<StackRecord> {
-    this.db.run(
-      'UPDATE records SET type_id = ?, content = ?, version = version + 1, updated_at = ? WHERE id = ?',
-      [toTypeId, JSON.stringify(content), toMs(new Date()), id],
-    );
-    this.updateFts(id, JSON.stringify(content));
-    this.persist();
+    this.removeFts(id);
+    this.db
+      .prepare(
+        'UPDATE records SET type_id = ?, content = ?, version = version + 1, updated_at = ? WHERE id = ?',
+      )
+      .run(toTypeId, JSON.stringify(content), toMs(new Date()), id);
+    this.insertFts(id, JSON.stringify(content));
 
     const updated = await this.getRecord(id);
     if (!updated) throw new Error(`Record not found after commitMigration: "${id}"`);
@@ -357,7 +343,7 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
   }
 
   async queryRecords(query: StackQuery): Promise<QueryResult> {
-    const { sql: where, params } = buildWhereClause(query, sanitizeFts4Query);
+    const { sql: where, params } = buildWhereClause(query, sanitizeFts5Query);
     const order = buildOrderClause(query);
     const limit = query.limit ?? 50;
 
@@ -400,7 +386,7 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
     fileId: FileId,
     metadataTypeId: TypeId,
   ): Promise<RecordId[]> {
-    this.db.run('BEGIN');
+    this.db.exec('BEGIN');
     try {
       const referenced = this.execQuery<{ found: number }>(
         `SELECT 1 as found FROM associations WHERE kind = 'attachment' AND file_id = ? LIMIT 1`,
@@ -419,11 +405,10 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
         this.hardDeleteRecord(id);
       }
 
-      this.db.run('COMMIT');
-      if (deletedIds.length) this.persist();
+      this.db.exec('COMMIT');
       return deletedIds;
     } catch (err) {
-      this.db.run('ROLLBACK');
+      this.db.exec('ROLLBACK');
       throw err;
     }
   }
@@ -449,11 +434,13 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
   }
 
   async saveVersion(id: string, version: RecordVersion): Promise<void> {
-    this.db.run(
-      `INSERT OR IGNORE INTO versions
-        (record_id, version, content, updated_at, entity_id, associations, permissions)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
-      [
+    this.db
+      .prepare(
+        `INSERT OR IGNORE INTO versions
+          (record_id, version, content, updated_at, entity_id, associations, permissions)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
         id,
         version.version,
         JSON.stringify(version.content),
@@ -461,9 +448,7 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
         version.entityId ?? null,
         version.associations ? JSON.stringify(version.associations) : null,
         version.permissions ? JSON.stringify(version.permissions) : null,
-      ],
-    );
-    this.persist();
+      );
   }
 
   // -------------------------------------------------------
@@ -471,11 +456,13 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
   // -------------------------------------------------------
 
   async saveType(type: StackType): Promise<void> {
-    this.db.run(
-      `INSERT OR REPLACE INTO types
-        (id, base_id, version, name, schema, schema_hash, migrates_from, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-      [
+    this.db
+      .prepare(
+        `INSERT OR REPLACE INTO types
+          (id, base_id, version, name, schema, schema_hash, migrates_from, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
         type.id,
         type.baseId,
         type.version,
@@ -484,9 +471,7 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
         type.schemaHash,
         type.migratesFrom ?? null,
         toMs(type.createdAt),
-      ],
-    );
-    this.persist();
+      );
   }
 
   async getType(id: TypeId): Promise<StackType | null> {
@@ -502,125 +487,63 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
   }
 
   // -------------------------------------------------------
-  // Tokens
-  // -------------------------------------------------------
-
-  async createToken(
-    entityId: string,
-    opts: { label?: string; expiresAt?: Date } = {},
-  ): Promise<{ id: string; token: string }> {
-    const id = randomBytes(8).toString('hex');
-    const token = randomBytes(32).toString('hex');
-    const tokenHash = createHash('sha256').update(token).digest('hex');
-    this.db.run(
-      'INSERT INTO tokens (id, token_hash, entity_id, label, created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?)',
-      [
-        id,
-        tokenHash,
-        entityId,
-        opts.label ?? null,
-        toMs(new Date()),
-        opts.expiresAt ? toMs(opts.expiresAt) : null,
-      ],
-    );
-    this.persist();
-    return { id, token };
-  }
-
-  async lookupToken(token: string): Promise<{ entityId: string } | null> {
-    const hash = createHash('sha256').update(token).digest('hex');
-    const rows = this.execQuery<{ entity_id: string; expires_at: number | null }>(
-      'SELECT entity_id, expires_at FROM tokens WHERE token_hash = ?',
-      [hash],
-    );
-    if (!rows.length) return null;
-    const row = rows[0];
-    if (row.expires_at !== null && Date.now() > row.expires_at) return null;
-    return { entityId: row.entity_id };
-  }
-
-  async listTokens(): Promise<TokenInfo[]> {
-    const rows = this.execQuery<{
-      id: string;
-      entity_id: string;
-      label: string | null;
-      created_at: number;
-      expires_at: number | null;
-    }>('SELECT id, entity_id, label, created_at, expires_at FROM tokens ORDER BY created_at DESC');
-    return rows.map((row) => ({
-      id: row.id,
-      entityId: row.entity_id,
-      ...(row.label && { label: row.label }),
-      createdAt: fromMs(row.created_at),
-      ...(row.expires_at !== null && { expiresAt: fromMs(row.expires_at) }),
-    }));
-  }
-
-  async revokeToken(id: string): Promise<void> {
-    this.db.run('DELETE FROM tokens WHERE id = ?', [id]);
-    this.persist();
-  }
-
-  // -------------------------------------------------------
   // Associations
   // -------------------------------------------------------
 
   async associate(recordId: string, association: Association): Promise<void> {
     this.insertAssociations(recordId, [association]);
     this.bumpVersion(recordId);
-    this.persist();
   }
 
   async dissociate(recordId: string, association: Association): Promise<void> {
-    this.db.run(
-      `DELETE FROM associations
-       WHERE record_id = ?
-         AND kind = ?
-         AND label = ?
-         AND file_id    = ?
-         AND related_id = ?`,
-      [
+    this.db
+      .prepare(
+        `DELETE FROM associations
+         WHERE record_id = ?
+           AND kind = ?
+           AND label = ?
+           AND file_id    = ?
+           AND related_id = ?`,
+      )
+      .run(
         recordId,
         association.kind,
         association.label,
         association.kind === 'attachment' ? association.fileId : '',
         association.kind === 'relationship' ? association.recordId : '',
-      ],
-    );
+      );
     this.bumpVersion(recordId);
-    this.persist();
   }
 
   private bumpVersion(id: string): void {
-    this.db.run('UPDATE records SET version = version + 1, updated_at = ? WHERE id = ?', [
-      toMs(new Date()),
-      id,
-    ]);
+    this.db
+      .prepare('UPDATE records SET version = version + 1, updated_at = ? WHERE id = ?')
+      .run(toMs(new Date()), id);
   }
 
   /**
    * FK enforcement (PRAGMA_FOREIGN_KEYS_ON) means inserting an
    * association against a record that doesn't exist throws — mapped
    * here to StackNotFoundError so associate() on a nonexistent record
-   * fails loudly with a proper error instead of silently creating an
-   * orphan row.
+   * fails loudly instead of silently creating an orphan row.
    */
   private insertAssociations(recordId: string, associations: Association[]): void {
     for (const assoc of associations) {
       try {
-        this.db.run(
-          `INSERT OR IGNORE INTO associations
-            (record_id, kind, label, file_id, mime_type, related_id)
-           VALUES (?, ?, ?, ?, ?, ?)`,
-          [
+        this.db
+          .prepare(
+            `INSERT OR IGNORE INTO associations
+              (record_id, kind, label, file_id, mime_type, related_id)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+          )
+          .run(
             recordId,
             assoc.kind,
             assoc.label,
             assoc.kind === 'attachment' ? assoc.fileId : '',
             assoc.kind === 'attachment' ? assoc.mimeType : null,
             assoc.kind === 'relationship' ? assoc.recordId : '',
-          ],
-        );
+          );
       } catch (err) {
         if (isForeignKeyViolation(err)) {
           throw new StackNotFoundError(`Record not found: "${recordId}"`);
@@ -638,35 +561,44 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
     return rows.map(rowToAssociation);
   }
 
-  private updateFts(recordId: string, content: string): void {
-    // FTS4 content table — delete old entry then insert new one
-    this.db.run(`DELETE FROM records_fts WHERE docid = (SELECT rowid FROM records WHERE id = ?)`, [
-      recordId,
-    ]);
-    this.db.run(
-      `INSERT INTO records_fts(docid, content)
-       SELECT rowid, ? FROM records WHERE id = ?`,
-      [content, recordId],
-    );
+  /** Index a record that has no FTS entry yet (used right after an INSERT). */
+  private insertFts(recordId: string, content: string): void {
+    this.db
+      .prepare(`INSERT INTO records_fts(rowid, content) SELECT rowid, ? FROM records WHERE id = ?`)
+      .run(content, recordId);
+  }
+
+  /**
+   * Remove a record's FTS entry via FTS5's special 'delete' command,
+   * which — for an external-content table — needs the *old* rowid and
+   * content to correctly unindex it; a plain `DELETE FROM records_fts`
+   * leaves stale, still-searchable index entries behind. MUST be called
+   * before the records row's content changes or the row is deleted, since
+   * it reads the current content to build that command. No-op if the
+   * record has no FTS entry (shouldn't happen in practice, but a missing
+   * row is not this method's problem to raise).
+   */
+  private removeFts(recordId: string): void {
+    const row = this.db.prepare('SELECT rowid, content FROM records WHERE id = ?').get(recordId) as
+      | { rowid: number; content: string }
+      | undefined;
+    if (!row) return;
+    this.db
+      .prepare(`INSERT INTO records_fts(records_fts, rowid, content) VALUES('delete', ?, ?)`)
+      .run(row.rowid, row.content);
   }
 
   private execQuery<T>(sql: string, params: unknown[] = []): T[] {
-    const stmt = this.db.prepare(sql);
-    stmt.bind(params as import('sql.js').BindParams);
-    const results: T[] = [];
-    while (stmt.step()) {
-      results.push(stmt.getAsObject() as T);
-    }
-    stmt.free();
-    return results;
+    return this.db.prepare(sql).all(...(params as (string | number | null)[])) as T[];
   }
 
   // -------------------------------------------------------
   // Lifecycle
   // -------------------------------------------------------
 
+  /** Folds the WAL back into the main file — useful before copying/backing up the database. */
   async flush(): Promise<void> {
-    this.persist();
+    this.db.exec('PRAGMA wal_checkpoint(TRUNCATE);');
   }
 
   async close(): Promise<void> {
@@ -674,3 +606,9 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
     releaseLock(this.path);
   }
 }
+
+export {
+  NativeTokenStore,
+  defaultTokenStorePath,
+  type NativeTokenStoreOptions,
+} from './token-store.js';

--- a/packages/record-adapter-sqlite/src/node-sqlite.ts
+++ b/packages/record-adapter-sqlite/src/node-sqlite.ts
@@ -1,0 +1,16 @@
+/**
+ * Loads node:sqlite via process.getBuiltinModule() rather than a static
+ * `import ... from 'node:sqlite'`. node:sqlite is new enough that some
+ * bundler/test-runner toolchains (Vite/Vitest as of this writing —
+ * https://github.com/vitest-dev/vitest/issues/7177) mis-resolve it,
+ * stripping the "node:" prefix and trying to load a package literally
+ * named "sqlite". process.getBuiltinModule() is the Node-sanctioned way
+ * to reach a builtin module without going through import resolution at
+ * all, so it's immune to that class of bug — useful here since a
+ * consuming app's own toolchain could hit the same issue, not just ours.
+ */
+export const { DatabaseSync } = process.getBuiltinModule(
+  'node:sqlite',
+) as typeof import('node:sqlite');
+
+export type DatabaseSync = InstanceType<typeof DatabaseSync>;

--- a/packages/record-adapter-sqlite/src/token-store.ts
+++ b/packages/record-adapter-sqlite/src/token-store.ts
@@ -1,0 +1,109 @@
+/**
+ * Bearer-token storage backing @haverstack/core's StackTokenStore,
+ * implemented against its own file — deliberately separate from
+ * NativeSQLiteRecordAdapter's records database. The portable stack file
+ * is "your data, take it with you"; auth material shouldn't travel with
+ * it, and restoring a backup shouldn't resurrect revoked tokens. Server
+ * implementations wire these up as separate parts
+ * (`{ adapter, tokens }`), the same philosophy as combineAdapters().
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+import type { StackTokenStore, TokenInfo } from '@haverstack/core';
+import {
+  TOKENS_SCHEMA_SQL,
+  PRAGMA_JOURNAL_MODE_WAL,
+  toMs,
+  fromMs,
+  acquireLock,
+  releaseLock,
+} from '@haverstack/sqlite-shared';
+import { DatabaseSync } from './node-sqlite.js';
+
+/** Conventional sibling path for a token store beside a stack's main .db file. */
+export const defaultTokenStorePath = (dbPath: string): string => `${dbPath}.tokens`;
+
+export type NativeTokenStoreOptions = {
+  /** Absolute path to the token store file. Created if it doesn't exist. */
+  path: string;
+  /** Bypass the storage-ownership lock check. See docs/spec.md § Concurrency & storage ownership. */
+  force?: boolean;
+};
+
+export class NativeTokenStore implements StackTokenStore {
+  private db!: DatabaseSync;
+
+  private constructor(private readonly path: string) {}
+
+  /** Opens the token store, creating the file and schema if needed. */
+  static async open(opts: NativeTokenStoreOptions): Promise<NativeTokenStore> {
+    acquireLock(opts.path, opts.force);
+    const store = new NativeTokenStore(opts.path);
+    store.db = new DatabaseSync(opts.path);
+    store.db.exec(PRAGMA_JOURNAL_MODE_WAL);
+    store.db.exec(TOKENS_SCHEMA_SQL);
+    return store;
+  }
+
+  async createToken(
+    entityId: string,
+    opts: { label?: string; expiresAt?: Date } = {},
+  ): Promise<{ id: string; token: string }> {
+    const id = randomBytes(8).toString('hex');
+    const token = randomBytes(32).toString('hex');
+    const tokenHash = createHash('sha256').update(token).digest('hex');
+    this.db
+      .prepare(
+        'INSERT INTO tokens (id, token_hash, entity_id, label, created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?)',
+      )
+      .run(
+        id,
+        tokenHash,
+        entityId,
+        opts.label ?? null,
+        toMs(new Date()),
+        opts.expiresAt ? toMs(opts.expiresAt) : null,
+      );
+    return { id, token };
+  }
+
+  async lookupToken(token: string): Promise<{ entityId: string } | null> {
+    const hash = createHash('sha256').update(token).digest('hex');
+    const row = this.db
+      .prepare('SELECT entity_id, expires_at FROM tokens WHERE token_hash = ?')
+      .get(hash) as { entity_id: string; expires_at: number | null } | undefined;
+    if (!row) return null;
+    if (row.expires_at !== null && Date.now() > row.expires_at) return null;
+    return { entityId: row.entity_id };
+  }
+
+  async listTokens(): Promise<TokenInfo[]> {
+    const rows = this.db
+      .prepare(
+        'SELECT id, entity_id, label, created_at, expires_at FROM tokens ORDER BY created_at DESC',
+      )
+      .all() as {
+      id: string;
+      entity_id: string;
+      label: string | null;
+      created_at: number;
+      expires_at: number | null;
+    }[];
+    return rows.map((row) => ({
+      id: row.id,
+      entityId: row.entity_id,
+      ...(row.label && { label: row.label }),
+      createdAt: fromMs(row.created_at),
+      ...(row.expires_at !== null && { expiresAt: fromMs(row.expires_at) }),
+    }));
+  }
+
+  async revokeToken(id: string): Promise<void> {
+    this.db.prepare('DELETE FROM tokens WHERE id = ?').run(id);
+  }
+
+  async close(): Promise<void> {
+    this.db.close();
+    releaseLock(this.path);
+  }
+}

--- a/packages/record-adapter-sqlite/src/token-store.ts
+++ b/packages/record-adapter-sqlite/src/token-store.ts
@@ -6,19 +6,23 @@
  * it, and restoring a backup shouldn't resurrect revoked tokens. Server
  * implementations wire these up as separate parts
  * (`{ adapter, tokens }`), the same philosophy as combineAdapters().
+ *
+ * The actual createToken/lookupToken/listTokens/revokeToken logic lives
+ * once in @haverstack/sqlite-shared's SharedTokenLogic, shared with
+ * record-adapter-sqljs's inline token methods via the SqlExecutor
+ * interface.
  */
 
-import { createHash, randomBytes } from 'node:crypto';
 import type { StackTokenStore, TokenInfo } from '@haverstack/core';
 import {
   TOKENS_SCHEMA_SQL,
   PRAGMA_JOURNAL_MODE_WAL,
-  toMs,
-  fromMs,
   acquireLock,
   releaseLock,
+  SharedTokenLogic,
 } from '@haverstack/sqlite-shared';
 import { DatabaseSync } from './node-sqlite.js';
+import { NativeSqliteExecutor } from './executor.js';
 
 /** Conventional sibling path for a token store beside a stack's main .db file. */
 export const defaultTokenStorePath = (dbPath: string): string => `${dbPath}.tokens`;
@@ -32,6 +36,7 @@ export type NativeTokenStoreOptions = {
 
 export class NativeTokenStore implements StackTokenStore {
   private db!: DatabaseSync;
+  private tokens!: SharedTokenLogic;
 
   private constructor(private readonly path: string) {}
 
@@ -42,64 +47,27 @@ export class NativeTokenStore implements StackTokenStore {
     store.db = new DatabaseSync(opts.path);
     store.db.exec(PRAGMA_JOURNAL_MODE_WAL);
     store.db.exec(TOKENS_SCHEMA_SQL);
+    store.tokens = new SharedTokenLogic({ exec: new NativeSqliteExecutor(store.db) });
     return store;
   }
 
-  async createToken(
+  createToken(
     entityId: string,
-    opts: { label?: string; expiresAt?: Date } = {},
+    opts?: { label?: string; expiresAt?: Date },
   ): Promise<{ id: string; token: string }> {
-    const id = randomBytes(8).toString('hex');
-    const token = randomBytes(32).toString('hex');
-    const tokenHash = createHash('sha256').update(token).digest('hex');
-    this.db
-      .prepare(
-        'INSERT INTO tokens (id, token_hash, entity_id, label, created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?)',
-      )
-      .run(
-        id,
-        tokenHash,
-        entityId,
-        opts.label ?? null,
-        toMs(new Date()),
-        opts.expiresAt ? toMs(opts.expiresAt) : null,
-      );
-    return { id, token };
+    return this.tokens.createToken(entityId, opts);
   }
 
-  async lookupToken(token: string): Promise<{ entityId: string } | null> {
-    const hash = createHash('sha256').update(token).digest('hex');
-    const row = this.db
-      .prepare('SELECT entity_id, expires_at FROM tokens WHERE token_hash = ?')
-      .get(hash) as { entity_id: string; expires_at: number | null } | undefined;
-    if (!row) return null;
-    if (row.expires_at !== null && Date.now() > row.expires_at) return null;
-    return { entityId: row.entity_id };
+  lookupToken(token: string): Promise<{ entityId: string } | null> {
+    return this.tokens.lookupToken(token);
   }
 
-  async listTokens(): Promise<TokenInfo[]> {
-    const rows = this.db
-      .prepare(
-        'SELECT id, entity_id, label, created_at, expires_at FROM tokens ORDER BY created_at DESC',
-      )
-      .all() as {
-      id: string;
-      entity_id: string;
-      label: string | null;
-      created_at: number;
-      expires_at: number | null;
-    }[];
-    return rows.map((row) => ({
-      id: row.id,
-      entityId: row.entity_id,
-      ...(row.label && { label: row.label }),
-      createdAt: fromMs(row.created_at),
-      ...(row.expires_at !== null && { expiresAt: fromMs(row.expires_at) }),
-    }));
+  listTokens(): Promise<TokenInfo[]> {
+    return this.tokens.listTokens();
   }
 
-  async revokeToken(id: string): Promise<void> {
-    this.db.prepare('DELETE FROM tokens WHERE id = ?').run(id);
+  revokeToken(id: string): Promise<void> {
+    return this.tokens.revokeToken(id);
   }
 
   async close(): Promise<void> {

--- a/packages/record-adapter-sqlite/tests/record.test.ts
+++ b/packages/record-adapter-sqlite/tests/record.test.ts
@@ -1,0 +1,785 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, existsSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { DatabaseSync } from '../src/node-sqlite.js';
+import { NativeSQLiteRecordAdapter } from '../src/index.js';
+import { StackConflictError, StackNotFoundError, StackQueryError } from '@haverstack/core';
+import type { StackRecord } from '@haverstack/core';
+
+// -------------------------------------------------------
+// Test helpers
+// -------------------------------------------------------
+
+let testDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `sqlite-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(testDir, { recursive: true });
+  dbPath = join(testDir, 'test.db');
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+const initAdapter = (opts?: { timezone?: string; entityId?: string }) =>
+  NativeSQLiteRecordAdapter.initialize({
+    path: dbPath,
+    entityId: opts?.entityId ?? 'entity-123',
+    timezone: opts?.timezone ?? 'America/New_York',
+  });
+
+const NOTE_TYPE = {
+  id: 'com.example.test/note@1',
+  baseId: 'com.example.test/note',
+  version: 1,
+  name: 'Note',
+  schema: { text: { kind: 'text' as const, required: true } },
+  schemaHash: 'abc123',
+  createdAt: new Date(),
+};
+
+const makeRecord = (overrides: Partial<StackRecord> = {}): StackRecord => ({
+  id: `rec-${Math.random().toString(36).slice(2)}`,
+  typeId: 'com.example.test/note@1',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  content: { text: 'Hello world' },
+  version: 1,
+  ...overrides,
+});
+
+// -------------------------------------------------------
+// initialize / open
+// -------------------------------------------------------
+
+describe('initialize', () => {
+  test('creates a new database file', async () => {
+    await initAdapter();
+    expect(existsSync(dbPath)).toBe(true);
+  });
+
+  test('sets ownerEntityId', async () => {
+    const adapter = await initAdapter({ entityId: 'owner-abc' });
+    expect(adapter.ownerEntityId).toBe('owner-abc');
+  });
+
+  test('sets timezone', async () => {
+    const adapter = await initAdapter({ timezone: 'Europe/London' });
+    expect(adapter.timezone).toBe('Europe/London');
+  });
+
+  test('throws if database already exists', async () => {
+    await initAdapter();
+    await expect(initAdapter()).rejects.toThrow(/already exists/);
+  });
+
+  test('enables WAL journal mode', async () => {
+    await initAdapter();
+    const db = new DatabaseSync(dbPath);
+    const mode = db.prepare('PRAGMA journal_mode').get() as { journal_mode: string };
+    expect(mode.journal_mode).toBe('wal');
+    db.close();
+  });
+});
+
+describe('open', () => {
+  test('opens an existing database', async () => {
+    await initAdapter();
+    const adapter = await NativeSQLiteRecordAdapter.open({ path: dbPath });
+    expect(adapter.ownerEntityId).toBe('entity-123');
+  });
+
+  test('throws if database does not exist', async () => {
+    await expect(
+      NativeSQLiteRecordAdapter.open({ path: join(testDir, 'nonexistent.db') }),
+    ).rejects.toThrow(/no database found/);
+  });
+
+  test('data persists across adapter instances (no explicit flush needed)', async () => {
+    const adapter1 = await initAdapter();
+    await adapter1.saveType(NOTE_TYPE);
+    const record = makeRecord();
+    await adapter1.createRecord(record);
+
+    const adapter2 = await NativeSQLiteRecordAdapter.open({ path: dbPath });
+    expect(await adapter2.getType(NOTE_TYPE.id)).not.toBeNull();
+    expect(await adapter2.getRecord(record.id)).not.toBeNull();
+  });
+});
+
+test('preserves ownerEntityId and timezone across reopen', async () => {
+  await initAdapter({ entityId: 'owner-abc', timezone: 'Europe/London' });
+  const adapter = await NativeSQLiteRecordAdapter.open({ path: dbPath });
+  expect(adapter.ownerEntityId).toBe('owner-abc');
+  expect(adapter.timezone).toBe('Europe/London');
+});
+
+// -------------------------------------------------------
+// Storage ownership lock
+// -------------------------------------------------------
+
+describe('storage ownership lock', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('open() rejects when a live process already holds the lock', async () => {
+    await initAdapter();
+    const otherPid = process.pid + 1;
+    writeFileSync(`${dbPath}.lock`, JSON.stringify({ pid: otherPid }));
+    vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    await expect(NativeSQLiteRecordAdapter.open({ path: dbPath })).rejects.toThrow(
+      new RegExp(`in use by another process \\(pid ${otherPid}\\)`),
+    );
+  });
+
+  test('open() reclaims a lock left by a dead process', async () => {
+    await initAdapter();
+    const deadPid = process.pid + 1;
+    writeFileSync(`${dbPath}.lock`, JSON.stringify({ pid: deadPid }));
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      const err = new Error('no such process') as NodeJS.ErrnoException;
+      err.code = 'ESRCH';
+      throw err;
+    });
+
+    const adapter = await NativeSQLiteRecordAdapter.open({ path: dbPath });
+    expect(adapter.ownerEntityId).toBe('entity-123');
+  });
+
+  test('open() with force bypasses a live lock', async () => {
+    await initAdapter();
+    const otherPid = process.pid + 1;
+    writeFileSync(`${dbPath}.lock`, JSON.stringify({ pid: otherPid }));
+    vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    const adapter = await NativeSQLiteRecordAdapter.open({ path: dbPath, force: true });
+    expect(adapter.ownerEntityId).toBe('entity-123');
+  });
+
+  test('close() releases the lock so a later open() succeeds without force', async () => {
+    const adapter = await initAdapter();
+    await adapter.close();
+    await expect(NativeSQLiteRecordAdapter.open({ path: dbPath })).resolves.toBeDefined();
+  });
+});
+
+// -------------------------------------------------------
+// Cross-compatibility with record-adapter-sqljs files
+// -------------------------------------------------------
+
+describe('FTS4 -> FTS5 migration', () => {
+  const writeSqljsStyleDb = (path: string) => {
+    // Mirrors record-adapter-sqljs's schema shape without depending on
+    // that package — a real file created with an FTS4 records_fts table.
+    const db = new DatabaseSync(path);
+    db.exec(`CREATE TABLE records (
+      id TEXT PRIMARY KEY, type_id TEXT NOT NULL, created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL, content TEXT NOT NULL, version INTEGER NOT NULL DEFAULT 1,
+      parent_id TEXT, entity_id TEXT, app_id TEXT, deleted_at INTEGER, permissions TEXT
+    ) STRICT;`);
+    db.exec(`CREATE VIRTUAL TABLE records_fts USING fts4(content, content='records');`);
+    const now = Date.now();
+    db.prepare(
+      `INSERT INTO records (id, type_id, created_at, updated_at, content, version)
+       VALUES ('_config', '_config@1', ?, ?, ?, 1)`,
+    ).run(now, now, JSON.stringify({ entityId: 'entity-123', timezone: 'UTC' }));
+    db.prepare(
+      `INSERT INTO records (id, type_id, created_at, updated_at, content, version) VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run(
+      'r1',
+      'com.example.test/note@1',
+      now,
+      now,
+      JSON.stringify({ text: 'hello from sqljs' }),
+      1,
+    );
+    db.prepare(
+      `INSERT INTO records_fts(docid, content) SELECT rowid, content FROM records WHERE id = 'r1'`,
+    ).run();
+    db.close();
+  };
+
+  test('open() transparently migrates an FTS4 file to FTS5', async () => {
+    writeSqljsStyleDb(dbPath);
+    const adapter = await NativeSQLiteRecordAdapter.open({ path: dbPath });
+    expect(adapter.ownerEntityId).toBe('entity-123');
+
+    const result = await adapter.queryRecords({ filter: { search: 'hello' } });
+    expect(result.records.map((r) => r.id)).toEqual(['r1']);
+
+    const db = new DatabaseSync(dbPath);
+    const ftsSql = db.prepare(`SELECT sql FROM sqlite_master WHERE name = 'records_fts'`).get() as {
+      sql: string;
+    };
+    expect(ftsSql.sql.toLowerCase()).toContain('fts5');
+    db.close();
+  });
+
+  test('migration is idempotent — reopening an already-migrated file is a no-op', async () => {
+    writeSqljsStyleDb(dbPath);
+    const adapter1 = await NativeSQLiteRecordAdapter.open({ path: dbPath });
+    await adapter1.close();
+
+    const adapter2 = await NativeSQLiteRecordAdapter.open({ path: dbPath, force: true });
+    const result = await adapter2.queryRecords({ filter: { search: 'hello' } });
+    expect(result.records.map((r) => r.id)).toEqual(['r1']);
+  });
+});
+
+// -------------------------------------------------------
+// Types
+// -------------------------------------------------------
+
+describe('types', () => {
+  test('saveType and getType roundtrip', async () => {
+    const adapter = await initAdapter();
+    await adapter.saveType(NOTE_TYPE);
+    const retrieved = await adapter.getType(NOTE_TYPE.id);
+    expect(retrieved?.id).toBe(NOTE_TYPE.id);
+    expect(retrieved?.name).toBe(NOTE_TYPE.name);
+    expect(retrieved?.schema).toEqual(NOTE_TYPE.schema);
+    expect(retrieved?.schemaHash).toBe(NOTE_TYPE.schemaHash);
+    expect(retrieved?.createdAt).toBeInstanceOf(Date);
+  });
+
+  test('getType returns null for unknown id', async () => {
+    const adapter = await initAdapter();
+    expect(await adapter.getType('com.example/unknown@1')).toBeNull();
+  });
+
+  test('listTypes returns all saved types', async () => {
+    const adapter = await initAdapter();
+    const typeB = { ...NOTE_TYPE, id: 'com.example.test/note@2', version: 2 };
+    await adapter.saveType(NOTE_TYPE);
+    await adapter.saveType(typeB);
+    const types = await adapter.listTypes();
+    expect(types.length).toBe(2);
+    expect(types.map((t) => t.id)).toContain(NOTE_TYPE.id);
+    expect(types.map((t) => t.id)).toContain(typeB.id);
+  });
+
+  test('saveType with migratesFrom stores lineage', async () => {
+    const adapter = await initAdapter();
+    const typeV2 = {
+      ...NOTE_TYPE,
+      id: 'com.example.test/note@2',
+      version: 2,
+      migratesFrom: NOTE_TYPE.id,
+    };
+    await adapter.saveType(typeV2);
+    const retrieved = await adapter.getType(typeV2.id);
+    expect(retrieved?.migratesFrom).toBe(NOTE_TYPE.id);
+  });
+
+  test('saveType overwrites existing type with same id', async () => {
+    const adapter = await initAdapter();
+    await adapter.saveType(NOTE_TYPE);
+    const updated = { ...NOTE_TYPE, name: 'Updated Note' };
+    await adapter.saveType(updated);
+    const retrieved = await adapter.getType(NOTE_TYPE.id);
+    expect(retrieved?.name).toBe('Updated Note');
+  });
+});
+
+// -------------------------------------------------------
+// Records — CRUD
+// -------------------------------------------------------
+
+describe('records — CRUD', () => {
+  test('createRecord and getRecord roundtrip', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord({ content: { text: 'Hello' } });
+    await adapter.createRecord(record);
+    const retrieved = await adapter.getRecord(record.id);
+    expect(retrieved?.id).toBe(record.id);
+    expect(retrieved?.content).toEqual({ text: 'Hello' });
+    expect(retrieved?.createdAt).toBeInstanceOf(Date);
+    expect(retrieved?.updatedAt).toBeInstanceOf(Date);
+  });
+
+  test('getRecord returns null for unknown id', async () => {
+    const adapter = await initAdapter();
+    expect(await adapter.getRecord('nonexistent')).toBeNull();
+  });
+
+  test('createRecord stores optional native fields', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord({
+      parentId: 'parent-abc',
+      entityId: 'entity-xyz',
+      appId: 'app-123',
+    });
+    await adapter.createRecord(record);
+    const retrieved = await adapter.getRecord(record.id);
+    expect(retrieved?.parentId).toBe('parent-abc');
+    expect(retrieved?.entityId).toBe('entity-xyz');
+    expect(retrieved?.appId).toBe('app-123');
+  });
+
+  test('patchContent changes content and bumps version', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord();
+    await adapter.createRecord(record);
+    const updated = await adapter.patchContent(record.id, { text: 'Updated' });
+    expect(updated.content).toEqual({ text: 'Updated' });
+    expect(updated.version).toBe(2);
+  });
+
+  test('patchContent preserves unchanged fields', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord({ parentId: 'parent-abc' });
+    await adapter.createRecord(record);
+    await adapter.patchContent(record.id, { text: 'Updated' });
+    const retrieved = await adapter.getRecord(record.id);
+    expect(retrieved?.parentId).toBe('parent-abc');
+  });
+
+  test('soft deleteRecord sets deletedAt', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord();
+    await adapter.createRecord(record);
+    await adapter.deleteRecord(record.id);
+    const retrieved = await adapter.getRecord(record.id);
+    expect(retrieved?.deletedAt).toBeInstanceOf(Date);
+  });
+
+  test('hard deleteRecord removes record entirely', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord();
+    await adapter.createRecord(record);
+    await adapter.deleteRecord(record.id, { hard: true });
+    expect(await adapter.getRecord(record.id)).toBeNull();
+  });
+
+  test('hard deleteRecord removes version history', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord();
+    await adapter.createRecord(record);
+    await adapter.saveVersion(record.id, {
+      version: 1,
+      content: record.content,
+      updatedAt: record.updatedAt,
+    });
+    await adapter.deleteRecord(record.id, { hard: true });
+    expect(await adapter.getVersions(record.id)).toEqual([]);
+  });
+
+  test('undeleteRecord clears deletedAt and returns the record', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord();
+    await adapter.createRecord(record);
+    await adapter.deleteRecord(record.id);
+
+    const undeleted = await adapter.undeleteRecord(record.id);
+    expect(undeleted.deletedAt).toBeUndefined();
+
+    const retrieved = await adapter.getRecord(record.id);
+    expect(retrieved?.deletedAt).toBeUndefined();
+  });
+
+  test('stored dates roundtrip correctly', async () => {
+    const adapter = await initAdapter();
+    const createdAt = new Date('2024-06-15T12:00:00.000Z');
+    const record = makeRecord({ createdAt });
+    await adapter.createRecord(record);
+    const retrieved = await adapter.getRecord(record.id);
+    expect(retrieved?.createdAt.getTime()).toBe(createdAt.getTime());
+  });
+});
+
+// -------------------------------------------------------
+// Records — queries
+// -------------------------------------------------------
+
+describe('records — queries', () => {
+  test('queryRecords returns all non-deleted records by default', async () => {
+    const adapter = await initAdapter();
+    const r1 = makeRecord({ id: 'r1' });
+    const r2 = makeRecord({ id: 'r2' });
+    const r3 = makeRecord({ id: 'r3' });
+    await adapter.createRecord(r1);
+    await adapter.createRecord(r2);
+    await adapter.createRecord(r3);
+    await adapter.deleteRecord(r3.id);
+    const result = await adapter.queryRecords({});
+    expect(result.records.length).toBe(2);
+    expect(result.total).toBe(2);
+  });
+
+  test('includeDeleted returns soft-deleted records', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord();
+    await adapter.createRecord(record);
+    await adapter.deleteRecord(record.id);
+    const result = await adapter.queryRecords({ filter: { includeDeleted: true } });
+    expect(result.records.some((r) => r.id === record.id)).toBe(true);
+  });
+
+  test('filters by typeId', async () => {
+    const adapter = await initAdapter();
+    const noteType = makeRecord({ typeId: 'com.example/note@1' });
+    const taskType = makeRecord({ typeId: 'com.example/task@1' });
+    await adapter.createRecord(noteType);
+    await adapter.createRecord(taskType);
+    const result = await adapter.queryRecords({ filter: { typeId: 'com.example/note@1' } });
+    expect(result.records.every((r) => r.typeId === 'com.example/note@1')).toBe(true);
+    expect(result.records.length).toBe(1);
+  });
+
+  test('filters by parentId', async () => {
+    const adapter = await initAdapter();
+    const parent = makeRecord({ id: 'parent' });
+    const child1 = makeRecord({ id: 'child1', parentId: 'parent' });
+    const other = makeRecord({ id: 'other' });
+    await adapter.createRecord(parent);
+    await adapter.createRecord(child1);
+    await adapter.createRecord(other);
+    const result = await adapter.queryRecords({ filter: { parentId: 'parent' } });
+    expect(result.records.length).toBe(1);
+    expect(result.records[0].parentId).toBe('parent');
+  });
+
+  test('filters by content field', async () => {
+    const adapter = await initAdapter();
+    await adapter.createRecord(makeRecord({ id: 'r1', content: { text: 'alpha', priority: 1 } }));
+    await adapter.createRecord(makeRecord({ id: 'r2', content: { text: 'beta', priority: 2 } }));
+    const result = await adapter.queryRecords({ filter: { content: { priority: 1 } } });
+    expect(result.records.length).toBe(1);
+    expect(result.records[0].id).toBe('r1');
+  });
+
+  test('full-text search (FTS5)', async () => {
+    const adapter = await initAdapter();
+    await adapter.createRecord(makeRecord({ id: 'r1', content: { text: 'SQLite is great' } }));
+    await adapter.createRecord(
+      makeRecord({ id: 'r2', content: { text: 'Postgres is also great' } }),
+    );
+    const result = await adapter.queryRecords({ filter: { search: 'SQLite' } });
+    expect(result.records.length).toBe(1);
+    expect(result.records[0].id).toBe('r1');
+  });
+
+  test('full-text search reflects patchContent updates (not stale index entries)', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord({ content: { text: 'original content here' } });
+    await adapter.createRecord(record);
+    await adapter.patchContent(record.id, { text: 'updated content here' });
+
+    const staleSearch = await adapter.queryRecords({ filter: { search: 'original' } });
+    expect(staleSearch.records).toEqual([]);
+    const freshSearch = await adapter.queryRecords({ filter: { search: 'updated' } });
+    expect(freshSearch.records.map((r) => r.id)).toEqual([record.id]);
+  });
+
+  test('full-text search no longer finds hard-deleted records', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord({ content: { text: 'findme unique token' } });
+    await adapter.createRecord(record);
+    await adapter.deleteRecord(record.id, { hard: true });
+
+    const result = await adapter.queryRecords({ filter: { search: 'findme' } });
+    expect(result.records).toEqual([]);
+  });
+
+  test('cursor pagination returns correct pages', async () => {
+    const adapter = await initAdapter();
+    for (let i = 0; i < 5; i++) {
+      await adapter.createRecord(
+        makeRecord({ id: `r${i}`, createdAt: new Date(Date.now() + i * 1000) }),
+      );
+    }
+    const page1 = await adapter.queryRecords({
+      sort: { field: 'createdAt', direction: 'asc' },
+      limit: 3,
+    });
+    expect(page1.records.length).toBe(3);
+    expect(page1.cursor).not.toBeNull();
+    expect(page1.total).toBe(5);
+
+    const page2 = await adapter.queryRecords({
+      sort: { field: 'createdAt', direction: 'asc' },
+      limit: 3,
+      cursor: page1.cursor!,
+    });
+    expect(page2.records.length).toBe(2);
+    expect(page2.cursor).toBeNull();
+  });
+
+  test('malformed cursor throws StackQueryError', async () => {
+    const adapter = await initAdapter();
+    await adapter.createRecord(makeRecord({ id: 'r1' }));
+    await expect(adapter.queryRecords({ cursor: '!!!not-a-cursor!!!' })).rejects.toThrow(
+      StackQueryError,
+    );
+  });
+
+  test('sort by createdAt descending (default)', async () => {
+    const adapter = await initAdapter();
+    await adapter.createRecord(makeRecord({ id: 'r1', createdAt: new Date(1000) }));
+    await adapter.createRecord(makeRecord({ id: 'r2', createdAt: new Date(2000) }));
+    await adapter.createRecord(makeRecord({ id: 'r3', createdAt: new Date(3000) }));
+    const result = await adapter.queryRecords({ sort: { field: 'createdAt', direction: 'desc' } });
+    expect(result.records.map((r) => r.id)).toEqual(['r3', 'r2', 'r1']);
+  });
+});
+
+// -------------------------------------------------------
+// Associations
+// -------------------------------------------------------
+
+describe('associations', () => {
+  test('associate adds a tag and it appears on the record', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord();
+    await adapter.createRecord(record);
+    await adapter.associate(record.id, { kind: 'tag', label: 'starred' });
+    const retrieved = await adapter.getRecord(record.id);
+    expect(retrieved?.associations?.some((a) => a.kind === 'tag' && a.label === 'starred')).toBe(
+      true,
+    );
+  });
+
+  test('dissociate removes a tag', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord();
+    await adapter.createRecord(record);
+    await adapter.associate(record.id, { kind: 'tag', label: 'starred' });
+    await adapter.dissociate(record.id, { kind: 'tag', label: 'starred' });
+    const retrieved = await adapter.getRecord(record.id);
+    const hasStarred = (retrieved?.associations ?? []).some((a) => a.label === 'starred');
+    expect(hasStarred).toBe(false);
+  });
+
+  test('associate is idempotent — duplicate does not create two entries', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord();
+    await adapter.createRecord(record);
+    await adapter.associate(record.id, { kind: 'tag', label: 'starred' });
+    await adapter.associate(record.id, { kind: 'tag', label: 'starred' });
+    const retrieved = await adapter.getRecord(record.id);
+    const stars = retrieved?.associations?.filter((a) => a.kind === 'tag' && a.label === 'starred');
+    expect(stars?.length).toBe(1);
+  });
+
+  test('associate bumps version', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord();
+    await adapter.createRecord(record);
+    await adapter.associate(record.id, { kind: 'tag', label: 'starred' });
+    const retrieved = await adapter.getRecord(record.id);
+    expect(retrieved?.version).toBe(2);
+  });
+
+  test('associate on a nonexistent record throws StackNotFoundError instead of creating an orphan row', async () => {
+    const adapter = await initAdapter();
+    await expect(
+      adapter.associate('does-not-exist', { kind: 'tag', label: 'starred' }),
+    ).rejects.toThrow(StackNotFoundError);
+  });
+});
+
+// -------------------------------------------------------
+// Permissions
+// -------------------------------------------------------
+
+describe('setPermissions', () => {
+  test('replaces permissions and bumps version', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord();
+    await adapter.createRecord(record);
+    await adapter.setPermissions(record.id, [{ access: 'public' }]);
+    const retrieved = await adapter.getRecord(record.id);
+    expect(retrieved?.permissions).toEqual([{ access: 'public' }]);
+    expect(retrieved?.version).toBe(2);
+  });
+});
+
+// -------------------------------------------------------
+// Versions
+// -------------------------------------------------------
+
+describe('versions', () => {
+  test('saveVersion and getVersion roundtrip', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord();
+    await adapter.createRecord(record);
+    const version = {
+      version: 1,
+      content: { text: 'original' },
+      updatedAt: new Date('2024-01-01'),
+      entityId: 'entity-123',
+    };
+    await adapter.saveVersion(record.id, version);
+    const retrieved = await adapter.getVersion(record.id, 1);
+    expect(retrieved?.content).toEqual({ text: 'original' });
+    expect(retrieved?.entityId).toBe('entity-123');
+  });
+
+  test('saveVersion is idempotent for same version number', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord();
+    await adapter.createRecord(record);
+    const v = { version: 1, content: { text: 'original' }, updatedAt: new Date() };
+    await adapter.saveVersion(record.id, v);
+    await adapter.saveVersion(record.id, v);
+    const versions = await adapter.getVersions(record.id);
+    expect(versions.length).toBe(1);
+  });
+});
+
+describe('restoreVersion', () => {
+  test('restores content and bumps version', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord();
+    await adapter.createRecord(record);
+    await adapter.saveVersion(record.id, {
+      version: 1,
+      content: { text: 'original' },
+      updatedAt: new Date(),
+    });
+    await adapter.patchContent(record.id, { text: 'changed' });
+
+    const restored = await adapter.restoreVersion(record.id, 1);
+    expect(restored.content).toEqual({ text: 'original' });
+    expect(restored.version).toBe(3);
+  });
+
+  test('restored content is searchable and the pre-restore content is not', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord({ content: { text: 'original searchable text' } });
+    await adapter.createRecord(record);
+    await adapter.saveVersion(record.id, {
+      version: 1,
+      content: { text: 'original searchable text' },
+      updatedAt: new Date(),
+    });
+    await adapter.patchContent(record.id, { text: 'changed unrelated text' });
+
+    await adapter.restoreVersion(record.id, 1);
+
+    const findsOriginal = await adapter.queryRecords({ filter: { search: 'searchable' } });
+    expect(findsOriginal.records.map((r) => r.id)).toEqual([record.id]);
+    const findsChanged = await adapter.queryRecords({ filter: { search: 'unrelated' } });
+    expect(findsChanged.records).toEqual([]);
+  });
+
+  test('throws for an unknown version', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord();
+    await adapter.createRecord(record);
+    await expect(adapter.restoreVersion(record.id, 99)).rejects.toThrow();
+  });
+});
+
+describe('commitMigration', () => {
+  test('changes typeId and content together, and bumps version', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord({ typeId: 'com.example.test/note@1' });
+    await adapter.createRecord(record);
+
+    const migrated = await adapter.commitMigration(record.id, 'com.example.test/note@2', {
+      text: 'Hello world',
+      pinned: false,
+    });
+    expect(migrated.typeId).toBe('com.example.test/note@2');
+    expect(migrated.content).toEqual({ text: 'Hello world', pinned: false });
+    expect(migrated.version).toBe(2);
+  });
+});
+
+// -------------------------------------------------------
+// deleteUnreferencedAttachmentRecords
+// -------------------------------------------------------
+
+describe('deleteUnreferencedAttachmentRecords', () => {
+  const ATTACHMENT_TYPE = 'com.example.test/_attachment@1';
+
+  test('throws StackConflictError when a record still references the file', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord();
+    await adapter.createRecord(record);
+    await adapter.associate(record.id, {
+      kind: 'attachment',
+      label: 'cover',
+      fileId: 'file-1',
+      mimeType: 'image/png',
+    });
+
+    await expect(
+      adapter.deleteUnreferencedAttachmentRecords('file-1', ATTACHMENT_TYPE),
+    ).rejects.toThrow(StackConflictError);
+  });
+
+  test('deletes an unreferenced metadata record and returns its id', async () => {
+    const adapter = await initAdapter();
+    await adapter.createRecord(
+      makeRecord({ id: 'meta1', typeId: ATTACHMENT_TYPE, content: { fileId: 'file-1' } }),
+    );
+
+    const deleted = await adapter.deleteUnreferencedAttachmentRecords('file-1', ATTACHMENT_TYPE);
+    expect(deleted).toEqual(['meta1']);
+    expect(await adapter.getRecord('meta1')).toBeNull();
+  });
+
+  test('deletes every metadata record sharing the same fileId (dedup case)', async () => {
+    const adapter = await initAdapter();
+    await adapter.createRecord(
+      makeRecord({ id: 'meta1', typeId: ATTACHMENT_TYPE, content: { fileId: 'shared-file' } }),
+    );
+    await adapter.createRecord(
+      makeRecord({ id: 'meta2', typeId: ATTACHMENT_TYPE, content: { fileId: 'shared-file' } }),
+    );
+
+    const deleted = await adapter.deleteUnreferencedAttachmentRecords(
+      'shared-file',
+      ATTACHMENT_TYPE,
+    );
+    expect(deleted.sort()).toEqual(['meta1', 'meta2']);
+  });
+
+  test('returns an empty array when no metadata records exist for the file', async () => {
+    const adapter = await initAdapter();
+    const deleted = await adapter.deleteUnreferencedAttachmentRecords(
+      'nonexistent-file',
+      ATTACHMENT_TYPE,
+    );
+    expect(deleted).toEqual([]);
+  });
+
+  test('rolls back and leaves the metadata record intact when the reference check fails', async () => {
+    const adapter = await initAdapter();
+    await adapter.createRecord(
+      makeRecord({ id: 'meta1', typeId: ATTACHMENT_TYPE, content: { fileId: 'file-1' } }),
+    );
+    const referencing = makeRecord({ id: 'referencing' });
+    await adapter.createRecord(referencing);
+    await adapter.associate(referencing.id, {
+      kind: 'attachment',
+      label: 'cover',
+      fileId: 'file-1',
+      mimeType: 'image/png',
+    });
+
+    await expect(
+      adapter.deleteUnreferencedAttachmentRecords('file-1', ATTACHMENT_TYPE),
+    ).rejects.toThrow(StackConflictError);
+    expect(await adapter.getRecord('meta1')).not.toBeNull();
+  });
+});
+
+// -------------------------------------------------------
+// Lifecycle
+// -------------------------------------------------------
+
+describe('flush', () => {
+  test('checkpoints the WAL without throwing', async () => {
+    const adapter = await initAdapter();
+    await adapter.createRecord(makeRecord());
+    await expect(adapter.flush()).resolves.toBeUndefined();
+  });
+});

--- a/packages/record-adapter-sqlite/tests/token-store.test.ts
+++ b/packages/record-adapter-sqlite/tests/token-store.test.ts
@@ -1,0 +1,111 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { NativeTokenStore, defaultTokenStorePath } from '../src/index.js';
+
+let testDir: string;
+let tokenPath: string;
+
+beforeEach(() => {
+  testDir = join(
+    tmpdir(),
+    `sqlite-tokens-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testDir, { recursive: true });
+  tokenPath = join(testDir, 'test.db.tokens');
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe('defaultTokenStorePath', () => {
+  test('derives a sibling path from the main db path', () => {
+    expect(defaultTokenStorePath('/stacks/my-stack.db')).toBe('/stacks/my-stack.db.tokens');
+  });
+});
+
+describe('NativeTokenStore', () => {
+  test('open() creates the store file', async () => {
+    await NativeTokenStore.open({ path: tokenPath });
+    expect(existsSync(tokenPath)).toBe(true);
+  });
+
+  test('does not create or touch a database at the main stack path', async () => {
+    const mainDbPath = join(testDir, 'test.db');
+    await NativeTokenStore.open({ path: tokenPath });
+    expect(existsSync(mainDbPath)).toBe(false);
+  });
+
+  test('createToken returns id and plaintext token', async () => {
+    const store = await NativeTokenStore.open({ path: tokenPath });
+    const { id, token } = await store.createToken('entity-abc');
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+    expect(typeof token).toBe('string');
+    expect(token.length).toBeGreaterThan(0);
+  });
+
+  test('lookupToken returns entityId for a valid token', async () => {
+    const store = await NativeTokenStore.open({ path: tokenPath });
+    const { token } = await store.createToken('entity-abc');
+    const result = await store.lookupToken(token);
+    expect(result?.entityId).toBe('entity-abc');
+  });
+
+  test('lookupToken returns null for an invalid token', async () => {
+    const store = await NativeTokenStore.open({ path: tokenPath });
+    expect(await store.lookupToken('not-a-real-token')).toBeNull();
+  });
+
+  test('lookupToken returns null for an expired token', async () => {
+    const store = await NativeTokenStore.open({ path: tokenPath });
+    const { token } = await store.createToken('entity-abc', {
+      expiresAt: new Date(Date.now() - 1000),
+    });
+    expect(await store.lookupToken(token)).toBeNull();
+  });
+
+  test('lookupToken returns entityId for a non-expired token', async () => {
+    const store = await NativeTokenStore.open({ path: tokenPath });
+    const { token } = await store.createToken('entity-abc', {
+      expiresAt: new Date(Date.now() + 60_000),
+    });
+    expect((await store.lookupToken(token))?.entityId).toBe('entity-abc');
+  });
+
+  test('listTokens returns all created tokens without plaintext values', async () => {
+    const store = await NativeTokenStore.open({ path: tokenPath });
+    await store.createToken('entity-a', { label: 'Token A' });
+    await store.createToken('entity-b', { label: 'Token B' });
+    const tokens = await store.listTokens();
+    expect(tokens.length).toBe(2);
+    expect(tokens.map((t) => t.label)).toEqual(expect.arrayContaining(['Token A', 'Token B']));
+    for (const t of tokens) {
+      expect(Object.keys(t)).not.toContain('token');
+    }
+  });
+
+  test('revokeToken removes the token', async () => {
+    const store = await NativeTokenStore.open({ path: tokenPath });
+    const { id, token } = await store.createToken('entity-abc');
+    await store.revokeToken(id);
+    expect(await store.lookupToken(token)).toBeNull();
+  });
+
+  test('tokens persist across store instances', async () => {
+    const store1 = await NativeTokenStore.open({ path: tokenPath });
+    const { token } = await store1.createToken('entity-abc');
+    await store1.close();
+
+    const store2 = await NativeTokenStore.open({ path: tokenPath });
+    expect((await store2.lookupToken(token))?.entityId).toBe('entity-abc');
+  });
+
+  test('close() releases the storage lock', async () => {
+    const store = await NativeTokenStore.open({ path: tokenPath });
+    await store.close();
+    await expect(NativeTokenStore.open({ path: tokenPath })).resolves.toBeDefined();
+  });
+});

--- a/packages/record-adapter-sqlite/tsconfig.build.json
+++ b/packages/record-adapter-sqlite/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "noEmit": false
+  },
+  "exclude": ["tests/**/*.ts"]
+}

--- a/packages/record-adapter-sqlite/tsconfig.json
+++ b/packages/record-adapter-sqlite/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/packages/record-adapter-sqlite/vitest.config.ts
+++ b/packages/record-adapter-sqlite/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@haverstack/core': resolve(__dirname, '../core/src/index.ts'),
+      '@haverstack/sqlite-shared': resolve(__dirname, '../sqlite-shared/src/index.ts'),
+    },
+  },
+  test: {
+    environment: 'node',
+  },
+});

--- a/packages/record-adapter-sqljs/src/index.ts
+++ b/packages/record-adapter-sqljs/src/index.ts
@@ -20,22 +20,39 @@
  * lookupToken, listTokens, revokeToken) used by server
  * implementations to issue and validate bearer tokens.
  *
- * Schema DDL, WHERE/ORDER building, cursor codec, row mappers,
- * the FTS4 sanitizer, and the storage-ownership lock all live in
- * @haverstack/sqlite-shared — shared with the native
- * record-adapter-sqlite so the two engines can't drift on
- * engine-independent logic.
+ * This class itself is a thin sql.js binding: schema DDL, the
+ * storage-ownership lock, and — most of the actual
+ * StackRecordAdapter/StackTokenStore logic — live in
+ * @haverstack/sqlite-shared's SharedSqlRecordLogic/SharedTokenLogic,
+ * shared with the native record-adapter-sqlite via the SqlExecutor
+ * interface (SqlJsExecutor here normalizes sql.js's bind/step/free
+ * calls to it). What's left here is genuinely sql.js-specific:
+ * WASM init, in-memory export/persist, and the pragma-reset quirk.
  */
 
 import initSqlJs from 'sql.js';
-import type { Database, SqlJsStatic } from 'sql.js';
-import { createHash, randomBytes } from 'node:crypto';
+import type { Database, SqlJsStatic, BindParams } from 'sql.js';
 import { readFileSync, writeFileSync, existsSync, renameSync } from 'fs';
 import { dirname, basename, join } from 'path';
+import { randomBytes } from 'node:crypto';
+import type { StackRecordAdapter, StackTokenStore, TokenInfo } from '@haverstack/core';
+export type { TokenInfo } from '@haverstack/core';
+import {
+  RECORD_SCHEMA_SQL,
+  TOKENS_SCHEMA_SQL,
+  FTS4_SCHEMA_SQL,
+  PRAGMA_FOREIGN_KEYS_ON,
+  sanitizeFts4Query,
+  fts4Strategy,
+  acquireLock,
+  releaseLock,
+  insertConfigRecord,
+  readStackConfig,
+  SharedSqlRecordLogic,
+  SharedTokenLogic,
+  type SqlExecutor,
+} from '@haverstack/sqlite-shared';
 import type {
-  StackRecordAdapter,
-  StackTokenStore,
-  TokenInfo,
   StackRecord,
   StackType,
   TypeId,
@@ -48,27 +65,6 @@ import type {
   Permission,
   AdapterCapabilities,
 } from '@haverstack/core';
-import { applyMergePatch, StackConflictError, StackNotFoundError } from '@haverstack/core';
-export type { TokenInfo } from '@haverstack/core';
-import {
-  RECORD_SCHEMA_SQL,
-  TOKENS_SCHEMA_SQL,
-  FTS4_SCHEMA_SQL,
-  PRAGMA_FOREIGN_KEYS_ON,
-  buildWhereClause,
-  buildOrderClause,
-  getSortField,
-  makeCursor,
-  rowToRecord,
-  rowToAssociation,
-  rowToType,
-  rowToVersion,
-  toMs,
-  fromMs,
-  sanitizeFts4Query,
-  acquireLock,
-  releaseLock,
-} from '@haverstack/sqlite-shared';
 
 // -------------------------------------------------------
 // Types
@@ -100,12 +96,43 @@ export type SQLiteRecordOpenOptions = {
 const SCHEMA_SQL = `${RECORD_SCHEMA_SQL}\n${TOKENS_SCHEMA_SQL}\n${FTS4_SCHEMA_SQL}`;
 
 // -------------------------------------------------------
-// Foreign key enforcement
+// SqlExecutor over a sql.js Database
 // -------------------------------------------------------
 
-/** sql.js's SQLite build reports FK violations as a plain Error with this message. */
-const isForeignKeyViolation = (err: unknown): boolean =>
-  err instanceof Error && err.message.includes('FOREIGN KEY constraint failed');
+class SqlJsExecutor implements SqlExecutor {
+  constructor(private readonly db: Database) {}
+
+  exec(sql: string): void {
+    this.db.run(sql);
+  }
+
+  run(sql: string, params: readonly unknown[] = []): void {
+    this.db.run(sql, params as BindParams);
+  }
+
+  get<T = Record<string, unknown>>(sql: string, params: readonly unknown[] = []): T | undefined {
+    const stmt = this.db.prepare(sql);
+    stmt.bind(params as BindParams);
+    if (!stmt.step()) {
+      stmt.free();
+      return undefined;
+    }
+    const row = stmt.getAsObject() as T;
+    stmt.free();
+    return row;
+  }
+
+  all<T = Record<string, unknown>>(sql: string, params: readonly unknown[] = []): T[] {
+    const stmt = this.db.prepare(sql);
+    stmt.bind(params as BindParams);
+    const results: T[] = [];
+    while (stmt.step()) {
+      results.push(stmt.getAsObject() as T);
+    }
+    stmt.free();
+    return results;
+  }
+}
 
 // -------------------------------------------------------
 // SQLiteRecordAdapter
@@ -122,11 +149,25 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
   timezone!: string;
 
   private db!: Database;
+  private exec!: SqlExecutor;
+  private record!: SharedSqlRecordLogic;
+  private tokens!: SharedTokenLogic;
 
   private constructor(
     private readonly SQL: SqlJsStatic,
     private readonly path: string,
   ) {}
+
+  private wire(): void {
+    this.exec = new SqlJsExecutor(this.db);
+    this.record = new SharedSqlRecordLogic({
+      exec: this.exec,
+      fts: fts4Strategy,
+      sanitizeSearch: sanitizeFts4Query,
+      onWrite: () => this.persist(),
+    });
+    this.tokens = new SharedTokenLogic({ exec: this.exec, onWrite: () => this.persist() });
+  }
 
   /**
    * Initialize a new stack database. Fails if the file already exists —
@@ -145,12 +186,8 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
     adapter.db = new SQL.Database();
     adapter.db.run(PRAGMA_FOREIGN_KEYS_ON);
     adapter.db.run(SCHEMA_SQL);
-    const now = Date.now();
-    adapter.db.run(
-      `INSERT INTO records (id, type_id, created_at, updated_at, content, version)
-       VALUES ('_config', '_config@1', ?, ?, ?, 1)`,
-      [now, now, JSON.stringify({ entityId: opts.entityId, timezone: opts.timezone })],
-    );
+    adapter.wire();
+    insertConfigRecord(adapter.exec, opts.entityId, opts.timezone);
     adapter.ownerEntityId = opts.entityId;
     adapter.timezone = opts.timezone;
     adapter.persist();
@@ -175,7 +212,10 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
     adapter.db = new SQL.Database(fileBuffer);
     adapter.db.run(PRAGMA_FOREIGN_KEYS_ON);
     adapter.db.run(SCHEMA_SQL);
-    adapter.readConfig();
+    adapter.wire();
+    const config = readStackConfig(adapter.exec);
+    adapter.ownerEntityId = config.entityId;
+    adapter.timezone = config.timezone;
     return adapter;
   }
 
@@ -203,462 +243,119 @@ export class SQLiteRecordAdapter implements StackRecordAdapter, StackTokenStore 
     renameSync(tmpPath, this.path);
   }
 
-  private readConfig(): void {
-    const rows = this.execQuery<{ content: string }>(
-      `SELECT content FROM records WHERE id = '_config'`,
-    );
-    if (!rows.length) throw new Error('Stack database is missing its config record.');
-    const content = JSON.parse(rows[0].content) as { entityId: string; timezone?: string };
-    this.ownerEntityId = content.entityId;
-    this.timezone = content.timezone ?? 'UTC';
-  }
-
   // -------------------------------------------------------
   // Records
   // -------------------------------------------------------
 
-  async createRecord(record: StackRecord): Promise<StackRecord> {
-    this.db.run(
-      `INSERT INTO records
-        (id, type_id, created_at, updated_at, content, version,
-         parent_id, entity_id, app_id, deleted_at, permissions)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      [
-        record.id,
-        record.typeId,
-        toMs(record.createdAt),
-        toMs(record.updatedAt),
-        JSON.stringify(record.content),
-        record.version,
-        record.parentId ?? null,
-        record.entityId ?? null,
-        record.appId ?? null,
-        record.deletedAt ? toMs(record.deletedAt) : null,
-        record.permissions ? JSON.stringify(record.permissions) : null,
-      ],
-    );
-
-    if (record.associations?.length) {
-      this.insertAssociations(record.id, record.associations);
-    }
-
-    this.updateFts(record.id, JSON.stringify(record.content));
-    this.persist();
-    return record;
+  createRecord(record: StackRecord): Promise<StackRecord> {
+    return this.record.createRecord(record);
   }
 
-  async getRecord(id: string): Promise<StackRecord | null> {
-    const stmt = this.db.prepare('SELECT * FROM records r WHERE r.id = ?');
-    stmt.bind([id]);
-    if (!stmt.step()) {
-      stmt.free();
-      return null;
-    }
-    const row = stmt.getAsObject();
-    stmt.free();
-    const associations = this.getAssociationsForRecord(id);
-    return rowToRecord(row, associations);
+  getRecord(id: string): Promise<StackRecord | null> {
+    return this.record.getRecord(id);
   }
 
-  async patchContent(id: string, patch: Record<string, unknown | null>): Promise<StackRecord> {
-    const existing = await this.getRecord(id);
-    if (!existing) throw new Error(`Record not found: "${id}"`);
-
-    const merged = applyMergePatch(existing.content, patch);
-    this.db.run(
-      'UPDATE records SET content = ?, version = version + 1, updated_at = ? WHERE id = ?',
-      [JSON.stringify(merged), toMs(new Date()), id],
-    );
-    this.updateFts(id, JSON.stringify(merged));
-    this.persist();
-
-    const updated = await this.getRecord(id);
-    if (!updated) throw new Error(`Record not found after patchContent: "${id}"`);
-    return updated;
+  patchContent(id: string, patch: Record<string, unknown | null>): Promise<StackRecord> {
+    return this.record.patchContent(id, patch);
   }
 
-  async deleteRecord(id: string, opts: { hard?: boolean } = {}): Promise<void> {
-    if (opts.hard) {
-      this.hardDeleteRecord(id);
-    } else {
-      this.db.run(
-        'UPDATE records SET deleted_at = ?, version = version + 1, updated_at = ? WHERE id = ?',
-        [toMs(new Date()), toMs(new Date()), id],
-      );
-    }
-    this.persist();
+  deleteRecord(id: string, opts?: { hard?: boolean }): Promise<void> {
+    return this.record.deleteRecord(id, opts);
   }
 
-  /** Deletes a record's associations, versions, FTS entry, and row — no persist(). */
-  private hardDeleteRecord(id: string): void {
-    this.db.run('DELETE FROM associations WHERE record_id = ?', [id]);
-    this.db.run('DELETE FROM versions WHERE record_id = ?', [id]);
-    this.db.run(`DELETE FROM records_fts WHERE docid = (SELECT rowid FROM records WHERE id = ?)`, [
-      id,
-    ]);
-    this.db.run('DELETE FROM records WHERE id = ?', [id]);
+  undeleteRecord(id: string): Promise<StackRecord> {
+    return this.record.undeleteRecord(id);
   }
 
-  async undeleteRecord(id: string): Promise<StackRecord> {
-    this.db.run(
-      'UPDATE records SET deleted_at = NULL, version = version + 1, updated_at = ? WHERE id = ?',
-      [toMs(new Date()), id],
-    );
-    this.persist();
-
-    const updated = await this.getRecord(id);
-    if (!updated) throw new Error(`Record not found after undelete: "${id}"`);
-    return updated;
+  setPermissions(id: string, permissions: Permission[]): Promise<void> {
+    return this.record.setPermissions(id, permissions);
   }
 
-  async setPermissions(id: string, permissions: Permission[]): Promise<void> {
-    this.db.run(
-      'UPDATE records SET permissions = ?, version = version + 1, updated_at = ? WHERE id = ?',
-      [permissions.length ? JSON.stringify(permissions) : null, toMs(new Date()), id],
-    );
-    this.persist();
+  restoreVersion(id: string, version: number): Promise<StackRecord> {
+    return this.record.restoreVersion(id, version);
   }
 
-  async restoreVersion(id: string, version: number): Promise<StackRecord> {
-    const target = await this.getVersion(id, version);
-    if (!target) throw new Error(`Version not found: ${id}@${version}`);
-
-    this.db.run(
-      'UPDATE records SET content = ?, version = version + 1, updated_at = ? WHERE id = ?',
-      [JSON.stringify(target.content), toMs(new Date()), id],
-    );
-    if (target.associations !== undefined) {
-      this.db.run('DELETE FROM associations WHERE record_id = ?', [id]);
-      if (target.associations.length) this.insertAssociations(id, target.associations);
-    }
-    this.updateFts(id, JSON.stringify(target.content));
-    this.persist();
-
-    const updated = await this.getRecord(id);
-    if (!updated) throw new Error(`Record not found after restoreVersion: "${id}"`);
-    return updated;
-  }
-
-  async commitMigration(
+  commitMigration(
     id: string,
     toTypeId: TypeId,
     content: Record<string, unknown>,
   ): Promise<StackRecord> {
-    this.db.run(
-      'UPDATE records SET type_id = ?, content = ?, version = version + 1, updated_at = ? WHERE id = ?',
-      [toTypeId, JSON.stringify(content), toMs(new Date()), id],
-    );
-    this.updateFts(id, JSON.stringify(content));
-    this.persist();
-
-    const updated = await this.getRecord(id);
-    if (!updated) throw new Error(`Record not found after commitMigration: "${id}"`);
-    return updated;
+    return this.record.commitMigration(id, toTypeId, content);
   }
 
-  async queryRecords(query: StackQuery): Promise<QueryResult> {
-    const { sql: where, params } = buildWhereClause(query, sanitizeFts4Query);
-    const order = buildOrderClause(query);
-    const limit = query.limit ?? 50;
-
-    // Fetch one extra to determine if there's a next page
-    const rows = this.execQuery<Record<string, unknown>>(
-      `SELECT r.* FROM records r ${where} ${order} LIMIT ?`,
-      [...params, limit + 1],
-    );
-
-    const hasMore = rows.length > limit;
-    const page = hasMore ? rows.slice(0, limit) : rows;
-
-    const records = page.map((row) => {
-      const associations = this.getAssociationsForRecord(row.id as string);
-      return rowToRecord(row, associations);
-    });
-
-    // Total count (without pagination)
-    const countRows = this.execQuery<{ total: number }>(
-      `SELECT COUNT(*) as total FROM records r ${where}`,
-      params,
-    );
-    const total = countRows[0]?.total ?? 0;
-
-    const lastRecord = records[records.length - 1];
-    const cursor = hasMore && lastRecord ? makeCursor(lastRecord, getSortField(query)) : null;
-
-    return { records, cursor, total };
+  queryRecords(query: StackQuery): Promise<QueryResult> {
+    return this.record.queryRecords(query);
   }
 
-  /**
-   * Atomically verify fileId is unreferenced, then hard-delete every
-   * metadataTypeId record whose content.fileId matches it. See
-   * StackRecordAdapter.deleteUnreferencedAttachmentRecords(). Runs as a
-   * real SQL transaction and, being entirely synchronous SQLite calls
-   * with no `await` in between, nothing else can interleave between the
-   * reference check and the deletes.
-   */
-  async deleteUnreferencedAttachmentRecords(
-    fileId: FileId,
-    metadataTypeId: TypeId,
-  ): Promise<RecordId[]> {
-    this.db.run('BEGIN');
-    try {
-      const referenced = this.execQuery<{ found: number }>(
-        `SELECT 1 as found FROM associations WHERE kind = 'attachment' AND file_id = ? LIMIT 1`,
-        [fileId],
-      );
-      if (referenced.length) {
-        throw new StackConflictError('Attachment is still referenced by one or more records');
-      }
-
-      const metaRows = this.execQuery<{ id: string }>(
-        `SELECT id FROM records WHERE type_id = ? AND json_extract(content, '$.fileId') = ?`,
-        [metadataTypeId, fileId],
-      );
-      const deletedIds = metaRows.map((row) => row.id);
-      for (const id of deletedIds) {
-        this.hardDeleteRecord(id);
-      }
-
-      this.db.run('COMMIT');
-      if (deletedIds.length) this.persist();
-      return deletedIds;
-    } catch (err) {
-      this.db.run('ROLLBACK');
-      throw err;
-    }
+  deleteUnreferencedAttachmentRecords(fileId: FileId, metadataTypeId: TypeId): Promise<RecordId[]> {
+    return this.record.deleteUnreferencedAttachmentRecords(fileId, metadataTypeId);
   }
 
   // -------------------------------------------------------
   // Versions
   // -------------------------------------------------------
 
-  async getVersions(id: string): Promise<RecordVersion[]> {
-    const rows = this.execQuery<Record<string, unknown>>(
-      'SELECT * FROM versions WHERE record_id = ? ORDER BY version DESC',
-      [id],
-    );
-    return rows.map(rowToVersion);
+  getVersions(id: string): Promise<RecordVersion[]> {
+    return this.record.getVersions(id);
   }
 
-  async getVersion(id: string, version: number): Promise<RecordVersion | null> {
-    const rows = this.execQuery<Record<string, unknown>>(
-      'SELECT * FROM versions WHERE record_id = ? AND version = ?',
-      [id, version],
-    );
-    return rows.length ? rowToVersion(rows[0]) : null;
+  getVersion(id: string, version: number): Promise<RecordVersion | null> {
+    return this.record.getVersion(id, version);
   }
 
-  async saveVersion(id: string, version: RecordVersion): Promise<void> {
-    this.db.run(
-      `INSERT OR IGNORE INTO versions
-        (record_id, version, content, updated_at, entity_id, associations, permissions)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
-      [
-        id,
-        version.version,
-        JSON.stringify(version.content),
-        toMs(version.updatedAt),
-        version.entityId ?? null,
-        version.associations ? JSON.stringify(version.associations) : null,
-        version.permissions ? JSON.stringify(version.permissions) : null,
-      ],
-    );
-    this.persist();
+  saveVersion(id: string, version: RecordVersion): Promise<void> {
+    return this.record.saveVersion(id, version);
   }
 
   // -------------------------------------------------------
   // Types
   // -------------------------------------------------------
 
-  async saveType(type: StackType): Promise<void> {
-    this.db.run(
-      `INSERT OR REPLACE INTO types
-        (id, base_id, version, name, schema, schema_hash, migrates_from, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-      [
-        type.id,
-        type.baseId,
-        type.version,
-        type.name,
-        JSON.stringify(type.schema),
-        type.schemaHash,
-        type.migratesFrom ?? null,
-        toMs(type.createdAt),
-      ],
-    );
-    this.persist();
+  saveType(type: StackType): Promise<void> {
+    return this.record.saveType(type);
   }
 
-  async getType(id: TypeId): Promise<StackType | null> {
-    const rows = this.execQuery<Record<string, unknown>>('SELECT * FROM types WHERE id = ?', [id]);
-    return rows.length ? rowToType(rows[0]) : null;
+  getType(id: TypeId): Promise<StackType | null> {
+    return this.record.getType(id);
   }
 
-  async listTypes(): Promise<StackType[]> {
-    const rows = this.execQuery<Record<string, unknown>>(
-      'SELECT * FROM types ORDER BY base_id, version',
-    );
-    return rows.map(rowToType);
-  }
-
-  // -------------------------------------------------------
-  // Tokens
-  // -------------------------------------------------------
-
-  async createToken(
-    entityId: string,
-    opts: { label?: string; expiresAt?: Date } = {},
-  ): Promise<{ id: string; token: string }> {
-    const id = randomBytes(8).toString('hex');
-    const token = randomBytes(32).toString('hex');
-    const tokenHash = createHash('sha256').update(token).digest('hex');
-    this.db.run(
-      'INSERT INTO tokens (id, token_hash, entity_id, label, created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?)',
-      [
-        id,
-        tokenHash,
-        entityId,
-        opts.label ?? null,
-        toMs(new Date()),
-        opts.expiresAt ? toMs(opts.expiresAt) : null,
-      ],
-    );
-    this.persist();
-    return { id, token };
-  }
-
-  async lookupToken(token: string): Promise<{ entityId: string } | null> {
-    const hash = createHash('sha256').update(token).digest('hex');
-    const rows = this.execQuery<{ entity_id: string; expires_at: number | null }>(
-      'SELECT entity_id, expires_at FROM tokens WHERE token_hash = ?',
-      [hash],
-    );
-    if (!rows.length) return null;
-    const row = rows[0];
-    if (row.expires_at !== null && Date.now() > row.expires_at) return null;
-    return { entityId: row.entity_id };
-  }
-
-  async listTokens(): Promise<TokenInfo[]> {
-    const rows = this.execQuery<{
-      id: string;
-      entity_id: string;
-      label: string | null;
-      created_at: number;
-      expires_at: number | null;
-    }>('SELECT id, entity_id, label, created_at, expires_at FROM tokens ORDER BY created_at DESC');
-    return rows.map((row) => ({
-      id: row.id,
-      entityId: row.entity_id,
-      ...(row.label && { label: row.label }),
-      createdAt: fromMs(row.created_at),
-      ...(row.expires_at !== null && { expiresAt: fromMs(row.expires_at) }),
-    }));
-  }
-
-  async revokeToken(id: string): Promise<void> {
-    this.db.run('DELETE FROM tokens WHERE id = ?', [id]);
-    this.persist();
+  listTypes(): Promise<StackType[]> {
+    return this.record.listTypes();
   }
 
   // -------------------------------------------------------
   // Associations
   // -------------------------------------------------------
 
-  async associate(recordId: string, association: Association): Promise<void> {
-    this.insertAssociations(recordId, [association]);
-    this.bumpVersion(recordId);
-    this.persist();
+  associate(recordId: string, association: Association): Promise<void> {
+    return this.record.associate(recordId, association);
   }
 
-  async dissociate(recordId: string, association: Association): Promise<void> {
-    this.db.run(
-      `DELETE FROM associations
-       WHERE record_id = ?
-         AND kind = ?
-         AND label = ?
-         AND file_id    = ?
-         AND related_id = ?`,
-      [
-        recordId,
-        association.kind,
-        association.label,
-        association.kind === 'attachment' ? association.fileId : '',
-        association.kind === 'relationship' ? association.recordId : '',
-      ],
-    );
-    this.bumpVersion(recordId);
-    this.persist();
+  dissociate(recordId: string, association: Association): Promise<void> {
+    return this.record.dissociate(recordId, association);
   }
 
-  private bumpVersion(id: string): void {
-    this.db.run('UPDATE records SET version = version + 1, updated_at = ? WHERE id = ?', [
-      toMs(new Date()),
-      id,
-    ]);
+  // -------------------------------------------------------
+  // Tokens
+  // -------------------------------------------------------
+
+  createToken(
+    entityId: string,
+    opts?: { label?: string; expiresAt?: Date },
+  ): Promise<{ id: string; token: string }> {
+    return this.tokens.createToken(entityId, opts);
   }
 
-  /**
-   * FK enforcement (PRAGMA_FOREIGN_KEYS_ON) means inserting an
-   * association against a record that doesn't exist throws — mapped
-   * here to StackNotFoundError so associate() on a nonexistent record
-   * fails loudly with a proper error instead of silently creating an
-   * orphan row.
-   */
-  private insertAssociations(recordId: string, associations: Association[]): void {
-    for (const assoc of associations) {
-      try {
-        this.db.run(
-          `INSERT OR IGNORE INTO associations
-            (record_id, kind, label, file_id, mime_type, related_id)
-           VALUES (?, ?, ?, ?, ?, ?)`,
-          [
-            recordId,
-            assoc.kind,
-            assoc.label,
-            assoc.kind === 'attachment' ? assoc.fileId : '',
-            assoc.kind === 'attachment' ? assoc.mimeType : null,
-            assoc.kind === 'relationship' ? assoc.recordId : '',
-          ],
-        );
-      } catch (err) {
-        if (isForeignKeyViolation(err)) {
-          throw new StackNotFoundError(`Record not found: "${recordId}"`);
-        }
-        throw err;
-      }
-    }
+  lookupToken(token: string): Promise<{ entityId: string } | null> {
+    return this.tokens.lookupToken(token);
   }
 
-  private getAssociationsForRecord(recordId: string): Association[] {
-    const rows = this.execQuery<Record<string, unknown>>(
-      'SELECT * FROM associations WHERE record_id = ?',
-      [recordId],
-    );
-    return rows.map(rowToAssociation);
+  listTokens(): Promise<TokenInfo[]> {
+    return this.tokens.listTokens();
   }
 
-  private updateFts(recordId: string, content: string): void {
-    // FTS4 content table — delete old entry then insert new one
-    this.db.run(`DELETE FROM records_fts WHERE docid = (SELECT rowid FROM records WHERE id = ?)`, [
-      recordId,
-    ]);
-    this.db.run(
-      `INSERT INTO records_fts(docid, content)
-       SELECT rowid, ? FROM records WHERE id = ?`,
-      [content, recordId],
-    );
-  }
-
-  private execQuery<T>(sql: string, params: unknown[] = []): T[] {
-    const stmt = this.db.prepare(sql);
-    stmt.bind(params as import('sql.js').BindParams);
-    const results: T[] = [];
-    while (stmt.step()) {
-      results.push(stmt.getAsObject() as T);
-    }
-    stmt.free();
-    return results;
+  revokeToken(id: string): Promise<void> {
+    return this.tokens.revokeToken(id);
   }
 
   // -------------------------------------------------------

--- a/packages/sqlite-shared/src/config.ts
+++ b/packages/sqlite-shared/src/config.ts
@@ -1,0 +1,21 @@
+import type { SqlExecutor } from './executor.js';
+
+export type StackConfig = { entityId: string; timezone: string };
+
+/** Inserts the singleton _config@1 record. Only valid on a freshly-created database. */
+export const insertConfigRecord = (exec: SqlExecutor, entityId: string, timezone: string): void => {
+  const now = Date.now();
+  exec.run(
+    `INSERT INTO records (id, type_id, created_at, updated_at, content, version)
+     VALUES ('_config', '_config@1', ?, ?, ?, 1)`,
+    [now, now, JSON.stringify({ entityId, timezone })],
+  );
+};
+
+/** Reads the singleton _config@1 record. Throws if the database is missing it. */
+export const readStackConfig = (exec: SqlExecutor): StackConfig => {
+  const row = exec.get<{ content: string }>(`SELECT content FROM records WHERE id = '_config'`);
+  if (!row) throw new Error('Stack database is missing its config record.');
+  const content = JSON.parse(row.content) as { entityId: string; timezone?: string };
+  return { entityId: content.entityId, timezone: content.timezone ?? 'UTC' };
+};

--- a/packages/sqlite-shared/src/executor.ts
+++ b/packages/sqlite-shared/src/executor.ts
@@ -1,0 +1,22 @@
+/**
+ * Normalizes sql.js's and node:sqlite's different call conventions
+ * (array-bind-then-step vs. spread-args run/get/all) behind one
+ * interface, so the actual CRUD/query/version/type/association/token
+ * logic can live once in this package instead of being re-typed per
+ * engine. Each adapter package provides a thin SqlExecutor
+ * implementation over its own database handle.
+ */
+export interface SqlExecutor {
+  /** Run DDL, pragmas, or any statement(s) with no bound params and no results needed. */
+  exec(sql: string): void;
+  /** Run a single parameterized statement, discarding any result rows. */
+  run(sql: string, params?: readonly unknown[]): void;
+  /** Run a parameterized statement and return the first result row, or undefined. */
+  get<T = Record<string, unknown>>(sql: string, params?: readonly unknown[]): T | undefined;
+  /** Run a parameterized statement and return all result rows. */
+  all<T = Record<string, unknown>>(sql: string, params?: readonly unknown[]): T[];
+}
+
+/** Both sql.js's and node:sqlite's SQLite builds report FK violations with this exact message. */
+export const isForeignKeyViolation = (err: unknown): boolean =>
+  err instanceof Error && err.message.includes('FOREIGN KEY constraint failed');

--- a/packages/sqlite-shared/src/fts-strategy.ts
+++ b/packages/sqlite-shared/src/fts-strategy.ts
@@ -1,0 +1,20 @@
+import type { SqlExecutor } from './executor.js';
+
+/**
+ * The one piece of record indexing that genuinely differs between FTS4
+ * and FTS5: FTS4's plain DELETE-then-INSERT works fine, but FTS5's
+ * external-content table needs its special `('delete', rowid, content)`
+ * command (with the *old* content) to correctly unindex a row — see
+ * fts5.ts's fts5Strategy for why. Everything else in record indexing is
+ * identical, which is why only this seam needs to be pluggable.
+ */
+export type FtsStrategy = {
+  /** Index a record that has no FTS entry yet (used right after an INSERT). */
+  insert(exec: SqlExecutor, recordId: string, content: string): void;
+  /**
+   * Remove a record's FTS entry. MUST be called before the records row's
+   * content changes or the row is deleted, since some strategies need to
+   * read the current content to build the removal.
+   */
+  remove(exec: SqlExecutor, recordId: string): void;
+};

--- a/packages/sqlite-shared/src/fts.ts
+++ b/packages/sqlite-shared/src/fts.ts
@@ -17,6 +17,9 @@
  * sanitizer reviewed against FTS5's rules rather than assuming this one
  * transfers — tracked with the native adapter's work, not duplicated here.
  */
+
+import type { FtsStrategy } from './fts-strategy.js';
+
 export const sanitizeFts4Query = (query: string, maxDepth = 2): string => {
   if (!query) return '';
 
@@ -59,4 +62,27 @@ export const sanitizeFts4Query = (query: string, maxDepth = 2): string => {
   } while (result !== prev);
 
   return result.replace(/\s+/g, ' ').replace(/\(\s+/g, '(').replace(/\s+\)/g, ')').trim();
+};
+
+// -------------------------------------------------------
+// Indexing strategy
+// -------------------------------------------------------
+
+/**
+ * FTS4's `content='records'` table uses `docid` as its rowid alias. A
+ * plain DELETE by docid is sufficient to unindex a row — FTS4 doesn't
+ * need the old content to do so, unlike FTS5 (see fts5Strategy).
+ */
+export const fts4Strategy: FtsStrategy = {
+  insert(exec, recordId, content) {
+    exec.run(`INSERT INTO records_fts(docid, content) SELECT rowid, ? FROM records WHERE id = ?`, [
+      content,
+      recordId,
+    ]);
+  },
+  remove(exec, recordId) {
+    exec.run(`DELETE FROM records_fts WHERE docid = (SELECT rowid FROM records WHERE id = ?)`, [
+      recordId,
+    ]);
+  },
 };

--- a/packages/sqlite-shared/src/fts5.ts
+++ b/packages/sqlite-shared/src/fts5.ts
@@ -1,0 +1,70 @@
+/**
+ * FTS5 query sanitization — used by the native (node:sqlite) adapter.
+ *
+ * FTS5's query grammar is close to FTS4's but not identical, so this is a
+ * separate function rather than a shared one (see the note on
+ * sanitizeFts4Query for the general approach), reviewed against real
+ * FTS5 rather than assumed. Two differences that matter here:
+ *
+ * - FTS5's NEAR is a function-call form — `NEAR(a b, 10)` — not FTS4's
+ *   infix `a NEAR/10 b`. Deleting the whole span (as FTS4 does for its
+ *   infix operator) would also delete the terms inside it, which can
+ *   leave a dangling operator when NEAR(...) sits next to AND/OR (e.g.
+ *   "x AND NEAR(a b, 5)" -> "x AND" — a syntax error). So this keeps
+ *   the terms and drops only the NEAR(...) wrapper and distance.
+ * - FTS5 has real column-filter syntax (`colname:term`) and errors hard
+ *   on any name but the table's actual columns — since records_fts has
+ *   exactly one column and callers have no business targeting columns
+ *   explicitly, colons are stripped outright rather than validated.
+ *
+ *   kept:    AND/OR/NOT (with a left operand), phrase queries ("…"), implicit AND
+ *   removed: wildcards (*), NEAR(...) (terms kept, wrapper dropped), column-filter
+ *            colons, bare NOT (no left operand)
+ *   capped:  parenthesis nesting depth (default: 2)
+ */
+export const sanitizeFts5Query = (query: string, maxDepth = 2): string => {
+  if (!query) return '';
+
+  // Remove wildcards
+  let clean = query.replace(/\*/g, '');
+
+  // Replace NEAR(terms, distance) with just its terms — see note above.
+  clean = clean.replace(/\bNEAR\s*\(\s*([^,)]*)(?:,[^)]*)?\)/gi, '$1');
+
+  // Strip column-filter colons — see note above.
+  clean = clean.replace(/:/g, ' ');
+
+  // Strip bare NOT with no left operand — FTS5 requires "term NOT term", not "NOT term"
+  clean = clean.replace(/(?:^|\(\s*)NOT\s+/gi, (m) => m.replace(/NOT\s+/i, ''));
+
+  // Enforce max nesting depth; replace excess ( with a space and discard unmatched )
+  let currentDepth = 0;
+  let result = '';
+  for (const char of clean) {
+    if (char === '(') {
+      if (currentDepth < maxDepth) {
+        currentDepth++;
+        result += char;
+      } else result += ' ';
+    } else if (char === ')') {
+      if (currentDepth > 0) {
+        currentDepth--;
+        result += char;
+      } else result += ' ';
+    } else {
+      result += char;
+    }
+  }
+
+  // Auto-close any unclosed parens
+  if (currentDepth > 0) result += ')'.repeat(currentDepth);
+
+  // Iteratively remove empty paren pairs left behind by NEAR/NOT stripping
+  let prev: string;
+  do {
+    prev = result;
+    result = result.replace(/\(\s*\)/g, ' ');
+  } while (result !== prev);
+
+  return result.replace(/\s+/g, ' ').replace(/\(\s+/g, '(').replace(/\s+\)/g, ')').trim();
+};

--- a/packages/sqlite-shared/src/fts5.ts
+++ b/packages/sqlite-shared/src/fts5.ts
@@ -22,6 +22,9 @@
  *            colons, bare NOT (no left operand)
  *   capped:  parenthesis nesting depth (default: 2)
  */
+
+import type { FtsStrategy } from './fts-strategy.js';
+
 export const sanitizeFts5Query = (query: string, maxDepth = 2): string => {
   if (!query) return '';
 
@@ -67,4 +70,37 @@ export const sanitizeFts5Query = (query: string, maxDepth = 2): string => {
   } while (result !== prev);
 
   return result.replace(/\s+/g, ' ').replace(/\(\s+/g, '(').replace(/\s+\)/g, ')').trim();
+};
+
+// -------------------------------------------------------
+// Indexing strategy
+// -------------------------------------------------------
+
+/**
+ * FTS5's external-content table needs its special `('delete', rowid,
+ * content)` command — with the *old* content — to correctly unindex a
+ * row; a plain DELETE leaves stale, still-searchable entries behind
+ * (discovered and regression-tested while building the native adapter).
+ * `remove()` therefore reads the current rowid/content before whatever
+ * caller-side change is about to happen, which is why it must run
+ * before that change, not after.
+ */
+export const fts5Strategy: FtsStrategy = {
+  insert(exec, recordId, content) {
+    exec.run(`INSERT INTO records_fts(rowid, content) SELECT rowid, ? FROM records WHERE id = ?`, [
+      content,
+      recordId,
+    ]);
+  },
+  remove(exec, recordId) {
+    const row = exec.get<{ rowid: number; content: string }>(
+      'SELECT rowid, content FROM records WHERE id = ?',
+      [recordId],
+    );
+    if (!row) return;
+    exec.run(`INSERT INTO records_fts(records_fts, rowid, content) VALUES('delete', ?, ?)`, [
+      row.rowid,
+      row.content,
+    ]);
+  },
 };

--- a/packages/sqlite-shared/src/index.ts
+++ b/packages/sqlite-shared/src/index.ts
@@ -22,6 +22,11 @@ export {
   type DecodedCursor,
 } from './cursor.js';
 export { rowToRecord, rowToAssociation, rowToType, rowToVersion, toMs, fromMs } from './mappers.js';
-export { sanitizeFts4Query } from './fts.js';
-export { sanitizeFts5Query } from './fts5.js';
+export { sanitizeFts4Query, fts4Strategy } from './fts.js';
+export { sanitizeFts5Query, fts5Strategy } from './fts5.js';
+export { type FtsStrategy } from './fts-strategy.js';
 export { acquireLock, releaseLock } from './lock.js';
+export { type SqlExecutor, isForeignKeyViolation } from './executor.js';
+export { insertConfigRecord, readStackConfig, type StackConfig } from './config.js';
+export { SharedSqlRecordLogic, type SharedSqlRecordLogicDeps } from './record-logic.js';
+export { SharedTokenLogic, type SharedTokenLogicDeps } from './token-logic.js';

--- a/packages/sqlite-shared/src/index.ts
+++ b/packages/sqlite-shared/src/index.ts
@@ -1,4 +1,11 @@
-export { RECORD_SCHEMA_SQL, FTS4_SCHEMA_SQL, PRAGMA_FOREIGN_KEYS_ON } from './schema.js';
+export {
+  RECORD_SCHEMA_SQL,
+  TOKENS_SCHEMA_SQL,
+  FTS4_SCHEMA_SQL,
+  FTS5_SCHEMA_SQL,
+  PRAGMA_FOREIGN_KEYS_ON,
+  PRAGMA_JOURNAL_MODE_WAL,
+} from './schema.js';
 export {
   buildWhereClause,
   buildOrderClause,
@@ -16,3 +23,5 @@ export {
 } from './cursor.js';
 export { rowToRecord, rowToAssociation, rowToType, rowToVersion, toMs, fromMs } from './mappers.js';
 export { sanitizeFts4Query } from './fts.js';
+export { sanitizeFts5Query } from './fts5.js';
+export { acquireLock, releaseLock } from './lock.js';

--- a/packages/sqlite-shared/src/lock.ts
+++ b/packages/sqlite-shared/src/lock.ts
@@ -1,0 +1,59 @@
+/**
+ * Storage-ownership lock file. A stack file is owned by exactly one
+ * process at a time (see docs/spec.md § Concurrency & storage ownership).
+ * The lock file sits beside the database and records the PID of its
+ * opener — pure Node fs/process logic, no SQLite engine involved, so
+ * every Node-backed record adapter shares one implementation and one
+ * error message.
+ */
+
+import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'fs';
+
+type LockInfo = { pid: number };
+
+const lockPathFor = (dbPath: string): string => `${dbPath}.lock`;
+
+const isProcessAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // ESRCH: no such process — safe to reclaim. Anything else (e.g. EPERM,
+    // meaning the process exists but we can't signal it) — assume alive.
+    return (err as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+};
+
+/**
+ * Acquire the lock, throwing a clear error if another live process
+ * already holds it. Reclaims stale locks (owning process no longer
+ * running) automatically. `force` bypasses the check entirely, for the
+ * rare case of PID reuse across a reboot.
+ */
+export const acquireLock = (dbPath: string, force?: boolean): void => {
+  const lockPath = lockPathFor(dbPath);
+  if (existsSync(lockPath)) {
+    const info = JSON.parse(readFileSync(lockPath, 'utf-8')) as LockInfo;
+    const ownedBySelf = info.pid === process.pid;
+    if (!ownedBySelf && !force && isProcessAlive(info.pid)) {
+      throw new Error(
+        `Stack database at "${dbPath}" is in use by another process (pid ${info.pid}). ` +
+          `Connect via its server instead, or pass { force: true } to override.`,
+      );
+    }
+  }
+  writeFileSync(lockPath, JSON.stringify({ pid: process.pid } satisfies LockInfo));
+};
+
+/** Release the lock, if it's still owned by this process. */
+export const releaseLock = (dbPath: string): void => {
+  const lockPath = lockPathFor(dbPath);
+  if (!existsSync(lockPath)) return;
+  try {
+    const info = JSON.parse(readFileSync(lockPath, 'utf-8')) as LockInfo;
+    if (info.pid === process.pid) unlinkSync(lockPath);
+  } catch {
+    // Corrupt lock file — remove it rather than leaving storage permanently unopenable.
+    unlinkSync(lockPath);
+  }
+};

--- a/packages/sqlite-shared/src/record-logic.ts
+++ b/packages/sqlite-shared/src/record-logic.ts
@@ -1,0 +1,413 @@
+/**
+ * The actual StackRecordAdapter logic (minus lifecycle: initialize/open/
+ * close/flush stay per-engine, since schema setup, pragmas, locking, and
+ * durability differ there). Every CRUD/query/version/type/association
+ * operation lives here exactly once, parametrized over a SqlExecutor
+ * (normalizes sql.js vs node:sqlite's call conventions) and an
+ * FtsStrategy (the one place FTS4 and FTS5 genuinely differ). Concrete
+ * adapters construct one of these and delegate their StackRecordAdapter
+ * methods to it — see record-adapter-sqljs and record-adapter-sqlite.
+ */
+
+import { StackConflictError, StackNotFoundError, applyMergePatch } from '@haverstack/core';
+import type {
+  StackRecord,
+  StackType,
+  TypeId,
+  RecordId,
+  FileId,
+  RecordVersion,
+  StackQuery,
+  QueryResult,
+  Association,
+  Permission,
+} from '@haverstack/core';
+import type { SqlExecutor } from './executor.js';
+import { isForeignKeyViolation } from './executor.js';
+import type { FtsStrategy } from './fts-strategy.js';
+import { buildWhereClause, buildOrderClause, getSortField } from './query.js';
+import type { SanitizeSearch } from './query.js';
+import { rowToRecord, rowToAssociation, rowToType, rowToVersion, toMs } from './mappers.js';
+import { makeCursor } from './cursor.js';
+
+export type SharedSqlRecordLogicDeps = {
+  exec: SqlExecutor;
+  fts: FtsStrategy;
+  sanitizeSearch: SanitizeSearch;
+  /** Called after every mutating operation. Omit for engines with durable writes (e.g. native SQLite/WAL); sql.js uses this to export+rename. */
+  onWrite?: () => void;
+};
+
+export class SharedSqlRecordLogic {
+  constructor(private readonly deps: SharedSqlRecordLogicDeps) {}
+
+  private get exec(): SqlExecutor {
+    return this.deps.exec;
+  }
+
+  private get fts(): FtsStrategy {
+    return this.deps.fts;
+  }
+
+  private write(): void {
+    this.deps.onWrite?.();
+  }
+
+  // -------------------------------------------------------
+  // Records
+  // -------------------------------------------------------
+
+  async createRecord(record: StackRecord): Promise<StackRecord> {
+    this.exec.run(
+      `INSERT INTO records
+        (id, type_id, created_at, updated_at, content, version,
+         parent_id, entity_id, app_id, deleted_at, permissions)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        record.id,
+        record.typeId,
+        toMs(record.createdAt),
+        toMs(record.updatedAt),
+        JSON.stringify(record.content),
+        record.version,
+        record.parentId ?? null,
+        record.entityId ?? null,
+        record.appId ?? null,
+        record.deletedAt ? toMs(record.deletedAt) : null,
+        record.permissions ? JSON.stringify(record.permissions) : null,
+      ],
+    );
+
+    if (record.associations?.length) {
+      this.insertAssociations(record.id, record.associations);
+    }
+
+    this.fts.insert(this.exec, record.id, JSON.stringify(record.content));
+    this.write();
+    return record;
+  }
+
+  async getRecord(id: string): Promise<StackRecord | null> {
+    const row = this.exec.get<Record<string, unknown>>('SELECT * FROM records WHERE id = ?', [id]);
+    if (!row) return null;
+    const associations = this.getAssociationsForRecord(id);
+    return rowToRecord(row, associations);
+  }
+
+  async patchContent(id: string, patch: Record<string, unknown | null>): Promise<StackRecord> {
+    const existing = await this.getRecord(id);
+    if (!existing) throw new Error(`Record not found: "${id}"`);
+
+    const merged = applyMergePatch(existing.content, patch);
+    this.fts.remove(this.exec, id);
+    this.exec.run(
+      'UPDATE records SET content = ?, version = version + 1, updated_at = ? WHERE id = ?',
+      [JSON.stringify(merged), toMs(new Date()), id],
+    );
+    this.fts.insert(this.exec, id, JSON.stringify(merged));
+    this.write();
+
+    const updated = await this.getRecord(id);
+    if (!updated) throw new Error(`Record not found after patchContent: "${id}"`);
+    return updated;
+  }
+
+  async deleteRecord(id: string, opts: { hard?: boolean } = {}): Promise<void> {
+    if (opts.hard) {
+      this.hardDeleteRecord(id);
+    } else {
+      this.exec.run(
+        'UPDATE records SET deleted_at = ?, version = version + 1, updated_at = ? WHERE id = ?',
+        [toMs(new Date()), toMs(new Date()), id],
+      );
+    }
+    this.write();
+  }
+
+  /** Deletes a record's FTS entry, associations, versions, and row. No write() call — callers batch it. */
+  private hardDeleteRecord(id: string): void {
+    this.fts.remove(this.exec, id);
+    this.exec.run('DELETE FROM associations WHERE record_id = ?', [id]);
+    this.exec.run('DELETE FROM versions WHERE record_id = ?', [id]);
+    this.exec.run('DELETE FROM records WHERE id = ?', [id]);
+  }
+
+  async undeleteRecord(id: string): Promise<StackRecord> {
+    this.exec.run(
+      'UPDATE records SET deleted_at = NULL, version = version + 1, updated_at = ? WHERE id = ?',
+      [toMs(new Date()), id],
+    );
+    this.write();
+
+    const updated = await this.getRecord(id);
+    if (!updated) throw new Error(`Record not found after undelete: "${id}"`);
+    return updated;
+  }
+
+  async setPermissions(id: string, permissions: Permission[]): Promise<void> {
+    this.exec.run(
+      'UPDATE records SET permissions = ?, version = version + 1, updated_at = ? WHERE id = ?',
+      [permissions.length ? JSON.stringify(permissions) : null, toMs(new Date()), id],
+    );
+    this.write();
+  }
+
+  async restoreVersion(id: string, version: number): Promise<StackRecord> {
+    const target = await this.getVersion(id, version);
+    if (!target) throw new Error(`Version not found: ${id}@${version}`);
+
+    this.fts.remove(this.exec, id);
+    this.exec.run(
+      'UPDATE records SET content = ?, version = version + 1, updated_at = ? WHERE id = ?',
+      [JSON.stringify(target.content), toMs(new Date()), id],
+    );
+    if (target.associations !== undefined) {
+      this.exec.run('DELETE FROM associations WHERE record_id = ?', [id]);
+      if (target.associations.length) this.insertAssociations(id, target.associations);
+    }
+    this.fts.insert(this.exec, id, JSON.stringify(target.content));
+    this.write();
+
+    const updated = await this.getRecord(id);
+    if (!updated) throw new Error(`Record not found after restoreVersion: "${id}"`);
+    return updated;
+  }
+
+  async commitMigration(
+    id: string,
+    toTypeId: TypeId,
+    content: Record<string, unknown>,
+  ): Promise<StackRecord> {
+    this.fts.remove(this.exec, id);
+    this.exec.run(
+      'UPDATE records SET type_id = ?, content = ?, version = version + 1, updated_at = ? WHERE id = ?',
+      [toTypeId, JSON.stringify(content), toMs(new Date()), id],
+    );
+    this.fts.insert(this.exec, id, JSON.stringify(content));
+    this.write();
+
+    const updated = await this.getRecord(id);
+    if (!updated) throw new Error(`Record not found after commitMigration: "${id}"`);
+    return updated;
+  }
+
+  async queryRecords(query: StackQuery): Promise<QueryResult> {
+    const { sql: where, params } = buildWhereClause(query, this.deps.sanitizeSearch);
+    const order = buildOrderClause(query);
+    const limit = query.limit ?? 50;
+
+    // Fetch one extra to determine if there's a next page
+    const rows = this.exec.all<Record<string, unknown>>(
+      `SELECT r.* FROM records r ${where} ${order} LIMIT ?`,
+      [...params, limit + 1],
+    );
+
+    const hasMore = rows.length > limit;
+    const page = hasMore ? rows.slice(0, limit) : rows;
+
+    const records = page.map((row) => {
+      const associations = this.getAssociationsForRecord(row.id as string);
+      return rowToRecord(row, associations);
+    });
+
+    const countRows = this.exec.all<{ total: number }>(
+      `SELECT COUNT(*) as total FROM records r ${where}`,
+      params,
+    );
+    const total = countRows[0]?.total ?? 0;
+
+    const lastRecord = records[records.length - 1];
+    const cursor = hasMore && lastRecord ? makeCursor(lastRecord, getSortField(query)) : null;
+
+    return { records, cursor, total };
+  }
+
+  /**
+   * Atomically verify fileId is unreferenced, then hard-delete every
+   * metadataTypeId record whose content.fileId matches it. See
+   * StackRecordAdapter.deleteUnreferencedAttachmentRecords(). Runs as a
+   * real SQL transaction and, being entirely synchronous SQL calls with
+   * no `await` in between, nothing else can interleave between the
+   * reference check and the deletes.
+   */
+  async deleteUnreferencedAttachmentRecords(
+    fileId: FileId,
+    metadataTypeId: TypeId,
+  ): Promise<RecordId[]> {
+    this.exec.exec('BEGIN');
+    try {
+      const referenced = this.exec.all<{ found: number }>(
+        `SELECT 1 as found FROM associations WHERE kind = 'attachment' AND file_id = ? LIMIT 1`,
+        [fileId],
+      );
+      if (referenced.length) {
+        throw new StackConflictError('Attachment is still referenced by one or more records');
+      }
+
+      const metaRows = this.exec.all<{ id: string }>(
+        `SELECT id FROM records WHERE type_id = ? AND json_extract(content, '$.fileId') = ?`,
+        [metadataTypeId, fileId],
+      );
+      const deletedIds = metaRows.map((row) => row.id);
+      for (const id of deletedIds) {
+        this.hardDeleteRecord(id);
+      }
+
+      this.exec.exec('COMMIT');
+      if (deletedIds.length) this.write();
+      return deletedIds;
+    } catch (err) {
+      this.exec.exec('ROLLBACK');
+      throw err;
+    }
+  }
+
+  // -------------------------------------------------------
+  // Versions
+  // -------------------------------------------------------
+
+  async getVersions(id: string): Promise<RecordVersion[]> {
+    const rows = this.exec.all<Record<string, unknown>>(
+      'SELECT * FROM versions WHERE record_id = ? ORDER BY version DESC',
+      [id],
+    );
+    return rows.map(rowToVersion);
+  }
+
+  async getVersion(id: string, version: number): Promise<RecordVersion | null> {
+    const rows = this.exec.all<Record<string, unknown>>(
+      'SELECT * FROM versions WHERE record_id = ? AND version = ?',
+      [id, version],
+    );
+    return rows.length ? rowToVersion(rows[0]) : null;
+  }
+
+  async saveVersion(id: string, version: RecordVersion): Promise<void> {
+    this.exec.run(
+      `INSERT OR IGNORE INTO versions
+        (record_id, version, content, updated_at, entity_id, associations, permissions)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id,
+        version.version,
+        JSON.stringify(version.content),
+        toMs(version.updatedAt),
+        version.entityId ?? null,
+        version.associations ? JSON.stringify(version.associations) : null,
+        version.permissions ? JSON.stringify(version.permissions) : null,
+      ],
+    );
+    this.write();
+  }
+
+  // -------------------------------------------------------
+  // Types
+  // -------------------------------------------------------
+
+  async saveType(type: StackType): Promise<void> {
+    this.exec.run(
+      `INSERT OR REPLACE INTO types
+        (id, base_id, version, name, schema, schema_hash, migrates_from, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        type.id,
+        type.baseId,
+        type.version,
+        type.name,
+        JSON.stringify(type.schema),
+        type.schemaHash,
+        type.migratesFrom ?? null,
+        toMs(type.createdAt),
+      ],
+    );
+    this.write();
+  }
+
+  async getType(id: TypeId): Promise<StackType | null> {
+    const rows = this.exec.all<Record<string, unknown>>('SELECT * FROM types WHERE id = ?', [id]);
+    return rows.length ? rowToType(rows[0]) : null;
+  }
+
+  async listTypes(): Promise<StackType[]> {
+    const rows = this.exec.all<Record<string, unknown>>(
+      'SELECT * FROM types ORDER BY base_id, version',
+    );
+    return rows.map(rowToType);
+  }
+
+  // -------------------------------------------------------
+  // Associations
+  // -------------------------------------------------------
+
+  async associate(recordId: string, association: Association): Promise<void> {
+    this.insertAssociations(recordId, [association]);
+    this.bumpVersion(recordId);
+    this.write();
+  }
+
+  async dissociate(recordId: string, association: Association): Promise<void> {
+    this.exec.run(
+      `DELETE FROM associations
+       WHERE record_id = ?
+         AND kind = ?
+         AND label = ?
+         AND file_id    = ?
+         AND related_id = ?`,
+      [
+        recordId,
+        association.kind,
+        association.label,
+        association.kind === 'attachment' ? association.fileId : '',
+        association.kind === 'relationship' ? association.recordId : '',
+      ],
+    );
+    this.bumpVersion(recordId);
+    this.write();
+  }
+
+  private bumpVersion(id: string): void {
+    this.exec.run('UPDATE records SET version = version + 1, updated_at = ? WHERE id = ?', [
+      toMs(new Date()),
+      id,
+    ]);
+  }
+
+  /**
+   * FK enforcement (PRAGMA_FOREIGN_KEYS_ON) means inserting an
+   * association against a record that doesn't exist throws — mapped
+   * here to StackNotFoundError so associate() on a nonexistent record
+   * fails loudly instead of silently creating an orphan row.
+   */
+  private insertAssociations(recordId: string, associations: Association[]): void {
+    for (const assoc of associations) {
+      try {
+        this.exec.run(
+          `INSERT OR IGNORE INTO associations
+            (record_id, kind, label, file_id, mime_type, related_id)
+           VALUES (?, ?, ?, ?, ?, ?)`,
+          [
+            recordId,
+            assoc.kind,
+            assoc.label,
+            assoc.kind === 'attachment' ? assoc.fileId : '',
+            assoc.kind === 'attachment' ? assoc.mimeType : null,
+            assoc.kind === 'relationship' ? assoc.recordId : '',
+          ],
+        );
+      } catch (err) {
+        if (isForeignKeyViolation(err)) {
+          throw new StackNotFoundError(`Record not found: "${recordId}"`);
+        }
+        throw err;
+      }
+    }
+  }
+
+  private getAssociationsForRecord(recordId: string): Association[] {
+    const rows = this.exec.all<Record<string, unknown>>(
+      'SELECT * FROM associations WHERE record_id = ?',
+      [recordId],
+    );
+    return rows.map(rowToAssociation);
+  }
+}

--- a/packages/sqlite-shared/src/schema.ts
+++ b/packages/sqlite-shared/src/schema.ts
@@ -1,8 +1,10 @@
 /**
- * Schema DDL shared by SQLite-backed record adapters. FTS4 is what sql.js's
- * WASM build supports; the native adapter uses FTS5 and defines its own
- * virtual table DDL rather than sharing this one — the rest of the schema
- * (tables, indexes) is identical across engines.
+ * Schema DDL shared by SQLite-backed record adapters. Split so each
+ * engine composes only what it needs: record-adapter-sqljs keeps tokens
+ * in the same file (RECORD_SCHEMA_SQL + TOKENS_SCHEMA_SQL + FTS4), while
+ * the native adapter keeps tokens in a separate file (RECORD_SCHEMA_SQL +
+ * FTS5 on the main db, TOKENS_SCHEMA_SQL on its own) — see docs/spec.md
+ * § Adapters and the StackTokenStore portability rationale in #46.
  */
 
 export const RECORD_SCHEMA_SQL = `
@@ -52,15 +54,6 @@ export const RECORD_SCHEMA_SQL = `
     created_at    INTEGER NOT NULL
   ) STRICT;
 
-  CREATE TABLE IF NOT EXISTS tokens (
-    id          TEXT PRIMARY KEY,
-    token_hash  TEXT NOT NULL UNIQUE,
-    entity_id   TEXT NOT NULL,
-    label       TEXT,
-    created_at  INTEGER NOT NULL,
-    expires_at  INTEGER
-  ) STRICT;
-
   -- Indexes
   CREATE INDEX IF NOT EXISTS idx_records_type_id    ON records(type_id);
   CREATE INDEX IF NOT EXISTS idx_records_parent_id  ON records(parent_id);
@@ -73,7 +66,24 @@ export const RECORD_SCHEMA_SQL = `
   CREATE INDEX IF NOT EXISTS idx_assoc_kind_label   ON associations(kind, label);
   CREATE INDEX IF NOT EXISTS idx_assoc_kind_file_id ON associations(kind, file_id);
   CREATE INDEX IF NOT EXISTS idx_types_base_id      ON types(base_id);
-  CREATE INDEX IF NOT EXISTS idx_tokens_hash        ON tokens(token_hash);
+`;
+
+/**
+ * Bearer-token storage backing StackTokenStore. Kept separate from
+ * RECORD_SCHEMA_SQL so an adapter can put it in its own file — the
+ * portable stack file shouldn't also carry a server's auth material.
+ */
+export const TOKENS_SCHEMA_SQL = `
+  CREATE TABLE IF NOT EXISTS tokens (
+    id          TEXT PRIMARY KEY,
+    token_hash  TEXT NOT NULL UNIQUE,
+    entity_id   TEXT NOT NULL,
+    label       TEXT,
+    created_at  INTEGER NOT NULL,
+    expires_at  INTEGER
+  ) STRICT;
+
+  CREATE INDEX IF NOT EXISTS idx_tokens_hash ON tokens(token_hash);
 `;
 
 /** FTS4 — compatible with sql.js's WASM SQLite build. */
@@ -81,6 +91,15 @@ export const FTS4_SCHEMA_SQL = `
   CREATE VIRTUAL TABLE IF NOT EXISTS records_fts USING fts4(
     content,
     content='records'
+  );
+`;
+
+/** FTS5 — used by the native (node:sqlite) adapter. */
+export const FTS5_SCHEMA_SQL = `
+  CREATE VIRTUAL TABLE IF NOT EXISTS records_fts USING fts5(
+    content,
+    content='records',
+    content_rowid='rowid'
   );
 `;
 
@@ -93,3 +112,11 @@ export const FTS4_SCHEMA_SQL = `
  * (chiefly `associate()` on a record that doesn't exist).
  */
 export const PRAGMA_FOREIGN_KEYS_ON = `PRAGMA foreign_keys = ON;`;
+
+/**
+ * WAL journaling: page-level writes, crash-safe without our own
+ * temp-file-and-rename dance, and real SQLite file locking. Only
+ * meaningful for a real file (a :memory: or sql.js in-memory database
+ * silently ignores it).
+ */
+export const PRAGMA_JOURNAL_MODE_WAL = `PRAGMA journal_mode = WAL;`;

--- a/packages/sqlite-shared/src/token-logic.ts
+++ b/packages/sqlite-shared/src/token-logic.ts
@@ -1,0 +1,85 @@
+/**
+ * The actual StackTokenStore logic (createToken/lookupToken/listTokens/
+ * revokeToken), parametrized over a SqlExecutor so it works whether the
+ * tokens table lives in the same file as records (record-adapter-sqljs,
+ * today) or its own separate file (record-adapter-sqlite's
+ * NativeTokenStore) — see TOKENS_SCHEMA_SQL in schema.ts.
+ */
+
+import { createHash, randomBytes } from 'node:crypto';
+import type { TokenInfo } from '@haverstack/core';
+import type { SqlExecutor } from './executor.js';
+import { toMs, fromMs } from './mappers.js';
+
+export type SharedTokenLogicDeps = {
+  exec: SqlExecutor;
+  /** Called after every mutating operation. Omit for engines with durable writes. */
+  onWrite?: () => void;
+};
+
+export class SharedTokenLogic {
+  constructor(private readonly deps: SharedTokenLogicDeps) {}
+
+  private get exec(): SqlExecutor {
+    return this.deps.exec;
+  }
+
+  private write(): void {
+    this.deps.onWrite?.();
+  }
+
+  async createToken(
+    entityId: string,
+    opts: { label?: string; expiresAt?: Date } = {},
+  ): Promise<{ id: string; token: string }> {
+    const id = randomBytes(8).toString('hex');
+    const token = randomBytes(32).toString('hex');
+    const tokenHash = createHash('sha256').update(token).digest('hex');
+    this.exec.run(
+      'INSERT INTO tokens (id, token_hash, entity_id, label, created_at, expires_at) VALUES (?, ?, ?, ?, ?, ?)',
+      [
+        id,
+        tokenHash,
+        entityId,
+        opts.label ?? null,
+        toMs(new Date()),
+        opts.expiresAt ? toMs(opts.expiresAt) : null,
+      ],
+    );
+    this.write();
+    return { id, token };
+  }
+
+  async lookupToken(token: string): Promise<{ entityId: string } | null> {
+    const hash = createHash('sha256').update(token).digest('hex');
+    const row = this.exec.get<{ entity_id: string; expires_at: number | null }>(
+      'SELECT entity_id, expires_at FROM tokens WHERE token_hash = ?',
+      [hash],
+    );
+    if (!row) return null;
+    if (row.expires_at !== null && Date.now() > row.expires_at) return null;
+    return { entityId: row.entity_id };
+  }
+
+  async listTokens(): Promise<TokenInfo[]> {
+    const rows = this.exec.all<{
+      id: string;
+      entity_id: string;
+      label: string | null;
+      created_at: number;
+      expires_at: number | null;
+    }>('SELECT id, entity_id, label, created_at, expires_at FROM tokens ORDER BY created_at DESC');
+    return rows.map((row) => ({
+      id: row.id,
+      entityId: row.entity_id,
+      ...(row.label && { label: row.label }),
+      createdAt: fromMs(row.created_at),
+      ...(row.expires_at !== null && { expiresAt: fromMs(row.expires_at) }),
+    }));
+  }
+
+  async revokeToken(id: string): Promise<void> {
+    this.exec.run('DELETE FROM tokens WHERE id = ?', [id]);
+    this.write();
+  }
+}

--- a/packages/sqlite-shared/tests/fts5.test.ts
+++ b/packages/sqlite-shared/tests/fts5.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from 'vitest';
+import { sanitizeFts5Query } from '../src/fts5.js';
+
+describe('sanitizeFts5Query', () => {
+  test('returns empty string unchanged', () => {
+    expect(sanitizeFts5Query('')).toBe('');
+  });
+
+  test('strips wildcards', () => {
+    expect(sanitizeFts5Query('hel*lo')).toBe('hello');
+  });
+
+  test('replaces NEAR(...) with its terms, dropping the wrapper and distance', () => {
+    expect(sanitizeFts5Query('NEAR(foo bar, 5)')).toBe('foo bar');
+  });
+
+  test('NEAR(...) next to AND does not leave a dangling operator', () => {
+    expect(sanitizeFts5Query('foo AND NEAR(bar baz, 3)')).toBe('foo AND bar baz');
+  });
+
+  test('strips column-filter colons', () => {
+    expect(sanitizeFts5Query('content:foo')).toBe('content foo');
+    expect(sanitizeFts5Query('bogus:foo')).toBe('bogus foo');
+  });
+
+  test('strips bare NOT with no left operand', () => {
+    expect(sanitizeFts5Query('NOT foo')).toBe('foo');
+  });
+
+  test('keeps NOT with a left operand', () => {
+    expect(sanitizeFts5Query('foo NOT bar')).toBe('foo NOT bar');
+  });
+
+  test('caps parenthesis nesting depth', () => {
+    expect(sanitizeFts5Query('(((deep)))', 2)).toBe('((deep))');
+  });
+
+  test('auto-closes unclosed parens', () => {
+    expect(sanitizeFts5Query('(unclosed')).toBe('(unclosed)');
+  });
+
+  test('discards unmatched closing parens', () => {
+    expect(sanitizeFts5Query('unmatched)')).toBe('unmatched');
+  });
+
+  test('keeps phrase queries and implicit AND', () => {
+    expect(sanitizeFts5Query('"exact phrase" other')).toBe('"exact phrase" other');
+  });
+});

--- a/packages/sqlite-shared/tests/lock.test.ts
+++ b/packages/sqlite-shared/tests/lock.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { acquireLock, releaseLock } from '../src/lock.js';
+
+let testDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  testDir = join(
+    tmpdir(),
+    `sqlite-shared-lock-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testDir, { recursive: true });
+  dbPath = join(testDir, 'test.db');
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe('acquireLock / releaseLock', () => {
+  test('acquireLock creates a lock file stamped with the current pid', () => {
+    acquireLock(dbPath);
+    expect(existsSync(`${dbPath}.lock`)).toBe(true);
+    const info = JSON.parse(readFileSync(`${dbPath}.lock`, 'utf-8'));
+    expect(info.pid).toBe(process.pid);
+  });
+
+  test('reacquiring from the same process does not throw', () => {
+    acquireLock(dbPath);
+    expect(() => acquireLock(dbPath)).not.toThrow();
+  });
+
+  test('rejects when a live process already holds the lock', () => {
+    const otherPid = process.pid + 1;
+    writeFileSync(`${dbPath}.lock`, JSON.stringify({ pid: otherPid }));
+    vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    expect(() => acquireLock(dbPath)).toThrow(/in use by another process \(pid \d+\)/);
+  });
+
+  test('reclaims a lock left by a dead process', () => {
+    const deadPid = process.pid + 1;
+    writeFileSync(`${dbPath}.lock`, JSON.stringify({ pid: deadPid }));
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      const err = new Error('no such process') as NodeJS.ErrnoException;
+      err.code = 'ESRCH';
+      throw err;
+    });
+
+    expect(() => acquireLock(dbPath)).not.toThrow();
+  });
+
+  test('force bypasses a live lock', () => {
+    const otherPid = process.pid + 1;
+    writeFileSync(`${dbPath}.lock`, JSON.stringify({ pid: otherPid }));
+    vi.spyOn(process, 'kill').mockImplementation(() => true);
+
+    expect(() => acquireLock(dbPath, true)).not.toThrow();
+  });
+
+  test('releaseLock removes a lock owned by this process', () => {
+    acquireLock(dbPath);
+    releaseLock(dbPath);
+    expect(existsSync(`${dbPath}.lock`)).toBe(false);
+  });
+
+  test('releaseLock is a no-op when no lock file exists', () => {
+    expect(() => releaseLock(dbPath)).not.toThrow();
+  });
+
+  test('releaseLock does not remove a lock owned by a different pid', () => {
+    writeFileSync(`${dbPath}.lock`, JSON.stringify({ pid: process.pid + 1 }));
+    releaseLock(dbPath);
+    expect(existsSync(`${dbPath}.lock`)).toBe(true);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,25 @@ importers:
         specifier: ^2.0.0
         version: 2.1.9(@types/node@22.19.17)
 
+  packages/record-adapter-sqlite:
+    dependencies:
+      '@haverstack/core':
+        specifier: workspace:*
+        version: link:../core
+      '@haverstack/sqlite-shared':
+        specifier: workspace:*
+        version: link:../sqlite-shared
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.19.17)
+
   packages/record-adapter-sqljs:
     dependencies:
       '@haverstack/core':


### PR DESCRIPTION
## Summary

Builds the native adapter piece of #46: a new `@haverstack/record-adapter-sqlite` package on `node:sqlite` (Node ≥ 22.5, no native compilation), plus the shared-layer/core plumbing it needs. Scoped to just this package per discussion — `adapter-local`'s swap to it, `record-adapter-sqljs`'s browser-only cleanup, and doc updates are left for a follow-up pass.

**`record-adapter-sqlite`:**
- `NativeSQLiteRecordAdapter` implements `StackRecordAdapter` directly against `node:sqlite`'s `DatabaseSync`. No `export()`/rewrite-the-whole-file step at all — native SQLite writes straight to the file under WAL journaling, so page-level writes, crash safety, and file locking come from the engine itself.
- FTS5 full-text search, with its own sanitizer (`sanitizeFts5Query`) reviewed against real FTS5 grammar rather than assumed from FTS4: `NEAR` is a function-call form here, not FTS4's infix operator, and FTS5 has real column-filter syntax that errors hard on unknown columns — both handled so they don't become new query-time failures.
- Opening a stack file created by `record-adapter-sqljs` transparently migrates its FTS4 index to FTS5 (detected via `sqlite_master`, rebuilt once) — cross-compatibility verified against a real sql.js-written file.
- FK enforcement (`PRAGMA foreign_keys = ON`, mapped to `StackNotFoundError`) and the same PID-lock-file storage-ownership guard as `record-adapter-sqljs`, now shared via `sqlite-shared`.
- `deleteUnreferencedAttachmentRecords` implemented as a real SQL transaction, matching `record-adapter-sqljs`'s existing fix for the same check-then-act race.
- `NativeTokenStore`: a separate class/file implementing core's new `StackTokenStore`, storing bearer tokens outside the portable stack file by default (`defaultTokenStorePath()` derives a sibling path) — the fix requested in #46's polish-backlog comment.

**Two things I ran into and fixed along the way:**
1. A real correctness bug: FTS5 external-content tables require the special `INSERT INTO fts(fts, rowid, content) VALUES('delete', ...)` command to unindex a row — a plain `DELETE FROM records_fts` leaves stale, still-searchable entries behind. Caught via direct testing against `node:sqlite` before it shipped; there's a regression test for it (`full-text search reflects patchContent updates`).
2. A Vitest/Vite bug where `node:sqlite` resolution drops the `node:` prefix and fails ([vitest-dev/vitest#7177](https://github.com/vitest-dev/vitest/issues/7177)) — worked around by loading the module via `process.getBuiltinModule()` instead of a static import. That's the Node-sanctioned mechanism for exactly this class of bundler incompatibility, so it protects consumers who build with Vite-based tooling too, not just our own test suite.

**`sqlite-shared`:**
- New: `FTS5_SCHEMA_SQL`, `sanitizeFts5Query`, `PRAGMA_JOURNAL_MODE_WAL`, `TOKENS_SCHEMA_SQL` split out of `RECORD_SCHEMA_SQL` (tokens now live in their own schema fragment so each adapter can place them in whatever file it wants).
- The storage-ownership lock (`acquireLock`/`releaseLock`) moves here from `record-adapter-sqljs` — always pure Node fs/process logic, not sql.js-specific, so both engines share one implementation and one error message now.

**`core`:**
- New `StackTokenStore` interface + `TokenInfo` type: bearer-token issuance/lookup for server implementations, deliberately not part of the `StackRecordAdapter` contract (neither `Stack` nor `StackClient` touches it) and deliberately decoupled from record storage.

**`record-adapter-sqljs`:**
- Consumes the shared lock module instead of its own copy; `TokenInfo` now sourced from core. No behavior change — its 95 tests pass unmodified.

## Test plan

- [x] `pnpm build` / `pnpm typecheck` / `pnpm lint` — full monorepo, clean
- [x] `pnpm test` — full monorepo, 582 tests passing, no regressions
- [x] New `record-adapter-sqlite` tests (71): CRUD, queries incl. FTS5 search, associations, versions, permissions, `restoreVersion`, `commitMigration`, `deleteUnreferencedAttachmentRecords`, WAL mode enabled, FK enforcement, storage lock (reject/reclaim/force/release), FTS4→FTS5 migration (idempotent), `NativeTokenStore` (separate file, expiry, revoke, persistence across instances)
- [x] New `sqlite-shared` tests: `sanitizeFts5Query` (NEAR term-preservation, column-filter stripping, parity with FTS4 sanitizer's known limitations), lock module (reject/reclaim/force/release) direct unit tests
- [x] Manual verification scripts (not committed) confirmed: `node:sqlite` JSON1/FTS5/WAL/FK support, cross-file-compatibility between sql.js and node:sqlite, and the FTS5 delete-command bug before writing the fix

Refs #46.

https://claude.ai/code/session_01RRLiGUZC344E3pgNEGAe5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01RRLiGUZC344E3pgNEGAe5W)_