### PR TITLE
restoreVersion() must validate the snapshot and restore its typeId

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -447,7 +447,11 @@ type RecordVersion = {
 **API surface:**
 
 - `stack.getVersions(recordId)` — retrieve version history
-- `stack.restoreVersion(recordId, version)` — revert to a prior version. Restores `content` and `associations` when the target snapshot has them, but **never restores `permissions`** — those are owner/creator territory (see [Permissions](#permissions)), and silently reverting an ACL as a side effect of a content rollback would be a surprise nobody wants. Permissions in a snapshot are for audit and deliberate owner action, not automatic restore.
+- `stack.restoreVersion(recordId, version)` — revert to a prior version. Restores `content`, `typeId`, and `associations` when the target snapshot has them, but **never restores `permissions`** — those are owner/creator territory (see [Permissions](#permissions)), and silently reverting an ACL as a side effect of a content rollback would be a surprise nobody wants. Permissions in a snapshot are for audit and deliberate owner action, not automatic restore.
+
+  The snapshot's content is validated against **the type it claims** (`typeId` as stored in the snapshot), not the Record's current type — a snapshot taken before a migration is `@1`-shaped, and validating it against a since-migrated `@2` schema would wrongly reject a legitimate restore. A snapshot that fails validation against its own claimed type — in-place schema drift, or a corrupted/buggy adapter — throws `StackValidationError` instead of being written back; restore is a recovery path, so it is not a backdoor around content validation.
+
+  Restoring a pre-migration snapshot therefore also restores its old `typeId`, leaving the Record legitimately **stale** rather than mislabeled. No forward-migration happens at restore time — migration functions are app code (see [Type migrations](#type-migrations)), so restore behaves the same locally as it does through the server-side restore endpoint, which cannot run them either. A stale restored Record self-heals the same way any other stale Record does: on the owning app's next `migrateAll()` sweep.
 
 **Storage per adapter:**
 
@@ -685,7 +689,7 @@ Under `ScopedStack`, `undelete()` is gated the same way as `delete()` — the `w
 
 Undelete does not re-run migrations. If a soft-deleted Record's schema fell behind while it was deleted, it comes back stale — a legal state, self-healing the same way any other stale Record is, the next time it's written or `migrateAll()` sweeps it. `migrateAll()` includes soft-deleted Records in its sweep, so a Record can be migrated while deleted and come back current on undelete.
 
-**Restore** always creates a new version with the old content — it never rewrites history. The act of restoring is itself part of the version history.
+**Restore** always creates a new version with the old content and `typeId` — it never rewrites history. The act of restoring is itself part of the version history. The snapshot's content is validated against the type it claims (its own stored `typeId`, not the Record's current one) before being written back; a snapshot that fails that validation — schema drift, or a corrupted/buggy adapter — throws `StackValidationError` rather than being restored. Restoring an old snapshot does not migrate it forward, so a restored pre-migration Record comes back stale, same as undelete above — legal, and healed by the next `migrateAll()` sweep.
 
 ```ts
 stack.restoreVersion(recordId, version); // creates a new version, doesn't rewrite history

--- a/packages/adapter-api/tests/conformance.test.ts
+++ b/packages/adapter-api/tests/conformance.test.ts
@@ -260,6 +260,10 @@ describe('error response fixtures', () => {
         if (fixture.method === 'POST' && fixture.path === '/records/query') {
           return adapter.queryRecords(fixture.requestBody as never);
         }
+        if (fixture.method === 'POST' && fixture.path.includes('/restore/')) {
+          const version = Number(fixture.path.split('/').pop());
+          return adapter.restoreVersion(idFromPath(fixture.path), version);
+        }
         if (fixture.method === 'PATCH') {
           return adapter.patchContent(
             idFromPath(fixture.path),

--- a/packages/conformance-fixtures/src/index.ts
+++ b/packages/conformance-fixtures/src/index.ts
@@ -340,6 +340,25 @@ export const errorResponseFixtures: ConformanceFixture<unknown, WireError>[] = [
     },
   },
   {
+    name: 'error-validation-failed-restore',
+    description:
+      'POST /records/:id/restore/:version against a drifted or corrupted snapshot — content ' +
+      'that no longer satisfies the schema of the type it claims — returns 422 with code ' +
+      '"validation", identically to a PATCH validation failure. Restore is not a backdoor ' +
+      'around schema validation (#62): the snapshot is validated against its own stored ' +
+      "typeId, not the record's current one.",
+    method: 'POST',
+    path: '/records/rec-1/restore/1',
+    responseStatus: 422,
+    responseBody: {
+      error: {
+        code: 'validation',
+        message: 'Content validation failed',
+        details: [{ path: 'title', message: 'expected string, got number' }],
+      },
+    },
+  },
+  {
     name: 'error-bad-request-malformed-cursor',
     description:
       'A query with an undecodable pagination cursor returns 400 with code "bad_request" — a ' +

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -794,7 +794,17 @@ export class Stack implements StackClient {
 
   /**
    * Restore a record to a previous version by creating a new version
-   * with the old content. Never rewrites history.
+   * with the old content and typeId. Never rewrites history.
+   *
+   * Validates the snapshot's content against the *snapshot's own* stored
+   * type — not the record's current type, which may have since migrated.
+   * A snapshot taken before a migration is `@1`-shaped; validating it
+   * against a current `@2` schema would wrongly reject a perfectly valid
+   * restore. Restoring an old-version snapshot therefore leaves the record
+   * stale at that old typeId, same as undelete() — legal, and healed by
+   * the owning app's next migrateAll() sweep. This never forward-migrates:
+   * migration functions are app code, and restore shouldn't behave
+   * differently locally than a server-side restore endpoint could.
    *
    * Restores associations too, when the target snapshot has them. Never
    * restores permissions — those are owner/creator territory (see
@@ -811,6 +821,16 @@ export class Stack implements StackClient {
     const target = await this.adapter.getVersion(id, version);
     if (!target) {
       throw new StackNotFoundError(`Version ${version} not found for record "${id}"`);
+    }
+
+    const type = await this.adapter.getType(target.typeId);
+    if (!type) {
+      throw new Error(`Unknown type: "${target.typeId}"`);
+    }
+
+    const errors = validateContent(target.content, type.schema);
+    if (errors.length > 0) {
+      throw new StackValidationError(errors);
     }
 
     // Snapshot current state before restoring

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -156,6 +156,7 @@ export class MemoryAdapter implements StackAdapter {
     if (!target) throw new Error(`Version not found: ${id}@${version}`);
     const updated = this.bump({
       ...record,
+      typeId: target.typeId,
       content: target.content,
       ...(target.associations !== undefined && { associations: target.associations }),
     });

--- a/packages/core/tests/stack.test.ts
+++ b/packages/core/tests/stack.test.ts
@@ -594,6 +594,62 @@ describe('migrateAll', () => {
 });
 
 // -------------------------------------------------------
+// restoreVersion — typeId and validation (#62)
+// -------------------------------------------------------
+
+describe('restoreVersion — typeId and validation', () => {
+  beforeEach(async () => {
+    await stack.defineType(
+      NOTE_V2,
+      'Note',
+      {
+        text: { kind: 'text', required: true },
+        title: { kind: 'string' },
+      },
+      { migratesFrom: NOTE_V1 },
+    );
+
+    stack.registerMigration({
+      from: NOTE_V1,
+      to: NOTE_V2,
+      migrate: (content) => ({ ...content, title: '' }),
+    });
+  });
+
+  test('restores the snapshot’s own typeId, leaving a stale record that migrateAll() subsequently heals', async () => {
+    const record = await stack.create(NOTE_V1, { text: 'original' });
+    await stack.migrateAll('com.example.test/note'); // now @2, snapshot v1 is @1-shaped
+    expect((await stack.get(record.id))?.typeId).toBe(NOTE_V2);
+
+    const restored = await stack.restoreVersion(record.id, 1);
+
+    // Restoring the pre-migration snapshot brings its typeId back too —
+    // the record is legitimately stale at @1, not mislabeled @2.
+    expect(restored.typeId).toBe(NOTE_V1);
+    expect(restored.content).toEqual({ text: 'original' });
+
+    const healed = await stack.migrateAll('com.example.test/note');
+    expect(healed.migrated).toBe(1);
+    expect((await stack.get(record.id))?.typeId).toBe(NOTE_V2);
+  });
+
+  test('rejects a drifted/invalid snapshot with StackValidationError instead of restoring it', async () => {
+    const record = await stack.create(NOTE_V1, { text: 'hello' });
+    // Simulate schema drift or adapter corruption: a stored snapshot whose
+    // content no longer satisfies its own claimed type's schema.
+    await adapter.saveVersion(record.id, {
+      version: 1,
+      typeId: NOTE_V1,
+      content: {}, // missing required "text"
+      updatedAt: new Date(),
+    });
+
+    await expect(stack.restoreVersion(record.id, 1)).rejects.toThrow(StackValidationError);
+    expect((await stack.get(record.id))?.content).toEqual({ text: 'hello' }); // untouched
+  });
+});
+
+// -------------------------------------------------------
 // Versions
 // -------------------------------------------------------
 

--- a/packages/record-adapter-sqlite/tests/record.test.ts
+++ b/packages/record-adapter-sqlite/tests/record.test.ts
@@ -683,6 +683,26 @@ describe('restoreVersion', () => {
     await adapter.createRecord(record);
     await expect(adapter.restoreVersion(record.id, 99)).rejects.toThrow();
   });
+
+  test('restores typeId from the snapshot, even when it differs from the record’s current typeId', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord({ typeId: 'com.example.test/note@1' });
+    await adapter.createRecord(record);
+    await adapter.saveVersion(record.id, {
+      version: 1,
+      typeId: 'com.example.test/note@1',
+      content: { text: 'original' },
+      updatedAt: new Date(),
+    });
+    await adapter.commitMigration(record.id, 'com.example.test/note@2', {
+      text: 'original',
+      pinned: false,
+    });
+
+    const restored = await adapter.restoreVersion(record.id, 1);
+    expect(restored.typeId).toBe('com.example.test/note@1');
+    expect(restored.content).toEqual({ text: 'original' });
+  });
 });
 
 describe('commitMigration', () => {

--- a/packages/record-adapter-sqljs/tests/record.test.ts
+++ b/packages/record-adapter-sqljs/tests/record.test.ts
@@ -923,6 +923,26 @@ describe('restoreVersion', () => {
     await adapter.createRecord(record);
     await expect(adapter.restoreVersion(record.id, 99)).rejects.toThrow();
   });
+
+  test('restores typeId from the snapshot, even when it differs from the record’s current typeId', async () => {
+    const adapter = await initAdapter();
+    const record = makeRecord({ typeId: 'com.example.test/note@1' });
+    await adapter.createRecord(record);
+    await adapter.saveVersion(record.id, {
+      version: 1,
+      typeId: 'com.example.test/note@1',
+      content: { text: 'original' },
+      updatedAt: new Date(),
+    });
+    await adapter.commitMigration(record.id, 'com.example.test/note@2', {
+      text: 'original',
+      pinned: false,
+    });
+
+    const restored = await adapter.restoreVersion(record.id, 1);
+    expect(restored.typeId).toBe('com.example.test/note@1');
+    expect(restored.content).toEqual({ text: 'original' });
+  });
 });
 
 describe('commitMigration', () => {

--- a/packages/sqlite-shared/src/record-logic.ts
+++ b/packages/sqlite-shared/src/record-logic.ts
@@ -164,8 +164,8 @@ export class SharedSqlRecordLogic {
 
     this.fts.remove(this.exec, id);
     this.exec.run(
-      'UPDATE records SET content = ?, version = version + 1, updated_at = ? WHERE id = ?',
-      [JSON.stringify(target.content), toMs(new Date()), id],
+      'UPDATE records SET type_id = ?, content = ?, version = version + 1, updated_at = ? WHERE id = ?',
+      [target.typeId, JSON.stringify(target.content), toMs(new Date()), id],
     );
     if (target.associations !== undefined) {
       this.exec.run('DELETE FROM associations WHERE record_id = ?', [id]);


### PR DESCRIPTION
## Summary

- `Stack.restoreVersion()` now validates the target snapshot's content against **the type it claims** (its own stored `typeId`), not the record's current type — a schema-drifted or corrupted snapshot throws `StackValidationError` instead of being written back unchecked.
- Restore now also restores `typeId` along with `content` and `associations`. A restored pre-migration snapshot is legitimately **stale** at its old type rather than mislabeled at the record's current one — the same stale-is-legal, `migrateAll()`-heals principle used by `undelete()` (#60), since no forward-migration happens at restore time (migration functions are app code, per #47).
- Fixed the two adapter implementations that back `restoreVersion()` (`sqlite-shared`'s shared record logic, used by both the SQLite and sql.js adapters, and core's in-memory test adapter) to actually persist the snapshot's `typeId` — both already had it in hand via the fetched snapshot but never wrote it back.
- Added a conformance fixture pinning restore-of-an-invalid-snapshot → 422 → `StackValidationError`, alongside the existing valid-restore round-trip fixture, and wired it into `adapter-api`'s conformance test dispatch.
- Updated `docs/spec.md` §Versions and the restore/undelete narrative to document the validation-against-own-type rule and the stale/self-healing behavior.

This closes out the last piece of #62; its blocking dependencies (#47's `RecordVersion.typeId`, #61's snapshot fields, #52's intent-split adapter contract, #53's typed wire errors) already landed.

## Test plan

- [x] `pnpm -r build`
- [x] `pnpm -r typecheck`
- [x] `pnpm -r lint`
- [x] `pnpm -r test` (all packages green, including new cases below)
- [x] New tests: typeId restoration + `migrateAll()` healing of a restored pre-migration snapshot; drifted/invalid snapshot rejected with `StackValidationError`; adapter-level typeId restoration in both sqlite and sqljs record adapters; conformance fixture round-trip for the new 422 case
- [x] `pnpm format:check`


---
_Generated by [Claude Code](https://claude.ai/code/session_015DCRTSfYzrV9uFzeXKx1oc)_