### PR TITLE
Core code treats one query() page as the complete result set

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -635,6 +635,8 @@ type Query = {
 
 Pagination is cursor-based rather than offset-based, so it works consistently across adapters and doesn't drift when records are inserted mid-page. A `cursor` that can't be decoded — an unknown sort field, a non-numeric sort value, or a corrupted/malformed blob — is a structurally malformed request, not a content-validation failure: adapters throw `StackQueryError`, which maps to **400** (code `bad_request`), not 422 and not a bare 500.
 
+**`query()` always paginates.** An absent `limit` means one adapter-default page (50), never "every matching Record." Any caller — app code or library-internal — that needs the complete result set MUST follow `cursor` to exhaustion; treating a single `query()` call as exhaustive is a caller bug, not a pagination bug, however the pages are sized.
+
 ### Adapter capabilities
 
 Adapters expose a capabilities object so apps can check what's supported before relying on a feature:

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -233,6 +233,47 @@ export interface StackClient {
 }
 
 // -------------------------------------------------------
+// Query helpers
+// -------------------------------------------------------
+
+/**
+ * query() always paginates: an absent `limit` returns one adapter-default
+ * page, never the complete result set. This walks `cursor` to exhaustion
+ * for the handful of internal call sites that need every match — grant
+ * checks, attachment-metadata cleanup, uploader-access checks — where
+ * silently stopping at page one would misfire past the page boundary
+ * (deny an existing grant, leave orphaned metadata, false-deny an
+ * uploader). Not a public API: callers that can tolerate normal paging
+ * should call query() directly.
+ *
+ * Throws StackQueryError rather than silently truncating if more than
+ * `max` records are found without the cursor terminating — a runaway
+ * scan is a bug to surface, not paper over.
+ */
+async function queryAllPages(
+  run: (query: StackQuery) => Promise<QueryResult>,
+  query: StackQuery,
+  max = QUERY_ALL_MAX,
+): Promise<StackRecord[]> {
+  const records: StackRecord[] = [];
+  let cursor = query.cursor;
+  do {
+    const page = await run({ ...query, cursor });
+    records.push(...page.records);
+    if (records.length > max) {
+      throw new StackQueryError(
+        `queryAllPages: exceeded max of ${max} records without exhausting the cursor`,
+      );
+    }
+    cursor = page.cursor ?? undefined;
+  } while (cursor);
+  return records;
+}
+
+/** Safety cap for queryAllPages() — generous for personal-stack scale. */
+const QUERY_ALL_MAX = 10_000;
+
+// -------------------------------------------------------
 // Stack class
 // -------------------------------------------------------
 
@@ -908,15 +949,19 @@ export class Stack implements StackClient {
       throw new StackConflictError('Attachment is still referenced by one or more records');
     }
 
-    const metaResult = await this.query({
+    // Cursor-walked: on adapters without contentFieldQuery, every
+    // _attachment@1 record must be scanned in memory below, and a single
+    // default page would leave metadata beyond page one un-deleted —
+    // exactly the orphan this method exists to prevent.
+    const metaResults = await queryAllPages((q) => this.query(q), {
       filter: {
         typeId: metadataTypeId,
         ...(this.features.contentFieldQuery && { content: { fileId } }),
       },
     });
     const metaRecords = this.features.contentFieldQuery
-      ? metaResult.records
-      : metaResult.records.filter((r) => (r.content as AttachmentContent).fileId === fileId);
+      ? metaResults
+      : metaResults.filter((r) => (r.content as AttachmentContent).fileId === fileId);
 
     for (const record of metaRecords) {
       await this.delete(record.id, { hard: true });
@@ -1134,9 +1179,11 @@ export class ScopedStack implements StackClient {
       // No content-field prefilter here: matching is by baseId, which a
       // stored grant may express as either a bare baseId or a versioned
       // typeId, so an exact-match content filter would wrongly exclude
-      // grants for other versions of the family.
-      const result = await this.stack.query({ filter: { typeId: `${SYSTEM_TYPES.GRANT}@1` } });
-      grantRecords = result.records;
+      // grants for other versions of the family. Cursor-walked: a single
+      // default page would silently miss grants past page one.
+      grantRecords = await queryAllPages((q) => this.stack.query(q), {
+        filter: { typeId: `${SYSTEM_TYPES.GRANT}@1` },
+      });
     }
 
     return grantRecords.some((r) => {
@@ -1232,7 +1279,10 @@ export class ScopedStack implements StackClient {
    * `total` is always null — see the QueryResult.total doc comment.
    *
    * Grant records are pre-fetched once before the pagination loop so read
-   * grants don't trigger a separate _grant@1 query per record.
+   * grants don't trigger a separate _grant@1 query per record. The
+   * prefetch itself cursor-walks every _grant@1 record — a single default
+   * page would silently miss grants past page one, denying access that
+   * should exist with no error (see queryAllPages()).
    */
   async query(query: StackQuery = {}): Promise<QueryResult> {
     const limit = Math.min(query.limit ?? DEFAULT_QUERY_LIMIT, MAX_QUERY_LIMIT);
@@ -1241,7 +1291,9 @@ export class ScopedStack implements StackClient {
     let totalFetched = 0;
 
     const prefetchedGrants = this.requesterEntityId
-      ? (await this.stack.query({ filter: { typeId: `${SYSTEM_TYPES.GRANT}@1` } })).records
+      ? await queryAllPages((q) => this.stack.query(q), {
+          filter: { typeId: `${SYSTEM_TYPES.GRANT}@1` },
+        })
       : undefined;
 
     let page: QueryResult = { records: [], cursor: query.cursor ?? null, total: null };
@@ -1380,19 +1432,32 @@ export class ScopedStack implements StackClient {
       return this.stack.getAttachment(fileId);
     }
 
-    // Accessible if the requester uploaded it and it hasn't been associated yet
+    // Accessible if the requester uploaded it and it hasn't been associated yet.
+    // With contentFieldQuery, the filter narrows to this fileId server-side, so
+    // limit: 1 is a correct existence check. Without it, matching happens in
+    // memory below — limit: 1 there would only ever see the requester's single
+    // most recent upload, false-denying every earlier one, so that path
+    // cursor-walks all of the requester's uploads instead.
     if (this.requesterEntityId) {
-      const uploadResult = await this.stack.query({
-        filter: {
-          typeId: `${SYSTEM_TYPES.ATTACHMENT}@1`,
-          entityId: this.requesterEntityId,
-          ...(this.stack.features.contentFieldQuery && { content: { fileId } }),
-        },
-        limit: 1,
-      });
       const hasUpload = this.stack.features.contentFieldQuery
-        ? uploadResult.records.length > 0
-        : uploadResult.records.some((r) => (r.content as AttachmentContent).fileId === fileId);
+        ? (
+            await this.stack.query({
+              filter: {
+                typeId: `${SYSTEM_TYPES.ATTACHMENT}@1`,
+                entityId: this.requesterEntityId,
+                content: { fileId },
+              },
+              limit: 1,
+            })
+          ).records.length > 0
+        : (
+            await queryAllPages((q) => this.stack.query(q), {
+              filter: {
+                typeId: `${SYSTEM_TYPES.ATTACHMENT}@1`,
+                entityId: this.requesterEntityId,
+              },
+            })
+          ).some((r) => (r.content as AttachmentContent).fileId === fileId);
       if (hasUpload) return this.stack.getAttachment(fileId);
     }
 

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -13,8 +13,11 @@ import type {
 import { applyMergePatch } from './merge.js';
 
 /**
- * Fully functional in-memory StackAdapter with offset-based cursor pagination.
- * Intended for use in tests — import from `@haverstack/core/testing`.
+ * In-memory StackAdapter with offset-based cursor pagination. Implements the
+ * full RecordFilter shape (mirroring sqlite-shared's buildWhereClause) so
+ * permission logic under test exercises real predicates rather than an
+ * adapter that quietly ignores most filters. Intended for use in tests —
+ * import from `@haverstack/core/testing`.
  */
 export class MemoryAdapter implements StackAdapter {
   readonly capabilities: AdapterCapabilities = {
@@ -95,15 +98,51 @@ export class MemoryAdapter implements StackAdapter {
           ? results.filter((r) => !r.parentId)
           : results.filter((r) => r.parentId === f.parentId);
     }
+    if (f.appId !== undefined) {
+      const ids = Array.isArray(f.appId) ? f.appId : [f.appId];
+      results = results.filter((r) => r.appId !== undefined && ids.includes(r.appId));
+    }
     if (f.entityId !== undefined) {
       const ids = Array.isArray(f.entityId) ? f.entityId : [f.entityId];
       results = results.filter((r) => r.entityId !== undefined && ids.includes(r.entityId));
+    }
+    if (f.createdAt?.after) results = results.filter((r) => r.createdAt > f.createdAt!.after!);
+    if (f.createdAt?.before) results = results.filter((r) => r.createdAt < f.createdAt!.before!);
+    if (f.updatedAt?.after) results = results.filter((r) => r.updatedAt > f.updatedAt!.after!);
+    if (f.updatedAt?.before) results = results.filter((r) => r.updatedAt < f.updatedAt!.before!);
+    if (f.tags?.length) {
+      const tags = f.tags;
+      results = results.filter((r) =>
+        tags.every((tag) =>
+          (r.associations ?? []).some((a) => a.kind === 'tag' && a.label === tag),
+        ),
+      );
+    }
+    if (f.hasAttachment) {
+      results = results.filter((r) =>
+        (r.associations ?? []).some((a) => a.kind === 'attachment' && a.label === f.hasAttachment),
+      );
     }
     if (f.attachmentFileId) {
       results = results.filter((r) =>
         (r.associations ?? []).some(
           (a) => a.kind === 'attachment' && a.fileId === f.attachmentFileId,
         ),
+      );
+    }
+    if (f.relatedTo) {
+      const { recordId, label } = f.relatedTo;
+      results = results.filter((r) =>
+        (r.associations ?? []).some(
+          (a) =>
+            a.kind === 'relationship' && a.recordId === recordId && (!label || a.label === label),
+        ),
+      );
+    }
+    if (f.content) {
+      const entries = Object.entries(f.content);
+      results = results.filter((r) =>
+        entries.every(([key, value]) => (r.content as Record<string, unknown>)[key] === value),
       );
     }
 
@@ -126,9 +165,7 @@ export class MemoryAdapter implements StackAdapter {
   async dissociate(id: string, association: Association) {
     const record = this.records.get(id);
     if (!record) throw new Error(`Not found: ${id}`);
-    const assocs = (record.associations ?? []).filter(
-      (a) => !(a.kind === association.kind && a.label === association.label),
-    );
+    const assocs = (record.associations ?? []).filter((a) => !associationEqual(a, association));
     this.records.set(id, this.bump({ ...record, associations: assocs }));
   }
 
@@ -192,4 +229,16 @@ export class MemoryAdapter implements StackAdapter {
 
   flush?: () => Promise<void>;
   close?: () => Promise<void>;
+}
+
+/**
+ * Mirrors Stack's private associationEqual(): identity is (kind, label) plus
+ * fileId for attachments / recordId for relationships — mimeType is not
+ * part of an attachment association's identity.
+ */
+function associationEqual(a: Association, b: Association): boolean {
+  if (a.kind !== b.kind || a.label !== b.label) return false;
+  if (a.kind === 'attachment' && b.kind === 'attachment') return a.fileId === b.fileId;
+  if (a.kind === 'relationship' && b.kind === 'relationship') return a.recordId === b.recordId;
+  return true;
 }

--- a/packages/core/tests/scoped-stack.test.ts
+++ b/packages/core/tests/scoped-stack.test.ts
@@ -581,6 +581,23 @@ describe('ScopedStack — grant-based read', () => {
     const record = await stack.create(COMMENT_V2, { text: 'hello', edited: false });
     expect((await stack.asEntity(MEMBER).get(record.id))?.id).toBe(record.id);
   });
+
+  // #50: the grant prefetch used to take a single unbounded query() page,
+  // so a grant past MemoryAdapter's 50-record default page went unseen —
+  // a legitimate grant silently stopped working with no error.
+  test('a grant beyond the first page (>50 _grant records) is still honored', async () => {
+    for (let i = 0; i < 55; i++) {
+      await stack.grant(STRANGER, [
+        { actions: ['read-any'], typeId: `com.example.test/filler${i}@1` },
+      ]);
+    }
+    await stack.grant(MEMBER, [{ actions: ['read-any'], typeId: COMMENT }]);
+    const record = await stack.create(COMMENT, { text: 'hello' });
+
+    expect((await stack.asEntity(MEMBER).get(record.id))?.id).toBe(record.id);
+    const result = await stack.asEntity(MEMBER).query({ filter: { typeId: COMMENT } });
+    expect(result.records.map((r) => r.id)).toContain(record.id);
+  });
 });
 
 // -------------------------------------------------------
@@ -785,5 +802,68 @@ describe('ScopedStack.putAttachmentBytes', () => {
     const result = await stack.query({ filter: { typeId: '_attachment@1', entityId: MEMBER } });
     expect(result.records).toHaveLength(1);
     expect(result.records[0].content).toMatchObject({ fileId, mimeType: 'image/png' });
+  });
+});
+
+// -------------------------------------------------------
+// ScopedStack.getAttachment — owner, referencing-record, and uploader access
+// -------------------------------------------------------
+
+describe('ScopedStack.getAttachment', () => {
+  test('owner can always download', async () => {
+    const bytes = await stack.asEntity(OWNER).getAttachment('any-file-id');
+    expect(bytes).toBeInstanceOf(Uint8Array);
+  });
+
+  test('requester who can read a record referencing the file can download', async () => {
+    await stack.grant(MEMBER, [{ actions: ['read-any'], typeId: NOTE }]);
+    const record = await stack.create(NOTE, { text: 'has attachment' });
+    await stack.associate(record.id, {
+      kind: 'attachment',
+      label: 'cover',
+      fileId: 'file-referenced',
+      mimeType: 'image/png',
+    });
+
+    const bytes = await stack.asEntity(MEMBER).getAttachment('file-referenced');
+    expect(bytes).toBeInstanceOf(Uint8Array);
+  });
+
+  test('uploader can download their own upload before it is associated with any record', async () => {
+    await stack.create(
+      '_attachment@1',
+      { fileId: 'file-mine', mimeType: 'image/png', size: 1 },
+      { entityId: MEMBER },
+    );
+
+    const bytes = await stack.asEntity(MEMBER).getAttachment('file-mine');
+    expect(bytes).toBeInstanceOf(Uint8Array);
+  });
+
+  test('requester with no relation to the file is denied', async () => {
+    await expect(stack.asEntity(STRANGER).getAttachment('file-nobody')).rejects.toThrow(
+      StackPermissionError,
+    );
+  });
+
+  // #50: on adapters without contentFieldQuery, the uploader check used
+  // limit: 1 even though matching happens in memory — it could only ever
+  // see one of the requester's uploads, false-denying every other one.
+  // MemoryAdapter returns records in insertion order with no sort applied,
+  // so under the old code this second upload was never even considered.
+  test('uploader can access an upload that is not their first (#50 regression)', async () => {
+    await stack.create(
+      '_attachment@1',
+      { fileId: 'file-first', mimeType: 'image/png', size: 1 },
+      { entityId: MEMBER },
+    );
+    await stack.create(
+      '_attachment@1',
+      { fileId: 'file-second', mimeType: 'image/png', size: 1 },
+      { entityId: MEMBER },
+    );
+
+    const bytes = await stack.asEntity(MEMBER).getAttachment('file-second');
+    expect(bytes).toBeInstanceOf(Uint8Array);
   });
 });

--- a/packages/core/tests/stack.test.ts
+++ b/packages/core/tests/stack.test.ts
@@ -1124,6 +1124,34 @@ describe('deleteAttachment', () => {
     );
   });
 
+  // #50: the fallback's metadata scan used to take a single unbounded
+  // query() page, so on adapters without contentFieldQuery — where matching
+  // happens in memory — metadata beyond page one was never found, leaving
+  // it orphaned once the bytes were deleted.
+  test('leaves no orphaned metadata when the matching record is beyond the first page (>50 records)', async () => {
+    const targetFileId = 'target-file-abc';
+    for (let i = 0; i < 55; i++) {
+      await stack.create('_attachment@1', {
+        fileId: `filler-${i}`,
+        mimeType: 'image/png',
+        size: 1,
+      });
+    }
+    const target = await stack.create('_attachment@1', {
+      fileId: targetFileId,
+      mimeType: 'image/png',
+      size: 1,
+    });
+
+    await stack.deleteAttachment(targetFileId);
+
+    expect(await stack.get(target.id)).toBeNull();
+    const remaining = await stack.query({ filter: { typeId: '_attachment@1' }, limit: 1000 });
+    expect(
+      remaining.records.some((r) => (r.content as Record<string, unknown>).fileId === targetFileId),
+    ).toBe(false);
+  });
+
   test('prefers the adapter atomic path over the fallback when the adapter implements it', async () => {
     const calls: string[] = [];
     class AtomicAdapter extends MemoryAdapter {


### PR DESCRIPTION
## Summary

`query()` always paginates — an absent `limit` returns one adapter-default page, never every match — but several internal call sites in `packages/core/src/stack.ts` assumed a single call was exhaustive:

- **`ScopedStack.query()`'s grant prefetch** and **`hasGrant()`'s non-prefetched path**: only the first page of `_grant@1` records was ever considered, so a grant past page one was silently invisible — legitimate access denied with no error.
- **`Stack.deleteAttachment()`'s fallback metadata scan**: on adapters without `contentFieldQuery`, only the first page of `_attachment@1` records was scanned, so metadata beyond page one survived bytes deletion — an orphan.
- **`ScopedStack.getAttachment()`'s uploader check**: hardcoded `limit: 1` even on the in-memory-matching path, so it could only ever see one of the requester's uploads. This one didn't need 50+ records to misfire — it false-denies with as few as **two** uploads.

## Changes

- Added `queryAllPages()` — a cursor-walking helper (throws `StackQueryError` rather than silently truncating past a generous safety cap) — and applied it at the three sites above. Left `migrateAll()`'s existing cursor walk as-is: it interleaves per-page mutation with fetching (already-migrated records naturally drop out of the filter as it goes), so "collect everything first" doesn't fit its access pattern.
- Kept the `contentFieldQuery` fast path everywhere it applies (a narrowed query already terminates in one page) — the full scan only runs on adapters without that capability.
- Brought `MemoryAdapter` (core's test double) up to real filter parity — `content`, `tags`, `hasAttachment`, `relatedTo`, `appId`, date ranges, and payload-aware `dissociate()` — mirroring `sqlite-shared`'s `buildWhereClause`, so permission-logic tests exercise real predicates instead of an adapter that quietly ignored most filters.
- Named the "`query()` always paginates" rule in `docs/spec.md` §Queries — it was previously unstated, which is how the ambiguity crept in.

## Test plan

- [x] Added regression tests: a grant beyond the first page (>50 `_grant` records) is still honored; `deleteAttachment()` leaves no orphaned metadata when the match is beyond the first page (>50 records); a new `ScopedStack.getAttachment` test suite (previously uncovered) including the n=2 uploader-access regression.
- [x] Verified each new test fails against the pre-fix code (temporarily reverted the `stack.ts` fix and confirmed all three failed with the expected symptoms) and passes with it restored.
- [x] `pnpm -r build`
- [x] `pnpm -r typecheck`
- [x] `pnpm -r lint`
- [x] `pnpm -r test` (all packages green)
- [x] `pnpm format:check`


---
_Generated by [Claude Code](https://claude.ai/code/session_015DCRTSfYzrV9uFzeXKx1oc)_