### PR TITLE
Explicit owner-driven migration, replacing lazy migrate-on-read/commit-on-write

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -146,6 +146,7 @@ await stack.grant(null, [{ typeId: 'com.example/comment@1', actions: ['create', 
 **Design decisions:**
 
 - **No wildcard `typeId`**: there is no `*` or catch-all. Every grant is opt-in per type. Adding a new type never implicitly inherits existing grants — it starts default-deny.
+- **Grants target the type family, not the exact version**: a grant naming `com.example/comment@1` also covers `com.example/comment@2` — matching is by `baseId`, derived from whichever form the grant's `typeId` was given in. This is what keeps a version bump from silently orphaning existing grants (previously, registering a migration broke every grant pinned to the old version, with no data change at all — grants are checked in memory _before_ any migration applies).
 - **Default grants** (grant record has no `entityId`): apply to any authenticated entity. Useful for "any logged-in user can comment" scenarios. Anonymous requesters (no `entityId`) are always denied, even under a default grant.
 - **Actions are independent**: `'create'` does not imply `'read-own'`, and so on. The combination `['create', 'read-own', 'update-own', 'delete-own']` is a common bundle for contributor access, but each action must be listed explicitly.
 - **`-own` scope**: `-own` actions apply only to Records where `record.entityId` equals the requester — Records the entity authored. Records with no `entityId` (owner-created) do not satisfy any `-own` check.
@@ -234,6 +235,8 @@ Used by apps that want to work with Records regardless of exact Type, e.g. any T
 
 ### Type migrations
 
+A Type's defining app is the only serious writer of its own types, so migration is **explicit and owner-driven**, not something that happens as a side effect of a read or an unrelated write. Disk state changes version only via a deliberate `migrateAll()` pass — the invariant is that all Records of a family sit at version N until the owning app moves them, so `query({ filter: { typeId } })` and grants targeting a type never silently miss not-yet-migrated records (see [Queries](#queries) and [Grant](#grant)).
+
 Apps register migration functions between adjacent Type versions at startup. The library composes them into a full migration graph, so an app that only knows about v3 doesn't need to know that v1 ever existed.
 
 ```ts
@@ -254,13 +257,32 @@ The migration registry is **per-stack-instance** — different stacks can be at 
 
 **What the library does with registered migrations:**
 
-- **Lazy migration on read** — `stack.get()` and `stack.query()` apply the migration chain in memory, returning Records as if they were the latest version. Nothing is written to disk.
-- **Migration committed on update** — when a record is next updated via `stack.update()`, the library migrates existing content first, then applies the patch, then writes at the latest typeId. This is when lazy migration is persisted.
+- **`get()` and `query()` return Records exactly as stored** — their own `typeId` and `content`, with no implicit migration. This is what makes `query()` a reliable way to find every record of a family regardless of migration state (previously a divergence from `get()`, which migrated in memory by default).
+- **`presentAt: 'latest'`** — an explicit opt-in on both `get()` and `query()` that applies the registered migration chain in memory before returning. Nothing is written to disk; this is a read-time convenience, never a persistence mechanism. Throws `StackMigrationError` rather than warning and returning a raw record when a matched Record's version can't be reconciled with what this app instance has registered (see stale-writer behavior, below).
+- **`update()` never migrates.** It validates the merge-patched content against the Record's _own current_ stored Type — never the latest — and writes back at the same `typeId`. An unrelated content edit can never fold an invisible schema rewrite into the same version-history entry.
 - **Path composition** — migrations between adjacent versions are automatically chained (v1→v2→v3), so apps only ever register one step at a time.
-- **Warn on unmigratable reads** — if a Record's Type version has no registered path to the latest, the library warns the app and returns the raw record.
-- **Batch migration** — `stack.migrateAll("com.example.myapp/note")` eagerly commits all pending migrations to disk in one deliberate pass. Version history is preserved before each write. Use before deployments or after major schema changes.
+- **`migrateAll("com.example.myapp/note")`** is the _only_ way disk state changes version. It eagerly commits all pending migrations for a type family in one deliberate pass — call it at app startup after registering migrations, or after a schema change. Sweeps soft-deleted Records unconditionally (`includeDeleted: true` is not a caller option in either direction — see [Deletion](#deletion)), validates each migrated result against the target Type's schema before writing, and aborts immediately on the first validation failure (a buggy migration function is a bug to surface, not to paper over by skipping the offending records) — anything already committed earlier in the pass stays committed. Previous content is snapshotted to version history before each write.
 
-> **Not yet implemented:** validation of migration function output against the target schema at registration time.
+**Stale-writer behavior.** A Record whose version this app instance can't reconcile — older than what it's registered _and_ not bridged by a migration path, or newer than anything it has ever `defineType()`'d — is an explicit error (`StackMigrationError`) under `presentAt: 'latest'`, not a silent pass-through. This covers both directions of "the same app at two versions" meeting via a shared stack: a stale binary encountering a record newer than it understands, or an app that's defined a later Type version but never registered the migration to reach it. Reading the Record as stored (the default, no `presentAt`) always succeeds regardless — the stale-writer signal only fires when the app explicitly asks for the migrated view and the library can't honestly provide one.
+
+### Additive evolution within a version
+
+Not every schema change needs a version bump. **Additive-in-place** changes — new optional fields only — can be added to a Type's schema without minting a new version, and are the default path for evolving a type family:
+
+- **Readers ignore unknown fields** — validation already permits undeclared content fields.
+- **Writers preserve unknown fields** — the merge-patch semantics of `update()` retain any field the caller didn't touch.
+
+This is what makes duck-typed cross-app consumption (`isCompatible()`, see [Types](#types)) actually work in practice: most evolution needs no coordination at all, and consumers that were never taught about a field simply don't see it.
+
+**A version bump is a consolidation point**, warranted when:
+
+- a field becomes _required_ (paired with a migration that backfills a real value for existing records),
+- a field's meaning changes, or
+- the shape is restructured.
+
+A schema accumulating many optional fields is a named smell that a consolidating bump is due — but the bump itself stays rare and semantic ("`@2` means `dueDate` is now guaranteed"), not a changelog entry for every field ever added. Bumping per addition costs a full-table rewrite per field, version-number noise, and — since records only reach a new version when the owning app next runs `migrateAll()` — doesn't even deliver per-record schema exactness in the interim; consumers face mixed-version data either way and need `baseId` queries plus duck typing regardless.
+
+> **Not yet implemented:** a drift guard that mechanically enforces this boundary (accepting additive-in-place diffs, rejecting anything else with "bump the version"), and validation of migration function output against the target schema at _registration_ time (write-time validation, in `migrateAll()`, is the enforced backstop today).
 
 ---
 
@@ -411,6 +433,7 @@ Version history is managed by the library as a side channel — apps do not mana
 ```ts
 type RecordVersion = {
   version: number;
+  typeId: string; // The Record's typeId at the moment this version was snapshotted
   content: object;
   updatedAt: Date;
   entityId?: string; // Who made this change
@@ -418,6 +441,8 @@ type RecordVersion = {
   permissions?: Permission[]; // Present if the record had permissions at snapshot time
 };
 ```
+
+`typeId` makes a version entry interpretable regardless of migration state: a snapshot taken before a migration records the pre-migration type, so restoring it later doesn't mislabel `@1`-shaped content as `@2` (see [restoreVersion](#type-migrations) and the `_grant` baseId matching this enables independent of exactly which version a snapshot predates).
 
 **API surface:**
 
@@ -560,6 +585,7 @@ Queries are expressed as a `Query` object passed to `stack.query()`. All adapter
 type Filter = {
   // Native fields
   typeId?: string | string[];
+  baseId?: string | string[]; // matches every version of a type family
   parentId?: string | null; // null = root records only
   appId?: string | string[];
   entityId?: string | string[];
@@ -584,6 +610,10 @@ type DateRange = {
   after?: Date;
 };
 ```
+
+`baseId` matches every version of a type family — resolved against registered Types (via `listTypes()`), not string-parsed from `typeId`, so it works regardless of which versions happen to exist. This is what fixes `typeId`-filtered queries silently missing not-yet-migrated older-version records under [explicit, owner-driven migration](#type-migrations): filter by `baseId` to see the whole family, or `typeId` for an exact version. Given both, they intersect. `Stack.query()` resolves `baseId` client-side before dispatching to the adapter — adapters and the wire protocol only ever see a concrete `typeId` set, so no adapter needs its own `baseId` concept. An unknown `baseId` returns an empty result set rather than throwing.
+
+By default, `query()` (like `get()`) returns Records exactly as stored — see [presentAt: 'latest'](#type-migrations) to migrate results in memory instead.
 
 ### Sorting and pagination
 

--- a/packages/adapter-api/src/index.ts
+++ b/packages/adapter-api/src/index.ts
@@ -121,6 +121,7 @@ const parseType = (raw: WireType): StackType => {
 const parseVersion = (raw: WireVersion): RecordVersion => {
   const v: RecordVersion = {
     version: raw.version,
+    typeId: raw.typeId,
     content: raw.content,
     updatedAt: new Date(raw.updatedAt),
   };

--- a/packages/adapter-api/tests/api.test.ts
+++ b/packages/adapter-api/tests/api.test.ts
@@ -54,6 +54,7 @@ const NOTE_TYPE_RAW = {
 
 const VERSION_RAW = {
   version: 1,
+  typeId: 'com.example/note@1',
   content: { text: 'original' },
   updatedAt: '2024-01-01T00:00:00.000Z',
   entityId: 'entity-owner-123',
@@ -532,6 +533,7 @@ describe('getVersions', () => {
     const versions = await adapter.getVersions('rec-abc123');
     expect(versions).toHaveLength(1);
     expect(versions[0].version).toBe(1);
+    expect(versions[0].typeId).toBe('com.example/note@1');
     expect(versions[0].updatedAt).toBeInstanceOf(Date);
     expect(versions[0].entityId).toBe('entity-owner-123');
   });
@@ -594,7 +596,12 @@ describe('saveVersion', () => {
   test('is a no-op — does not make any HTTP requests', async () => {
     const adapter = await openAdapter();
     const callsBefore = mockFetch.mock.calls.length;
-    const v: RecordVersion = { version: 1, content: { text: 'v1' }, updatedAt: new Date() };
+    const v: RecordVersion = {
+      version: 1,
+      typeId: 'com.example/note@1',
+      content: { text: 'v1' },
+      updatedAt: new Date(),
+    };
     await expect(adapter.saveVersion('rec-abc123', v)).resolves.toBeUndefined();
     expect(mockFetch.mock.calls.length).toBe(callsBefore);
   });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -86,7 +86,7 @@ export {
   isValidIdFormat,
   idTimestamp,
 } from './id.js';
-export { hashSchema, isCompatible, parseTypeId, buildTypeId } from './schema.js';
+export { hashSchema, isCompatible, parseTypeId, buildTypeId, baseIdOf } from './schema.js';
 export { validateContent, isValid } from './validate.js';
 export type { ValidationError } from './validate.js';
 export { applyMergePatch } from './merge.js';

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -169,3 +169,10 @@ export const parseTypeId = (typeId: string): { baseId: string; version: number }
  * e.g. ("com.example.myapp/note", 2) → "com.example.myapp/note@2"
  */
 export const buildTypeId = (baseId: string, version: number): string => `${baseId}@${version}`;
+
+/**
+ * Extract the base (family) ID from a TypeId, tolerating an already-bare
+ * baseId (no "@n" suffix) as a no-op. Used to compare across versions —
+ * e.g. a grant on "comment@1" and a record at "comment@2" share a baseId.
+ */
+export const baseIdOf = (typeId: string): string => parseTypeId(typeId)?.baseId ?? typeId;

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -7,7 +7,7 @@
  *  - ID generation
  *  - Type definition and schema hashing
  *  - Content validation on write
- *  - Migration registry and auto-migration on read
+ *  - Migration registry and explicit, owner-driven migrateAll()
  *  - Version snapshotting on update
  *  - Soft and hard delete
  *
@@ -15,7 +15,7 @@
  */
 
 import { generateId, isValidIdFormat, idTimestamp } from './id.js';
-import { hashSchema, isCompatible, parseTypeId } from './schema.js';
+import { hashSchema, isCompatible, parseTypeId, baseIdOf } from './schema.js';
 import { validateContent } from './validate.js';
 import { applyMergePatch } from './merge.js';
 import { checkAccess } from './access.js';
@@ -28,6 +28,7 @@ import type {
   TypeId,
   StackAdapter,
   StackQuery,
+  RecordFilter,
   QueryResult,
   Association,
   Permission,
@@ -43,6 +44,9 @@ import type {
 // -------------------------------------------------------
 // Supporting types
 // -------------------------------------------------------
+
+/** Sentinel: filter.baseId resolved to zero matching types. */
+const EMPTY_FAMILY = Symbol('empty-family');
 
 export type CreateRecordOptions = {
   /**
@@ -71,8 +75,13 @@ export type StackOptions = {
 };
 
 export type GetRecordOptions = {
-  /** If false, return the raw stored record without auto-migrating. Default: true */
-  migrate?: boolean;
+  /**
+   * Records are returned exactly as stored by default ("stored"). Pass
+   * "latest" to apply the registered migration chain in memory before
+   * returning — never written back. Throws StackMigrationError if the
+   * record has no registered path to the latest version.
+   */
+  presentAt?: 'stored' | 'latest';
 };
 
 export type DeleteRecordOptions = {
@@ -229,6 +238,13 @@ export interface StackClient {
 
 export class Stack implements StackClient {
   private readonly migrations = new Map<TypeId, Migration>();
+  /**
+   * Highest version this Stack instance has itself defineType()'d, per
+   * baseId — i.e. what *this app process* currently understands, as
+   * distinct from whatever versions happen to exist in shared storage.
+   * Used to detect the stale-writer case in presentAtLatest().
+   */
+  private readonly maxDefinedVersion = new Map<string, number>();
 
   private constructor(
     private readonly adapter: StackAdapter,
@@ -315,6 +331,9 @@ export class Stack implements StackClient {
       ...(opts.migratesFrom && { migratesFrom: opts.migratesFrom }),
     };
 
+    const priorMax = this.maxDefinedVersion.get(parsed.baseId) ?? 0;
+    if (parsed.version > priorMax) this.maxDefinedVersion.set(parsed.baseId, parsed.version);
+
     await this.adapter.saveType(type);
     return type;
   }
@@ -400,14 +419,22 @@ export class Stack implements StackClient {
 
   /**
    * Eagerly migrate all records of a type family to the latest version,
-   * committing the results to disk immediately.
+   * committing the results to disk immediately. This is the *only* way a
+   * record's disk state changes version — the library never migrates as a
+   * side effect of a read or an unrelated content edit. Call it at app
+   * startup after registerMigration(), or after a schema change.
    *
-   * Normally migration is lazy — records are migrated in memory on read
-   * and written back only when next updated. Call migrateAll() when you
-   * want to commit all pending migrations in one deliberate pass, for
-   * example before a deployment or after a major schema change.
+   * Sweeps soft-deleted records unconditionally (includeDeleted: true is
+   * not a caller option in either direction) so a record can't come back
+   * from undelete() stale merely because it was deleted during a migration
+   * window.
    *
-   * Previous content is preserved in version history before each write.
+   * Each record's migrated content is validated against the target type's
+   * schema before it's written; a validation failure aborts the batch
+   * immediately (a buggy migration function is a bug, not something to
+   * paper over by skipping the offending records) — anything already
+   * committed earlier in the pass stays committed. Previous content is
+   * preserved in version history before each write.
    */
   async migrateAll(baseTypeId: string): Promise<{ migrated: number }> {
     const types = await this.adapter.listTypes();
@@ -428,6 +455,11 @@ export class Stack implements StackClient {
       const migrateFn = this.resolveMigrationPath(typeId, latestId);
       if (!migrateFn) continue;
 
+      const latestType = await this.adapter.getType(latestId);
+      if (!latestType) {
+        throw new StackMigrationError(`migrateAll: target type "${latestId}" is not defined.`);
+      }
+
       let cursor: string | undefined;
       do {
         const result: QueryResult = await this.adapter.queryRecords({
@@ -437,8 +469,13 @@ export class Stack implements StackClient {
         });
 
         for (const record of result.records) {
-          await this.saveVersion(record);
           const migratedContent = migrateFn(record.content);
+          const errors = validateContent(migratedContent, latestType.schema);
+          if (errors.length > 0) {
+            throw new StackValidationError(errors);
+          }
+
+          await this.saveVersion(record);
           await this.adapter.commitMigration(record.id, latestId, migratedContent);
           migrated++;
         }
@@ -498,39 +535,59 @@ export class Stack implements StackClient {
   }
 
   /**
-   * Get a record by ID.
+   * Apply the registered migration chain to a record in memory, for the
+   * presentAt: 'latest' opt-in on get() and query(). Never writes back —
+   * only migrateAll() commits a migration to disk.
    *
-   * If the record is on an older type version and a migration path is
-   * registered, the content is migrated in memory and returned at the
-   * latest type version — but nothing is written to disk. Migration is
-   * only persisted when the record is next updated via update().
+   * If there's no forward migration path from the record's stored version,
+   * that's only unambiguous when this app instance has never defineType()'d
+   * a different version of the family — otherwise the record's version
+   * disagrees with what this app understands (older with a registration
+   * gap, or newer than anything this app has ever defined — the
+   * stale-writer case) and presentAt: 'latest' can't honor the request.
+   * Throws StackMigrationError rather than silently returning the raw
+   * record with a console.warn.
+   */
+  private presentAtLatest(record: StackRecord): StackRecord {
+    const latestId = this.latestTypeId(record.typeId);
+
+    if (latestId !== record.typeId) {
+      // latestTypeId() found this by walking the same migration graph
+      // resolveMigrationPath() walks, from the same starting point, so a
+      // path is always resolvable here.
+      const migrateFn = this.resolveMigrationPath(record.typeId, latestId)!;
+      return { ...record, typeId: latestId, content: migrateFn(record.content) };
+    }
+
+    const parsed = parseTypeId(record.typeId);
+    const knownMax = parsed ? this.maxDefinedVersion.get(parsed.baseId) : undefined;
+    if (parsed && knownMax !== undefined && parsed.version !== knownMax) {
+      const direction =
+        parsed.version > knownMax
+          ? `the record is newer than this app instance understands — update the app, or register the missing migrations`
+          : `no registered migration bridges the gap — call stack.registerMigration()`;
+      throw new StackMigrationError(
+        `Record "${record.id}" is at "${record.typeId}", but this app instance has defined ` +
+          `up to "${parsed.baseId}@${knownMax}": ${direction}. Omit presentAt: "latest" to ` +
+          `read the record as stored.`,
+      );
+    }
+
+    return record;
+  }
+
+  /**
+   * Get a record by ID, exactly as stored (its own typeId and content —
+   * no implicit migration).
    *
-   * Pass { migrate: false } to get the raw stored record without migration.
+   * Pass { presentAt: 'latest' } to apply the registered migration chain
+   * in memory instead; nothing is written to disk. Committing a migration
+   * to disk is exclusively migrateAll()'s job.
    */
   async get(id: string, opts: GetRecordOptions = {}): Promise<StackRecord | null> {
     const record = await this.adapter.getRecord(id);
     if (!record) return null;
-
-    const shouldMigrate = opts.migrate !== false;
-    if (!shouldMigrate) return record;
-
-    const latestId = this.latestTypeId(record.typeId);
-    if (latestId === record.typeId) return record;
-
-    const migrateFn = this.resolveMigrationPath(record.typeId, latestId);
-    if (!migrateFn) {
-      console.warn(
-        `[Stack] No migration path from "${record.typeId}" to "${latestId}" for record "${id}". ` +
-          `Returning raw record. Register migrations with stack.registerMigration().`,
-      );
-      return record;
-    }
-
-    return {
-      ...record,
-      typeId: latestId,
-      content: migrateFn(record.content),
-    };
+    return opts.presentAt === 'latest' ? this.presentAtLatest(record) : record;
   }
 
   /**
@@ -540,13 +597,13 @@ export class Stack implements StackClient {
    * To remove an optional field, set it explicitly to null:
    *   stack.update(id, { title: null })  // removes 'title' from content
    *
-   * If the record is on an older type version, its content is migrated
-   * in memory first, then the patch is applied. The updated record is
-   * written at the latest type version — this is when lazy migration
-   * is committed to disk.
+   * Validates the merged result against the record's *current* stored
+   * type's schema — update() never changes a record's typeId as a side
+   * effect. Migrating disk state is migrateAll()'s job exclusively, so an
+   * unrelated content edit never folds an invisible schema rewrite into
+   * the same version-history entry.
    *
-   * Validates the merged result against the type's schema. Saves the
-   * previous state to version history before updating.
+   * Saves the previous state to version history before updating.
    *
    * For association or permission changes, use associate(), dissociate(),
    * and setPermissions() instead.
@@ -557,20 +614,13 @@ export class Stack implements StackClient {
       throw new StackNotFoundError(`Record not found: "${id}"`);
     }
 
-    // Resolve the latest type version and migrate existing content
-    // in memory before applying the patch. This is when lazy migration
-    // from get() gets committed to disk.
-    const latestTypeId = this.latestTypeId(existing.typeId);
-    const migrateFn = this.resolveMigrationPath(existing.typeId, latestTypeId);
-    const existingContent = migrateFn ? migrateFn(existing.content) : existing.content;
-
-    const type = await this.adapter.getType(latestTypeId);
+    const type = await this.adapter.getType(existing.typeId);
     if (!type) {
-      throw new Error(`Unknown type: "${latestTypeId}"`);
+      throw new Error(`Unknown type: "${existing.typeId}"`);
     }
 
     // Merge (RFC 7396 / JSON Merge Patch): null values delete a field.
-    const merged = applyMergePatch(existingContent, content);
+    const merged = applyMergePatch(existing.content, content);
 
     const errors = validateContent(merged, type.schema);
     if (errors.length > 0) {
@@ -580,12 +630,6 @@ export class Stack implements StackClient {
     // Snapshot the raw stored state before overwriting
     await this.saveVersion(existing);
 
-    // If a pending lazy migration is being committed alongside this patch,
-    // the typeId change has to travel through commitMigration() — a
-    // content-only patch has no way to carry it.
-    if (latestTypeId !== existing.typeId) {
-      return this.adapter.commitMigration(id, latestTypeId, merged);
-    }
     return this.adapter.patchContent(id, content);
   }
 
@@ -681,10 +725,59 @@ export class Stack implements StackClient {
 
   /**
    * Query records. See StackQuery for filter, sort, and pagination options.
+   *
+   * filter.baseId matches every version of a type family, resolved against
+   * registered Types (not string-parsed from typeId) — this is what fixes
+   * `query({ filter: { baseId } })` missing not-yet-migrated older-version
+   * records. Records are returned exactly as stored by default; pass
+   * presentAt: 'latest' to migrate each result in memory (see get()).
    */
   async query(query: StackQuery = {}): Promise<QueryResult> {
-    const limit = query.limit !== undefined ? Math.min(query.limit, MAX_QUERY_LIMIT) : undefined;
-    return this.adapter.queryRecords(limit !== undefined ? { ...query, limit } : query);
+    const { presentAt, filter, limit: rawLimit, ...rest } = query;
+    const limit = rawLimit !== undefined ? Math.min(rawLimit, MAX_QUERY_LIMIT) : undefined;
+
+    const resolvedFilter = await this.resolveBaseIdFilter(filter);
+    if (resolvedFilter === EMPTY_FAMILY) {
+      return { records: [], cursor: null, total: 0 };
+    }
+
+    const result = await this.adapter.queryRecords({
+      ...rest,
+      ...(resolvedFilter !== undefined && { filter: resolvedFilter }),
+      ...(limit !== undefined && { limit }),
+    });
+
+    if (presentAt !== 'latest') return result;
+    return { ...result, records: result.records.map((r) => this.presentAtLatest(r)) };
+  }
+
+  /**
+   * Resolve filter.baseId into a concrete typeId set via listTypes(), so
+   * adapters — which only know about typeId — never need their own baseId
+   * concept. Intersects with filter.typeId when both are given. Returns
+   * EMPTY_FAMILY as a sentinel when the resolved set is empty (unknown
+   * baseId, or a typeId/baseId combination with no overlap), so the caller
+   * can short-circuit without a wasted adapter round trip.
+   */
+  private async resolveBaseIdFilter(
+    filter: RecordFilter | undefined,
+  ): Promise<RecordFilter | undefined | typeof EMPTY_FAMILY> {
+    if (filter?.baseId === undefined) return filter;
+
+    const { baseId, typeId, ...rest } = filter;
+    const requestedBaseIds = Array.isArray(baseId) ? baseId : [baseId];
+    const types = await this.adapter.listTypes();
+    const familyTypeIds = types.filter((t) => requestedBaseIds.includes(t.baseId)).map((t) => t.id);
+
+    const resolvedTypeIds =
+      typeId === undefined
+        ? familyTypeIds
+        : familyTypeIds.filter((id) =>
+            Array.isArray(typeId) ? typeId.includes(id) : typeId === id,
+          );
+
+    if (resolvedTypeIds.length === 0) return EMPTY_FAMILY;
+    return { ...rest, typeId: resolvedTypeIds };
   }
 
   // -------------------------------------------------------
@@ -901,6 +994,7 @@ export class Stack implements StackClient {
   private async saveVersion(record: StackRecord): Promise<void> {
     const version: RecordVersion = {
       version: record.version,
+      typeId: record.typeId,
       content: record.content,
       updatedAt: record.updatedAt,
       ...(record.entityId && { entityId: record.entityId }),
@@ -972,8 +1066,7 @@ export class ScopedStack implements StackClient {
     return this.stack.features;
   }
 
-  private resolveRecord = (id: string): Promise<StackRecord | null> =>
-    this.stack.get(id, { migrate: false });
+  private resolveRecord = (id: string): Promise<StackRecord | null> => this.stack.get(id);
 
   private checkRead(record: StackRecord): Promise<boolean> {
     return checkAccess(
@@ -997,9 +1090,12 @@ export class ScopedStack implements StackClient {
 
   /**
    * Check whether the requester holds a _grant record covering at least one
-   * of the given actions for the given type. For -own actions, additionally
-   * requires that `record.entityId` matches the requester (authorship check).
-   * Anonymous requesters always return false.
+   * of the given actions for the given type's family. Grants target
+   * baseId, not the exact versioned typeId — a grant on "comment@1" covers
+   * "comment@2" too, so a version bump never silently orphans an existing
+   * grant. For -own actions, additionally requires that `record.entityId`
+   * matches the requester (authorship check). Anonymous requesters always
+   * return false.
    */
   private async hasGrant(
     typeId: TypeId,
@@ -1009,22 +1105,23 @@ export class ScopedStack implements StackClient {
   ): Promise<boolean> {
     if (!this.requesterEntityId) return false;
 
+    const familyId = baseIdOf(typeId);
+
     let grantRecords: StackRecord[];
     if (prefetchedGrants !== undefined) {
       grantRecords = prefetchedGrants;
     } else {
-      const result = await this.stack.query({
-        filter: {
-          typeId: `${SYSTEM_TYPES.GRANT}@1`,
-          ...(this.stack.features.contentFieldQuery && { content: { typeId } }),
-        },
-      });
+      // No content-field prefilter here: matching is by baseId, which a
+      // stored grant may express as either a bare baseId or a versioned
+      // typeId, so an exact-match content filter would wrongly exclude
+      // grants for other versions of the family.
+      const result = await this.stack.query({ filter: { typeId: `${SYSTEM_TYPES.GRANT}@1` } });
       grantRecords = result.records;
     }
 
     return grantRecords.some((r) => {
       const c = r.content as GrantContent;
-      if (c.typeId !== typeId) return false;
+      if (baseIdOf(c.typeId) !== familyId) return false;
       if (r.entityId && r.entityId !== this.requesterEntityId) return false;
       return actions.some((action) => {
         if (!(c.actions as string[]).includes(action)) return false;
@@ -1048,7 +1145,7 @@ export class ScopedStack implements StackClient {
 
   /** Fetch a record the requester can update (via permissions or an update grant), or throw. */
   private async requireUpdatable(id: string): Promise<StackRecord> {
-    const record = await this.stack.get(id, { migrate: false });
+    const record = await this.stack.get(id);
     if (!record) throw new StackNotFoundError(`Record not found: "${id}"`);
     const allowed =
       (await this.checkWrite(record)) ||
@@ -1059,7 +1156,7 @@ export class ScopedStack implements StackClient {
 
   /** Fetch a record the requester can delete (via permissions or a delete grant), or throw. */
   private async requireDeletable(id: string): Promise<StackRecord> {
-    const record = await this.stack.get(id, { migrate: false });
+    const record = await this.stack.get(id);
     if (!record) throw new StackNotFoundError(`Record not found: "${id}"`);
     const allowed =
       (await this.checkWrite(record)) ||
@@ -1155,7 +1252,7 @@ export class ScopedStack implements StackClient {
   }
 
   async setPermissions(id: string, permissions: Permission[]): Promise<void> {
-    const record = await this.stack.get(id, { migrate: false });
+    const record = await this.stack.get(id);
     if (!record) throw new StackNotFoundError(`Record not found: "${id}"`);
 
     const isOwner = this.requesterEntityId === this.stack.ownerEntityId;
@@ -1189,14 +1286,14 @@ export class ScopedStack implements StackClient {
   }
 
   async getVersions(id: string): Promise<RecordVersion[]> {
-    const existing = await this.stack.get(id, { migrate: false });
+    const existing = await this.stack.get(id);
     if (!existing) throw new StackNotFoundError(`Record not found: "${id}"`);
     if (!(await this.canRead(existing))) throw new StackPermissionError();
     return this.stack.getVersions(id);
   }
 
   async getVersion(id: string, version: number): Promise<RecordVersion | null> {
-    const existing = await this.stack.get(id, { migrate: false });
+    const existing = await this.stack.get(id);
     if (!existing) throw new StackNotFoundError(`Record not found: "${id}"`);
     if (!(await this.canRead(existing))) throw new StackPermissionError();
     return this.stack.getVersion(id, version);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -89,6 +89,8 @@ export type StackRecord = {
 
 export type RecordVersion = {
   version: number;
+  /** The record's typeId at the moment this version was snapshotted. */
+  typeId: TypeId;
   content: Record<string, unknown>;
   updatedAt: Date;
   entityId?: RecordId; // Who made this change
@@ -245,6 +247,14 @@ export type DateRange = {
 export type RecordFilter = {
   // Native fields
   typeId?: TypeId | TypeId[];
+  /**
+   * Match every version of a type family — e.g. baseId: "com.example/note"
+   * matches both "com.example/note@1" and "com.example/note@2" records.
+   * Resolved against registered Types, not parsed from typeId strings, so
+   * it works regardless of which versions happen to exist. Combined with
+   * typeId (if both given) as an intersection.
+   */
+  baseId?: string | string[];
   parentId?: RecordId | null; // null = root records only
   appId?: RecordId | RecordId[];
   entityId?: RecordId | RecordId[];
@@ -280,6 +290,13 @@ export type StackQuery = {
   sort?: QuerySort;
   limit?: number;
   cursor?: string; // Opaque cursor for page-based pagination
+  /**
+   * Records are returned exactly as stored by default ("stored"). Pass
+   * "latest" to apply the registered migration chain in memory before
+   * returning — never written back. Throws StackMigrationError if any
+   * matched record has no registered path to the latest version.
+   */
+  presentAt?: 'stored' | 'latest';
 };
 
 export type QueryResult = {
@@ -374,8 +391,8 @@ export interface StackRecordAdapter {
   /**
    * Commit a migration: write new content under a new typeId in one step.
    * This is the only way a record's typeId changes after creation — used
-   * by Stack.update() when committing a pending lazy migration, and by
-   * Stack.migrateAll(). Bumps version internally.
+   * exclusively by Stack.migrateAll(); Stack.update() never changes typeId
+   * as a side effect. Bumps version internally.
    */
   commitMigration(
     id: RecordId,

--- a/packages/core/tests/scoped-stack.test.ts
+++ b/packages/core/tests/scoped-stack.test.ts
@@ -280,6 +280,7 @@ describe('ScopedStack — versions', () => {
     const record = await adapter.createRecord(makeRecord());
     await adapter.saveVersion(record.id, {
       version: 1,
+      typeId: NOTE,
       content: { text: 'old' },
       updatedAt: new Date(),
     });
@@ -292,7 +293,12 @@ describe('ScopedStack — versions', () => {
 
   test('getVersions/getVersion enforce read access', async () => {
     const record = await adapter.createRecord(makeRecord());
-    await adapter.saveVersion(record.id, { version: 1, content: {}, updatedAt: new Date() });
+    await adapter.saveVersion(record.id, {
+      version: 1,
+      typeId: NOTE,
+      content: {},
+      updatedAt: new Date(),
+    });
     await expect(stack.asEntity(STRANGER).getVersions(record.id)).rejects.toThrow(
       StackPermissionError,
     );
@@ -561,6 +567,19 @@ describe('ScopedStack — grant-based read', () => {
     await expect(stack.asEntity(MEMBER).update(record.id, { text: 'edited' })).rejects.toThrow(
       StackPermissionError,
     );
+  });
+
+  test('a grant on comment@1 covers comment@2 records — version bump does not orphan it', async () => {
+    const COMMENT_V2 = 'com.example.test/comment@2';
+    await stack.defineType(
+      COMMENT_V2,
+      'Comment',
+      { text: { kind: 'text', required: true }, edited: { kind: 'boolean' } },
+      { migratesFrom: COMMENT },
+    );
+    await stack.grant(MEMBER, [{ actions: ['read-any'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT_V2, { text: 'hello', edited: false });
+    expect((await stack.asEntity(MEMBER).get(record.id))?.id).toBe(record.id);
   });
 });
 

--- a/packages/core/tests/stack.test.ts
+++ b/packages/core/tests/stack.test.ts
@@ -242,10 +242,11 @@ describe('update', () => {
 });
 
 // -------------------------------------------------------
-// Lazy migration
+// Records at rest: get()/query() are stored-version by default,
+// migrateAll() is the only thing that ever changes disk state.
 // -------------------------------------------------------
 
-describe('lazy migration', () => {
+describe('records at rest', () => {
   beforeEach(async () => {
     await stack.defineType(
       NOTE_V2,
@@ -264,51 +265,190 @@ describe('lazy migration', () => {
     });
   });
 
-  test('get() returns migrated content in memory', async () => {
+  test('get() returns the record exactly as stored, no implicit migration', async () => {
     const record = await stack.create(NOTE_V1, { text: 'hello' });
     const fetched = await stack.get(record.id);
+    expect(fetched?.typeId).toBe(NOTE_V1);
+    expect((fetched?.content as Record<string, unknown>).title).toBeUndefined();
+  });
+
+  test('query() returns records exactly as stored, no implicit migration', async () => {
+    await stack.create(NOTE_V1, { text: 'hello' });
+    const result = await stack.query({ filter: { typeId: NOTE_V1 } });
+    expect(result.records[0]?.typeId).toBe(NOTE_V1);
+  });
+
+  test("update() validates against the record's own current typeId, never migrates it", async () => {
+    const record = await stack.create(NOTE_V1, { text: 'hello' });
+    const updated = await stack.update(record.id, { text: 'updated' });
+    expect(updated.typeId).toBe(NOTE_V1);
+    const raw = await adapter.getRecord(record.id);
+    expect(raw?.typeId).toBe(NOTE_V1); // still v1 on disk — update() never migrates
+    expect((raw?.content as Record<string, unknown>).text).toBe('updated');
+  });
+
+  test("update() validates only against v1's schema — a v2-only field passes through unchecked, and the record stays at v1", async () => {
+    const record = await stack.create(NOTE_V1, { text: 'hello' });
+    // "title" isn't declared in v1's schema, so validateContent() doesn't
+    // check it (additive fields are ignored, not rejected) — but this is
+    // still a v1 record; only migrateAll() can move it to v2.
+    const updated = await stack.update(record.id, { title: 'not part of v1' });
+    expect(updated.typeId).toBe(NOTE_V1);
+    const raw = await adapter.getRecord(record.id);
+    expect(raw?.typeId).toBe(NOTE_V1);
+  });
+});
+
+describe('query — baseId filter', () => {
+  beforeEach(async () => {
+    await stack.defineType(
+      NOTE_V2,
+      'Note',
+      {
+        text: { kind: 'text', required: true },
+        title: { kind: 'string' },
+      },
+      { migratesFrom: NOTE_V1 },
+    );
+  });
+
+  test('matches records across every version of the family, including not-yet-migrated ones', async () => {
+    const v1 = await stack.create(NOTE_V1, { text: 'old' });
+    const v2 = await stack.create(NOTE_V2, { text: 'new', title: 'hi' });
+
+    const result = await stack.query({ filter: { baseId: 'com.example.test/note' } });
+
+    const ids = result.records.map((r) => r.id).sort();
+    expect(ids).toEqual([v1.id, v2.id].sort());
+  });
+
+  test('returns empty results for an unknown baseId rather than throwing', async () => {
+    const result = await stack.query({ filter: { baseId: 'com.example.test/nonexistent' } });
+    expect(result).toEqual({ records: [], cursor: null, total: 0 });
+  });
+
+  test('intersects with typeId when both are given', async () => {
+    await stack.create(NOTE_V1, { text: 'old' });
+    const v2 = await stack.create(NOTE_V2, { text: 'new', title: 'hi' });
+
+    const result = await stack.query({
+      filter: { baseId: 'com.example.test/note', typeId: NOTE_V2 },
+    });
+
+    expect(result.records.map((r) => r.id)).toEqual([v2.id]);
+  });
+
+  test('accepts an array of baseIds', async () => {
+    await stack.defineType('com.example.test/other@1', 'Other', {
+      text: { kind: 'text', required: true },
+    });
+    const note = await stack.create(NOTE_V1, { text: 'note' });
+    const other = await stack.create('com.example.test/other@1', { text: 'other' });
+
+    const result = await stack.query({
+      filter: { baseId: ['com.example.test/note', 'com.example.test/other'] },
+    });
+
+    const ids = result.records.map((r) => r.id).sort();
+    expect(ids).toEqual([note.id, other.id].sort());
+  });
+});
+
+describe("presentAt: 'latest' (explicit in-memory migration)", () => {
+  beforeEach(async () => {
+    await stack.defineType(
+      NOTE_V2,
+      'Note',
+      {
+        text: { kind: 'text', required: true },
+        title: { kind: 'string' },
+      },
+      { migratesFrom: NOTE_V1 },
+    );
+
+    stack.registerMigration({
+      from: NOTE_V1,
+      to: NOTE_V2,
+      migrate: (content) => ({ ...content, title: '' }),
+    });
+  });
+
+  test("get({ presentAt: 'latest' }) returns migrated content in memory", async () => {
+    const record = await stack.create(NOTE_V1, { text: 'hello' });
+    const fetched = await stack.get(record.id, { presentAt: 'latest' });
     expect(fetched?.typeId).toBe(NOTE_V2);
     expect((fetched?.content as Record<string, unknown>).title).toBe('');
   });
 
-  test('get() does not write migrated content to disk', async () => {
+  test("get({ presentAt: 'latest' }) does not write migrated content to disk", async () => {
     const record = await stack.create(NOTE_V1, { text: 'hello' });
-    await stack.get(record.id);
+    await stack.get(record.id, { presentAt: 'latest' });
     const raw = await adapter.getRecord(record.id);
     expect(raw?.typeId).toBe(NOTE_V1); // still v1 on disk
   });
 
-  test('get({ migrate: false }) returns raw stored record', async () => {
-    const record = await stack.create(NOTE_V1, { text: 'hello' });
-    const raw = await stack.get(record.id, { migrate: false });
+  test("query({ presentAt: 'latest' }) migrates every result in memory", async () => {
+    await stack.create(NOTE_V1, { text: 'hello' });
+    const result = await stack.query({ filter: { typeId: NOTE_V1 }, presentAt: 'latest' });
+    expect(result.records[0]?.typeId).toBe(NOTE_V2);
+    expect((result.records[0]?.content as Record<string, unknown>).title).toBe('');
+    // Still not written to disk.
+    const raw = await adapter.getRecord(result.records[0]!.id);
     expect(raw?.typeId).toBe(NOTE_V1);
-    expect((raw?.content as Record<string, unknown>).title).toBeUndefined();
   });
 
-  test('update() commits migration to disk', async () => {
-    const record = await stack.create(NOTE_V1, { text: 'hello' });
-    await stack.update(record.id, { title: 'My Title' });
-    const raw = await adapter.getRecord(record.id);
-    expect(raw?.typeId).toBe(NOTE_V2);
-    expect((raw?.content as Record<string, unknown>).title).toBe('My Title');
-  });
-
-  test('update() merges patch against migrated content', async () => {
-    const record = await stack.create(NOTE_V1, { text: 'hello' });
-    await stack.update(record.id, {}); // empty patch, just commits migration
-    const raw = await adapter.getRecord(record.id);
-    expect((raw?.content as Record<string, unknown>).title).toBe(''); // migration default
-  });
-
-  test('warns when no migration path exists', async () => {
+  test('a single-version type with no migration history is trivially "latest" — no throw', async () => {
     const unmigratableType = 'com.example.test/other@1';
     await stack.defineType(unmigratableType, 'Other', {
       text: { kind: 'text', required: true },
     });
     const record = await stack.create(unmigratableType, { text: 'hello' });
-    // Should not throw — just warn and return raw
-    const fetched = await stack.get(record.id);
+    const fetched = await stack.get(record.id, { presentAt: 'latest' });
     expect(fetched?.typeId).toBe(unmigratableType);
+  });
+
+  test('stale-writer signal: a record newer than what this app instance has defined throws', async () => {
+    // stackA is fully up to date: knows v1 and v2, and writes a v2 record.
+    const stackA = await Stack.create(adapter);
+    await stackA.defineType(NOTE_V1, 'Note', { text: { kind: 'text', required: true } });
+    await stackA.defineType(
+      NOTE_V2,
+      'Note',
+      { text: { kind: 'text', required: true }, title: { kind: 'string' } },
+      { migratesFrom: NOTE_V1 },
+    );
+    const record = await stackA.create(NOTE_V2, { text: 'hello', title: 'hi' });
+
+    // stackB simulates a stale binary sharing the same storage — its own
+    // startup code only ever defineType()'d v1, so it has no idea v2 exists.
+    const stackB = await Stack.create(adapter);
+    await stackB.defineType(NOTE_V1, 'Note', { text: { kind: 'text', required: true } });
+
+    await expect(stackB.get(record.id, { presentAt: 'latest' })).rejects.toThrow(
+      StackMigrationError,
+    );
+    // Reading it as stored (the default) still works fine even for the stale app.
+    const fetched = await stackB.get(record.id);
+    expect(fetched?.typeId).toBe(NOTE_V2);
+  });
+
+  test('registration gap: an older record with no migration path to a type this app has defined throws', async () => {
+    const gapAdapter = new MemoryAdapter({ ownerEntityId: 'owner-123', timezone: 'UTC' });
+    const gapStack = await Stack.create(gapAdapter);
+    await gapStack.defineType(NOTE_V1, 'Note', { text: { kind: 'text', required: true } });
+    await gapStack.defineType(
+      NOTE_V2,
+      'Note',
+      { text: { kind: 'text', required: true }, title: { kind: 'string' } },
+      { migratesFrom: NOTE_V1 },
+    );
+    // Note: no registerMigration() call — this app knows v2 exists but has
+    // no path to reach it from a v1 record.
+    const record = await gapStack.create(NOTE_V1, { text: 'hello' });
+
+    await expect(gapStack.get(record.id, { presentAt: 'latest' })).rejects.toThrow(
+      StackMigrationError,
+    );
   });
 
   test('chained migration: v1 → v2 → v3', async () => {
@@ -330,7 +470,7 @@ describe('lazy migration', () => {
     });
 
     const record = await stack.create(NOTE_V1, { text: 'hello' });
-    const fetched = await stack.get(record.id);
+    const fetched = await stack.get(record.id, { presentAt: 'latest' });
     expect(fetched?.typeId).toBe(NOTE_V3);
     expect((fetched?.content as Record<string, unknown>).title).toBe('');
     expect((fetched?.content as Record<string, unknown>).pinned).toBe(false);
@@ -420,6 +560,36 @@ describe('migrateAll', () => {
     const versions = await stack.getVersions(record.id);
     expect(versions.length).toBe(1);
     expect(versions[0].content).toEqual({ text: 'original' });
+    expect(versions[0].typeId).toBe(NOTE_V1);
+  });
+
+  test('aborts immediately if a migration function produces invalid content, leaving that record unmigrated', async () => {
+    // Fresh stack so this test can register its own (deliberately buggy)
+    // migration instead of the valid one from the outer beforeEach.
+    const buggyAdapter = new MemoryAdapter({ ownerEntityId: 'owner-123', timezone: 'UTC' });
+    const buggyStack = await Stack.create(buggyAdapter);
+    await buggyStack.defineType(NOTE_V1, 'Note', { text: { kind: 'text', required: true } });
+    await buggyStack.defineType(
+      NOTE_V2,
+      'Note',
+      { text: { kind: 'text', required: true }, title: { kind: 'string' } },
+      { migratesFrom: NOTE_V1 },
+    );
+    buggyStack.registerMigration({
+      from: NOTE_V1,
+      to: NOTE_V2,
+      // Buggy migration: drops the required "text" field instead of carrying it forward.
+      migrate: () => ({ title: '' }),
+    });
+
+    const record = await buggyStack.create(NOTE_V1, { text: 'original' });
+    await expect(buggyStack.migrateAll('com.example.test/note')).rejects.toThrow(
+      StackValidationError,
+    );
+
+    const raw = await buggyAdapter.getRecord(record.id);
+    expect(raw?.typeId).toBe(NOTE_V1); // never committed
+    expect(await buggyStack.getVersions(record.id)).toEqual([]); // no snapshot either
   });
 });
 

--- a/packages/record-adapter-sqlite/tests/record.test.ts
+++ b/packages/record-adapter-sqlite/tests/record.test.ts
@@ -362,6 +362,7 @@ describe('records — CRUD', () => {
     await adapter.createRecord(record);
     await adapter.saveVersion(record.id, {
       version: 1,
+      typeId: record.typeId,
       content: record.content,
       updatedAt: record.updatedAt,
     });
@@ -610,6 +611,7 @@ describe('versions', () => {
     await adapter.createRecord(record);
     const version = {
       version: 1,
+      typeId: record.typeId,
       content: { text: 'original' },
       updatedAt: new Date('2024-01-01'),
       entityId: 'entity-123',
@@ -624,7 +626,12 @@ describe('versions', () => {
     const adapter = await initAdapter();
     const record = makeRecord();
     await adapter.createRecord(record);
-    const v = { version: 1, content: { text: 'original' }, updatedAt: new Date() };
+    const v = {
+      version: 1,
+      typeId: record.typeId,
+      content: { text: 'original' },
+      updatedAt: new Date(),
+    };
     await adapter.saveVersion(record.id, v);
     await adapter.saveVersion(record.id, v);
     const versions = await adapter.getVersions(record.id);
@@ -639,6 +646,7 @@ describe('restoreVersion', () => {
     await adapter.createRecord(record);
     await adapter.saveVersion(record.id, {
       version: 1,
+      typeId: record.typeId,
       content: { text: 'original' },
       updatedAt: new Date(),
     });
@@ -655,6 +663,7 @@ describe('restoreVersion', () => {
     await adapter.createRecord(record);
     await adapter.saveVersion(record.id, {
       version: 1,
+      typeId: record.typeId,
       content: { text: 'original searchable text' },
       updatedAt: new Date(),
     });

--- a/packages/record-adapter-sqljs/tests/record.test.ts
+++ b/packages/record-adapter-sqljs/tests/record.test.ts
@@ -254,6 +254,7 @@ describe('records — CRUD', () => {
     await adapter.createRecord(record);
     await adapter.saveVersion(record.id, {
       version: 1,
+      typeId: record.typeId,
       content: record.content,
       updatedAt: record.updatedAt,
     });
@@ -771,6 +772,7 @@ describe('versions', () => {
     await adapter.createRecord(record);
     const version = {
       version: 1,
+      typeId: record.typeId,
       content: { text: 'original' },
       updatedAt: new Date('2024-01-01'),
       entityId: 'entity-123',
@@ -788,11 +790,13 @@ describe('versions', () => {
     await adapter.createRecord(record);
     await adapter.saveVersion(record.id, {
       version: 1,
+      typeId: record.typeId,
       content: { text: 'v1' },
       updatedAt: new Date(),
     });
     await adapter.saveVersion(record.id, {
       version: 2,
+      typeId: record.typeId,
       content: { text: 'v2' },
       updatedAt: new Date(),
     });
@@ -813,7 +817,12 @@ describe('versions', () => {
     const adapter = await initAdapter();
     const record = makeRecord();
     await adapter.createRecord(record);
-    const v = { version: 1, content: { text: 'original' }, updatedAt: new Date() };
+    const v = {
+      version: 1,
+      typeId: record.typeId,
+      content: { text: 'original' },
+      updatedAt: new Date(),
+    };
     await adapter.saveVersion(record.id, v);
     await adapter.saveVersion(record.id, v);
     const versions = await adapter.getVersions(record.id);
@@ -826,6 +835,7 @@ describe('versions', () => {
     await adapter.createRecord(record);
     await adapter.saveVersion(record.id, {
       version: 1,
+      typeId: record.typeId,
       content: { text: 'original' },
       updatedAt: new Date(),
       associations: [{ kind: 'tag', label: 'starred' }],
@@ -842,6 +852,7 @@ describe('versions', () => {
     await adapter.createRecord(record);
     await adapter.saveVersion(record.id, {
       version: 1,
+      typeId: record.typeId,
       content: { text: 'original' },
       updatedAt: new Date(),
     });
@@ -858,6 +869,7 @@ describe('restoreVersion', () => {
     await adapter.createRecord(record);
     await adapter.saveVersion(record.id, {
       version: 1,
+      typeId: record.typeId,
       content: { text: 'original' },
       updatedAt: new Date(),
     });
@@ -874,6 +886,7 @@ describe('restoreVersion', () => {
     await adapter.createRecord(record);
     await adapter.saveVersion(record.id, {
       version: 1,
+      typeId: record.typeId,
       content: { text: 'original' },
       updatedAt: new Date(),
       associations: [{ kind: 'tag', label: 'starred' }],
@@ -890,6 +903,7 @@ describe('restoreVersion', () => {
     await adapter.createRecord(record);
     await adapter.saveVersion(record.id, {
       version: 1,
+      typeId: record.typeId,
       content: { text: 'original searchable text' },
       updatedAt: new Date(),
     });
@@ -1013,6 +1027,7 @@ describe('deleteUnreferencedAttachmentRecords', () => {
     );
     await adapter.saveVersion('meta1', {
       version: 1,
+      typeId: ATTACHMENT_TYPE,
       content: { fileId: 'file-1' },
       updatedAt: new Date(),
     });

--- a/packages/sqlite-shared/src/mappers.ts
+++ b/packages/sqlite-shared/src/mappers.ts
@@ -67,6 +67,7 @@ export const rowToType = (row: Record<string, unknown>): StackType => {
 export const rowToVersion = (row: Record<string, unknown>): RecordVersion => {
   const v: RecordVersion = {
     version: row.version as number,
+    typeId: row.type_id as string,
     content: JSON.parse(row.content as string),
     updatedAt: fromMs(row.updated_at as number),
   };

--- a/packages/sqlite-shared/src/record-logic.ts
+++ b/packages/sqlite-shared/src/record-logic.ts
@@ -291,11 +291,12 @@ export class SharedSqlRecordLogic {
   async saveVersion(id: string, version: RecordVersion): Promise<void> {
     this.exec.run(
       `INSERT OR IGNORE INTO versions
-        (record_id, version, content, updated_at, entity_id, associations, permissions)
-       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        (record_id, version, type_id, content, updated_at, entity_id, associations, permissions)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
       [
         id,
         version.version,
+        version.typeId,
         JSON.stringify(version.content),
         toMs(version.updatedAt),
         version.entityId ?? null,

--- a/packages/sqlite-shared/src/schema.ts
+++ b/packages/sqlite-shared/src/schema.ts
@@ -34,6 +34,7 @@ export const RECORD_SCHEMA_SQL = `
   CREATE TABLE IF NOT EXISTS versions (
     record_id   TEXT NOT NULL REFERENCES records(id),
     version     INTEGER NOT NULL,
+    type_id     TEXT NOT NULL,
     content     TEXT NOT NULL CHECK (json_valid(content)),
     updated_at  INTEGER NOT NULL,
     entity_id   TEXT,

--- a/packages/wire-types/src/index.ts
+++ b/packages/wire-types/src/index.ts
@@ -43,6 +43,7 @@ export type WireType = {
 
 export type WireVersion = {
   version: number;
+  typeId: string;
   content: Record<string, unknown>;
   updatedAt: string;
   entityId?: string;
@@ -85,6 +86,7 @@ export function serializeType(t: StackType): WireType {
 export function serializeVersion(v: RecordVersion): WireVersion {
   const w: WireVersion = {
     version: v.version,
+    typeId: v.typeId,
     content: v.content,
     updatedAt: v.updatedAt.toISOString(),
   };


### PR DESCRIPTION
## Summary

Implements #47: replaces the lazy migration model (transform-on-read + commit-on-next-write) with explicit, owner-driven `migrateAll()`, plus the mechanical fixes the RFC calls out.

- **`migrateAll()` is the only thing that ever changes a record's disk-state `typeId`.** `update()` no longer silently commits a pending migration as a side effect of an unrelated content edit — it validates the merge-patched content against the record's own current stored type and writes back at the same `typeId`.
- **`get()`/`query()` return records exactly as stored by default**, fixing the spec/impl divergence where `query()` never migrated but `get()` did (the bug that made `query({ filter: { typeId } })` silently miss not-yet-migrated records). `presentAt: 'latest'` is an explicit, never-persisted opt-in supported by both.
- **Stale-writer signal**: `presentAt: 'latest'` throws `StackMigrationError` (replacing a `console.warn` + raw record) when a record's version can't be reconciled with what this app instance has registered/defined — covering both a stale binary reading a newer record and an app that knows a later type exists but has no migration path to reach it.
- **`Filter.baseId`** matches every version of a type family, resolved client-side via `listTypes()` before hitting the adapter/wire layer — no adapter or wire changes needed.
- **Grants match by `baseId`** instead of exact `typeId`, so a version bump no longer orphans existing grants.
- **`RecordVersion` gains `typeId`**, threaded through `sqlite-shared` (DDL + row mapper), `wire-types`, and `adapter-api`.
- **`migrateAll()` validates** each migrated record's content against the target schema before committing, aborting immediately on the first failure rather than partially applying a buggy migration function.

Also updates `docs/spec.md`'s Type migrations, Queries, Grant, and Versions sections, and adds a new "Additive evolution within a version" section capturing the governance rule from the issue's two amendment comments (when a version bump is warranted vs. additive-in-place).

## Test plan

- [x] `pnpm -r build` — all 9 packages build clean
- [x] `pnpm -r typecheck` — clean
- [x] `pnpm -r test` — all packages pass (core: 278 tests, including new coverage for `presentAt: 'latest'`, `baseId` filtering, grant-by-family matching, and `migrateAll()` abort-on-invalid-migration)
- [x] `pnpm -r lint` — clean
- [x] `pnpm format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01N7kvcnFyZcz3NdwaiCadVY)_