### PR TITLE
Add file-ref field kind so content-held file references are real references

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -185,7 +185,8 @@ type ScalarFieldKind =
   | 'boolean'
   | 'date'
   | 'text' // Long-form string (e.g. markdown body)
-  | 'record-ref'; // Reference to another record by ID
+  | 'record-ref' // Reference to another record by ID
+  | 'file-ref'; // Reference to an attachment file ID (SHA-256 hex)
 
 type FieldDef =
   | { kind: ScalarFieldKind; required?: boolean }
@@ -210,6 +211,8 @@ type StackType = {
 
 **Array and object fields** are schema-validated on write but opaque to the query engine in v1 — only top-level scalar fields support exact-match content filtering in queries.
 
+**`file-ref` fields are real references, not just strings that look like fileIds.** A `file-ref` value must be a well-formed fileId (SHA-256 hex) — validated at write time, though referential existence is not (the same stance as `record-ref`; upload-before-associate flows make strictness hostile). What `file-ref` buys over a plain `string` field holding the same value: the [`attachmentFileId` query filter](#queries), [`deleteAttachment()`'s reference check](#attachments), and attachment-access conveyance under `ScopedStack` all treat a top-level `file-ref` field as a real reference to the file, the same way an `attachment` Association is. An app that stores a fileId in a plain `string` field keeps working, but gets **none** of that — no delete protection, no access conveyance, no garbage-collection protection. Only top-level scalar `file-ref` fields are indexed this way (matching the content-filtering limit above); a `file-ref` nested in an array or object is validated but not indexed as a reference.
+
 **Type identity:** Two Types are the same if their `id` matches (including version). Two stacks running the same app will have the same Type IDs and can rely on that for interop.
 
 **Schema drift detection:** If two Records share a `typeId` but their Type definitions have different `schemaHash` values, that is unambiguously a bug — intentional changes always produce a new version number.
@@ -218,14 +221,15 @@ type StackType = {
 
 A field's kind is read-compatible with a required kind per this table (row = required kind, columns = candidate kinds accepted):
 
-| required →   | `string` | `text` | `number` | `boolean` | `date` | `record-ref` |
-| ------------ | -------- | ------ | -------- | --------- | ------ | ------------ |
-| `string`     | ✓        | ✓      |          |           |        |              |
-| `text`       | ✓        | ✓      |          |           |        |              |
-| `number`     |          |        | ✓        |           |        |              |
-| `boolean`    |          |        |          | ✓         |        |              |
-| `date`       |          |        |          |           | ✓      |              |
-| `record-ref` |          |        |          |           |        | ✓            |
+| required →   | `string` | `text` | `number` | `boolean` | `date` | `record-ref` | `file-ref` |
+| ------------ | -------- | ------ | -------- | --------- | ------ | ------------ | ---------- |
+| `string`     | ✓        | ✓      |          |           |        |              |            |
+| `text`       | ✓        | ✓      |          |           |        |              |            |
+| `number`     |          |        | ✓        |           |        |              |            |
+| `boolean`    |          |        |          | ✓         |        |              |            |
+| `date`       |          |        |          |           | ✓      |              |            |
+| `record-ref` |          |        |          |           |        | ✓            |            |
+| `file-ref`   |          |        |          |           |        |              | ✓          |
 
 `string` and `text` are mutually read-compatible — both are strings at the value level, and the distinction is presentation/indexing intent. Every other kind requires an exact match; notably `date` is not compatible with `string`, since `date` carries a parse/validity guarantee a plain string doesn't.
 
@@ -570,7 +574,7 @@ const meta = results.records[0]?.content as AttachmentContent | undefined;
 - `Stack.getAttachment(fileId)` — no permission check; always succeeds if the bytes exist.
 - `ScopedStack.getAttachment(fileId)` — accessible if the requester is the owner, can read any record that references the file, or uploaded the file themselves and it hasn't been associated with a record yet. Throws `StackPermissionError` otherwise.
 
-- `Stack.deleteAttachment(fileId)` — deletes bytes and all `_attachment@1` metadata records for the file. Throws `StackConflictError` if any record still references the file. Throws `StackNotFoundError` if the file doesn't exist.
+- `Stack.deleteAttachment(fileId)` — deletes bytes and all `_attachment@1` metadata records for the file. Throws `StackConflictError` if any record still references the file — either via an `attachment` Association or via a top-level `file-ref` content field (see [Types](#types)). Throws `StackNotFoundError` if the file doesn't exist.
 - `ScopedStack.deleteAttachment(fileId)` — owner only. Throws `StackPermissionError` for non-owners. Delegates to `Stack.deleteAttachment()`.
 
 **Atomicity of the reference check.** The reference check and the metadata-record deletes must happen as one unit — otherwise a concurrent `associate()` can add a new reference in the gap between them, leaving a dangling association after the delete completes. Adapters MAY implement `StackRecordAdapter.deleteUnreferencedAttachmentRecords(fileId, metadataTypeId)` to close this race (`Stack.deleteAttachment()` uses it when present, falling back to a non-atomic check-then-act sequence otherwise). Byte deletion always happens after the metadata step commits: a crash in between leaves orphaned bytes, which is harmless and later reclaimed by garbage collection, rather than a dangling reference, which is not.
@@ -600,7 +604,7 @@ type Filter = {
   tags?: string[]; // records that have ALL of these tags
   hasAttachment?: string; // records with an attachment of this label
   relatedTo?: { recordId: string; label?: string };
-  attachmentFileId?: string; // records that reference a specific attachment file ID
+  attachmentFileId?: string; // records that reference a specific attachment file ID, via an `attachment` Association or a top-level `file-ref` content field
 
   // Content fields (exact match on top-level keys)
   content?: { [key: string]: unknown };

--- a/packages/core/src/schema.ts
+++ b/packages/core/src/schema.ts
@@ -87,6 +87,7 @@ const READ_COMPATIBLE: Record<ScalarFieldKind, ScalarFieldKind[]> = {
   boolean: ['boolean'],
   date: ['date'],
   'record-ref': ['record-ref'],
+  'file-ref': ['file-ref'],
 };
 
 // Candidate schemas can come from another app's Type definition (the

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -56,6 +56,21 @@ export class MemoryAdapter implements StackAdapter {
     return { ...record, version: record.version + 1, updatedAt: new Date() };
   }
 
+  /**
+   * True if any top-level file-ref field in the record's registered type
+   * schema currently holds this fileId — the content-reference half of
+   * attachmentFileId matching (see #63). Mirrors sqlite-shared's file_refs
+   * index, computed on the fly since MemoryAdapter has no persisted index.
+   */
+  private hasFileRefTo(record: StackRecord, fileId: string): boolean {
+    const schema = this.types.get(record.typeId)?.schema;
+    if (!schema) return false;
+    const content = record.content as Record<string, unknown>;
+    return Object.entries(schema).some(
+      ([field, def]) => def.kind === 'file-ref' && content[field] === fileId,
+    );
+  }
+
   async patchContent(id: string, patch: Record<string, unknown | null>) {
     const existing = this.records.get(id);
     if (!existing) throw new Error(`Not found: ${id}`);
@@ -124,10 +139,11 @@ export class MemoryAdapter implements StackAdapter {
       );
     }
     if (f.attachmentFileId) {
-      results = results.filter((r) =>
-        (r.associations ?? []).some(
-          (a) => a.kind === 'attachment' && a.fileId === f.attachmentFileId,
-        ),
+      const fileId = f.attachmentFileId;
+      results = results.filter(
+        (r) =>
+          (r.associations ?? []).some((a) => a.kind === 'attachment' && a.fileId === fileId) ||
+          this.hasFileRefTo(r, fileId),
       );
     }
     if (f.relatedTo) {
@@ -219,8 +235,12 @@ export class MemoryAdapter implements StackAdapter {
     return [...this.types.values()];
   }
 
-  async putAttachment(_data: Uint8Array): Promise<string> {
-    return 'file-123';
+  /** Content-addressed, like the real adapters — needed so file-ref values (SHA-256 hex) validate. */
+  async putAttachment(data: Uint8Array): Promise<string> {
+    const hashBuffer = await crypto.subtle.digest('SHA-256', data as BufferSource);
+    return Array.from(new Uint8Array(hashBuffer))
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
   }
   async getAttachment(_fileId: string): Promise<Uint8Array> {
     return new Uint8Array();

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -108,7 +108,8 @@ export type ScalarFieldKind =
   | 'boolean'
   | 'date'
   | 'text' // Long-form string (e.g. markdown body)
-  | 'record-ref'; // Reference to another record by ID
+  | 'record-ref' // Reference to another record by ID
+  | 'file-ref'; // Reference to an attachment file ID (SHA-256 hex) — indexed, unlike a plain `string` fileId
 
 export type ScalarFieldDef = {
   kind: ScalarFieldKind;

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -12,6 +12,9 @@ import type { TypeSchema, FieldDef, ScalarFieldKind } from './types.js';
 
 const MAX_VALIDATION_DEPTH = 32;
 
+/** fileId format: SHA-256 hex, lowercase — matches blob-adapter-disk's assertFileId(). */
+const FILE_ID_RE = /^[0-9a-f]{64}$/;
+
 // -------------------------------------------------------
 // Validation errors
 // -------------------------------------------------------
@@ -30,6 +33,7 @@ const jsTypeForScalar = (kind: ScalarFieldKind): string => {
     case 'string':
     case 'text':
     case 'record-ref':
+    case 'file-ref':
       return 'string';
     case 'number':
       return 'number';
@@ -79,6 +83,16 @@ const validateField = (
       errors.push({
         path,
         message: `Expected ISO 8601 date string, got ${typeof value}`,
+      });
+    }
+    return;
+  }
+
+  if (def.kind === 'file-ref') {
+    if (typeof value !== 'string' || !FILE_ID_RE.test(value)) {
+      errors.push({
+        path,
+        message: 'Expected a 64-character lowercase hex fileId (SHA-256)',
       });
     }
     return;

--- a/packages/core/tests/schema.test.ts
+++ b/packages/core/tests/schema.test.ts
@@ -186,6 +186,24 @@ describe('isCompatible', () => {
     expect(isCompatible(candidate, required)).toBe(false);
   });
 
+  test('file-ref candidate satisfies a required file-ref field', () => {
+    const candidate: TypeSchema = { fileId: { kind: 'file-ref', required: true } };
+    const required: TypeSchema = { fileId: { kind: 'file-ref', required: true } };
+    expect(isCompatible(candidate, required)).toBe(true);
+  });
+
+  test('string candidate does not satisfy a required file-ref field', () => {
+    const candidate: TypeSchema = { fileId: { kind: 'string', required: true } };
+    const required: TypeSchema = { fileId: { kind: 'file-ref', required: true } };
+    expect(isCompatible(candidate, required)).toBe(false);
+  });
+
+  test('file-ref candidate does not satisfy a required string field', () => {
+    const candidate: TypeSchema = { fileId: { kind: 'file-ref', required: true } };
+    const required: TypeSchema = { fileId: { kind: 'string', required: true } };
+    expect(isCompatible(candidate, required)).toBe(false);
+  });
+
   test('nested required object property mismatch is not compatible', () => {
     const candidate: TypeSchema = {
       author: {

--- a/packages/core/tests/scoped-stack.test.ts
+++ b/packages/core/tests/scoped-stack.test.ts
@@ -867,3 +867,36 @@ describe('ScopedStack.getAttachment', () => {
     expect(bytes).toBeInstanceOf(Uint8Array);
   });
 });
+
+// -------------------------------------------------------
+// ScopedStack.getAttachment — file-ref content fields convey access (#63)
+// -------------------------------------------------------
+
+describe('ScopedStack.getAttachment — file-ref content fields', () => {
+  const PHOTO_NOTE = 'com.example.test/photo-note@1';
+  const PHOTO_NOTE_PLAIN = 'com.example.test/photo-note-plain@1';
+  const FILE_ID = 'b'.repeat(64);
+
+  test('requester who can read a record with a file-ref field referencing the file can download', async () => {
+    await stack.defineType(PHOTO_NOTE, 'Photo note', {
+      coverFileId: { kind: 'file-ref', required: true },
+    });
+    await stack.grant(MEMBER, [{ actions: ['read-any'], typeId: PHOTO_NOTE }]);
+    await stack.create(PHOTO_NOTE, { coverFileId: FILE_ID });
+
+    const bytes = await stack.asEntity(MEMBER).getAttachment(FILE_ID);
+    expect(bytes).toBeInstanceOf(Uint8Array);
+  });
+
+  test('a plain string field holding the same-looking fileId conveys no access', async () => {
+    await stack.defineType(PHOTO_NOTE_PLAIN, 'Photo note (plain)', {
+      coverFileId: { kind: 'string', required: true },
+    });
+    await stack.grant(MEMBER, [{ actions: ['read-any'], typeId: PHOTO_NOTE_PLAIN }]);
+    await stack.create(PHOTO_NOTE_PLAIN, { coverFileId: FILE_ID });
+
+    await expect(stack.asEntity(MEMBER).getAttachment(FILE_ID)).rejects.toThrow(
+      StackPermissionError,
+    );
+  });
+});

--- a/packages/core/tests/stack.test.ts
+++ b/packages/core/tests/stack.test.ts
@@ -1152,6 +1152,34 @@ describe('deleteAttachment', () => {
     ).toBe(false);
   });
 
+  // #63: a fileId held in a file-ref content field is a real reference —
+  // deleteAttachment()'s 409 check must see it, not just attachment associations.
+  test('throws StackConflictError when only a file-ref content field references the file (fallback path)', async () => {
+    const attachmentTypeId = 'com.example.test/photo-note@1';
+    await stack.defineType(attachmentTypeId, 'Photo note', {
+      coverFileId: { kind: 'file-ref', required: true },
+    });
+
+    const data = new Uint8Array([1, 2, 3]);
+    const fileId = await stack.putAttachment(data, 'image/png');
+    await stack.create(attachmentTypeId, { coverFileId: fileId });
+
+    await expect(stack.deleteAttachment(fileId)).rejects.toThrow(StackConflictError);
+  });
+
+  test('a plain string field holding a fileId conveys no delete protection', async () => {
+    const attachmentTypeId = 'com.example.test/photo-note-plain@1';
+    await stack.defineType(attachmentTypeId, 'Photo note (plain)', {
+      coverFileId: { kind: 'string', required: true },
+    });
+
+    const data = new Uint8Array([1, 2, 3]);
+    const fileId = await stack.putAttachment(data, 'image/png');
+    await stack.create(attachmentTypeId, { coverFileId: fileId });
+
+    await expect(stack.deleteAttachment(fileId)).resolves.toBeUndefined();
+  });
+
   test('prefers the adapter atomic path over the fallback when the adapter implements it', async () => {
     const calls: string[] = [];
     class AtomicAdapter extends MemoryAdapter {

--- a/packages/core/tests/validate.test.ts
+++ b/packages/core/tests/validate.test.ts
@@ -68,6 +68,33 @@ describe('scalar field validation', () => {
     expect(errorsFor({ parentId: 'abc123' }, schema)).toEqual([]);
   });
 
+  const FILE_ID = 'a'.repeat(64);
+
+  test('file-ref field accepts a well-formed SHA-256 hex fileId', () => {
+    const schema: TypeSchema = { fileId: { kind: 'file-ref', required: true } };
+    expect(errorsFor({ fileId: FILE_ID }, schema)).toEqual([]);
+  });
+
+  test('file-ref field rejects a string of the wrong length', () => {
+    const schema: TypeSchema = { fileId: { kind: 'file-ref', required: true } };
+    expect(paths({ fileId: 'abc123' }, schema)).toContain('fileId');
+  });
+
+  test('file-ref field rejects uppercase hex', () => {
+    const schema: TypeSchema = { fileId: { kind: 'file-ref', required: true } };
+    expect(paths({ fileId: FILE_ID.toUpperCase() }, schema)).toContain('fileId');
+  });
+
+  test('file-ref field rejects non-hex characters', () => {
+    const schema: TypeSchema = { fileId: { kind: 'file-ref', required: true } };
+    expect(paths({ fileId: 'g'.repeat(64) }, schema)).toContain('fileId');
+  });
+
+  test('file-ref field rejects a number', () => {
+    const schema: TypeSchema = { fileId: { kind: 'file-ref', required: true } };
+    expect(paths({ fileId: 12345 }, schema)).toContain('fileId');
+  });
+
   test('date field accepts ISO 8601 string', () => {
     const schema: TypeSchema = { dueAt: { kind: 'date', required: true } };
     expect(errorsFor({ dueAt: '2024-01-15T14:30:00Z' }, schema)).toEqual([]);

--- a/packages/record-adapter-sqlite/tests/record.test.ts
+++ b/packages/record-adapter-sqlite/tests/record.test.ts
@@ -530,6 +530,100 @@ describe('records — queries', () => {
 });
 
 // -------------------------------------------------------
+// file-ref indexing (#63)
+// -------------------------------------------------------
+
+describe('file-ref indexing', () => {
+  const FILE_REF_TYPE = {
+    id: 'com.example.test/photo-note@1',
+    baseId: 'com.example.test/photo-note',
+    version: 1,
+    name: 'Photo note',
+    schema: { coverFileId: { kind: 'file-ref' as const, required: true } },
+    schemaHash: 'abc123',
+    createdAt: new Date(),
+  };
+
+  const STRING_TYPE = {
+    id: 'com.example.test/photo-note-plain@1',
+    baseId: 'com.example.test/photo-note-plain',
+    version: 1,
+    name: 'Photo note (plain)',
+    schema: { coverFileId: { kind: 'string' as const, required: true } },
+    schemaHash: 'def456',
+    createdAt: new Date(),
+  };
+
+  test('attachmentFileId filter matches a record via a top-level file-ref field', async () => {
+    const adapter = await initAdapter();
+    await adapter.saveType(FILE_REF_TYPE);
+    await adapter.createRecord(
+      makeRecord({ id: 'r1', typeId: FILE_REF_TYPE.id, content: { coverFileId: 'file-1' } }),
+    );
+
+    const result = await adapter.queryRecords({ filter: { attachmentFileId: 'file-1' } });
+    expect(result.records.map((r) => r.id)).toEqual(['r1']);
+  });
+
+  test('attachmentFileId filter does not match a plain string field holding the same value', async () => {
+    const adapter = await initAdapter();
+    await adapter.saveType(STRING_TYPE);
+    await adapter.createRecord(
+      makeRecord({ id: 'r1', typeId: STRING_TYPE.id, content: { coverFileId: 'file-1' } }),
+    );
+
+    const result = await adapter.queryRecords({ filter: { attachmentFileId: 'file-1' } });
+    expect(result.records).toEqual([]);
+  });
+
+  test('patchContent that changes the file-ref value updates the index', async () => {
+    const adapter = await initAdapter();
+    await adapter.saveType(FILE_REF_TYPE);
+    const record = makeRecord({
+      id: 'r1',
+      typeId: FILE_REF_TYPE.id,
+      content: { coverFileId: 'file-1' },
+    });
+    await adapter.createRecord(record);
+    await adapter.patchContent('r1', { coverFileId: 'file-2' });
+
+    const oldMatch = await adapter.queryRecords({ filter: { attachmentFileId: 'file-1' } });
+    expect(oldMatch.records).toEqual([]);
+    const newMatch = await adapter.queryRecords({ filter: { attachmentFileId: 'file-2' } });
+    expect(newMatch.records.map((r) => r.id)).toEqual(['r1']);
+  });
+
+  test('hard delete removes the record from file-ref matching', async () => {
+    const adapter = await initAdapter();
+    await adapter.saveType(FILE_REF_TYPE);
+    await adapter.createRecord(
+      makeRecord({ id: 'r1', typeId: FILE_REF_TYPE.id, content: { coverFileId: 'file-1' } }),
+    );
+    await adapter.deleteRecord('r1', { hard: true });
+
+    const result = await adapter.queryRecords({ filter: { attachmentFileId: 'file-1' } });
+    expect(result.records).toEqual([]);
+  });
+
+  test('deleteUnreferencedAttachmentRecords is blocked by a content-held file-ref field', async () => {
+    const adapter = await initAdapter();
+    const ATTACHMENT_TYPE = 'com.example.test/_attachment@1';
+    await adapter.saveType(FILE_REF_TYPE);
+    await adapter.createRecord(
+      makeRecord({ id: 'meta1', typeId: ATTACHMENT_TYPE, content: { fileId: 'file-1' } }),
+    );
+    await adapter.createRecord(
+      makeRecord({ id: 'r1', typeId: FILE_REF_TYPE.id, content: { coverFileId: 'file-1' } }),
+    );
+
+    await expect(
+      adapter.deleteUnreferencedAttachmentRecords('file-1', ATTACHMENT_TYPE),
+    ).rejects.toThrow(StackConflictError);
+    expect(await adapter.getRecord('meta1')).not.toBeNull();
+  });
+});
+
+// -------------------------------------------------------
 // Associations
 // -------------------------------------------------------
 

--- a/packages/record-adapter-sqlite/tests/record.test.ts
+++ b/packages/record-adapter-sqlite/tests/record.test.ts
@@ -621,6 +621,42 @@ describe('file-ref indexing', () => {
     ).rejects.toThrow(StackConflictError);
     expect(await adapter.getRecord('meta1')).not.toBeNull();
   });
+
+  // File-ref field names are cached per typeId (keyed off saveType()) so that
+  // syncFileRefs() doesn't re-query and re-parse the schema on every write —
+  // this guards against that cache going stale if a type is redefined.
+  test('redefining a type via saveType updates which fields are treated as file-ref', async () => {
+    const adapter = await initAdapter();
+    await adapter.saveType(FILE_REF_TYPE);
+    await adapter.createRecord(
+      makeRecord({ id: 'r1', typeId: FILE_REF_TYPE.id, content: { coverFileId: 'file-1' } }),
+    );
+    let result = await adapter.queryRecords({ filter: { attachmentFileId: 'file-1' } });
+    expect(result.records.map((r) => r.id)).toEqual(['r1']);
+
+    // Redefine the same typeId so coverFileId is no longer a file-ref field.
+    await adapter.saveType({ ...FILE_REF_TYPE, schema: STRING_TYPE.schema });
+    await adapter.patchContent('r1', { coverFileId: 'file-1' });
+
+    result = await adapter.queryRecords({ filter: { attachmentFileId: 'file-1' } });
+    expect(result.records).toEqual([]);
+  });
+
+  // A cold adapter has an empty in-memory cache even though the `types`
+  // table already has the schema on disk — the lazy-fill fallback in
+  // getFileRefFields() must still find it.
+  test('indexes file-ref fields for a type saved before this adapter instance existed', async () => {
+    const first = await initAdapter();
+    await first.saveType(FILE_REF_TYPE);
+
+    const reopened = await NativeSQLiteRecordAdapter.open({ path: dbPath });
+    await reopened.createRecord(
+      makeRecord({ id: 'r1', typeId: FILE_REF_TYPE.id, content: { coverFileId: 'file-1' } }),
+    );
+
+    const result = await reopened.queryRecords({ filter: { attachmentFileId: 'file-1' } });
+    expect(result.records.map((r) => r.id)).toEqual(['r1']);
+  });
 });
 
 // -------------------------------------------------------

--- a/packages/record-adapter-sqljs/tests/record.test.ts
+++ b/packages/record-adapter-sqljs/tests/record.test.ts
@@ -606,6 +606,100 @@ describe('records — queries', () => {
 });
 
 // -------------------------------------------------------
+// file-ref indexing (#63)
+// -------------------------------------------------------
+
+describe('file-ref indexing', () => {
+  const FILE_REF_TYPE = {
+    id: 'com.example.test/photo-note@1',
+    baseId: 'com.example.test/photo-note',
+    version: 1,
+    name: 'Photo note',
+    schema: { coverFileId: { kind: 'file-ref' as const, required: true } },
+    schemaHash: 'abc123',
+    createdAt: new Date(),
+  };
+
+  const STRING_TYPE = {
+    id: 'com.example.test/photo-note-plain@1',
+    baseId: 'com.example.test/photo-note-plain',
+    version: 1,
+    name: 'Photo note (plain)',
+    schema: { coverFileId: { kind: 'string' as const, required: true } },
+    schemaHash: 'def456',
+    createdAt: new Date(),
+  };
+
+  test('attachmentFileId filter matches a record via a top-level file-ref field', async () => {
+    const adapter = await initAdapter();
+    await adapter.saveType(FILE_REF_TYPE);
+    await adapter.createRecord(
+      makeRecord({ id: 'r1', typeId: FILE_REF_TYPE.id, content: { coverFileId: 'file-1' } }),
+    );
+
+    const result = await adapter.queryRecords({ filter: { attachmentFileId: 'file-1' } });
+    expect(result.records.map((r) => r.id)).toEqual(['r1']);
+  });
+
+  test('attachmentFileId filter does not match a plain string field holding the same value', async () => {
+    const adapter = await initAdapter();
+    await adapter.saveType(STRING_TYPE);
+    await adapter.createRecord(
+      makeRecord({ id: 'r1', typeId: STRING_TYPE.id, content: { coverFileId: 'file-1' } }),
+    );
+
+    const result = await adapter.queryRecords({ filter: { attachmentFileId: 'file-1' } });
+    expect(result.records).toEqual([]);
+  });
+
+  test('patchContent that changes the file-ref value updates the index', async () => {
+    const adapter = await initAdapter();
+    await adapter.saveType(FILE_REF_TYPE);
+    const record = makeRecord({
+      id: 'r1',
+      typeId: FILE_REF_TYPE.id,
+      content: { coverFileId: 'file-1' },
+    });
+    await adapter.createRecord(record);
+    await adapter.patchContent('r1', { coverFileId: 'file-2' });
+
+    const oldMatch = await adapter.queryRecords({ filter: { attachmentFileId: 'file-1' } });
+    expect(oldMatch.records).toEqual([]);
+    const newMatch = await adapter.queryRecords({ filter: { attachmentFileId: 'file-2' } });
+    expect(newMatch.records.map((r) => r.id)).toEqual(['r1']);
+  });
+
+  test('hard delete removes the record from file-ref matching', async () => {
+    const adapter = await initAdapter();
+    await adapter.saveType(FILE_REF_TYPE);
+    await adapter.createRecord(
+      makeRecord({ id: 'r1', typeId: FILE_REF_TYPE.id, content: { coverFileId: 'file-1' } }),
+    );
+    await adapter.deleteRecord('r1', { hard: true });
+
+    const result = await adapter.queryRecords({ filter: { attachmentFileId: 'file-1' } });
+    expect(result.records).toEqual([]);
+  });
+
+  test('deleteUnreferencedAttachmentRecords is blocked by a content-held file-ref field', async () => {
+    const adapter = await initAdapter();
+    const ATTACHMENT_TYPE = 'com.example.test/_attachment@1';
+    await adapter.saveType(FILE_REF_TYPE);
+    await adapter.createRecord(
+      makeRecord({ id: 'meta1', typeId: ATTACHMENT_TYPE, content: { fileId: 'file-1' } }),
+    );
+    await adapter.createRecord(
+      makeRecord({ id: 'r1', typeId: FILE_REF_TYPE.id, content: { coverFileId: 'file-1' } }),
+    );
+
+    await expect(
+      adapter.deleteUnreferencedAttachmentRecords('file-1', ATTACHMENT_TYPE),
+    ).rejects.toThrow(StackConflictError);
+    expect(await adapter.getRecord('meta1')).not.toBeNull();
+  });
+});
+
+// -------------------------------------------------------
 // Associations
 // -------------------------------------------------------
 

--- a/packages/record-adapter-sqljs/tests/record.test.ts
+++ b/packages/record-adapter-sqljs/tests/record.test.ts
@@ -697,6 +697,43 @@ describe('file-ref indexing', () => {
     ).rejects.toThrow(StackConflictError);
     expect(await adapter.getRecord('meta1')).not.toBeNull();
   });
+
+  // File-ref field names are cached per typeId (keyed off saveType()) so that
+  // syncFileRefs() doesn't re-query and re-parse the schema on every write —
+  // this guards against that cache going stale if a type is redefined.
+  test('redefining a type via saveType updates which fields are treated as file-ref', async () => {
+    const adapter = await initAdapter();
+    await adapter.saveType(FILE_REF_TYPE);
+    await adapter.createRecord(
+      makeRecord({ id: 'r1', typeId: FILE_REF_TYPE.id, content: { coverFileId: 'file-1' } }),
+    );
+    let result = await adapter.queryRecords({ filter: { attachmentFileId: 'file-1' } });
+    expect(result.records.map((r) => r.id)).toEqual(['r1']);
+
+    // Redefine the same typeId so coverFileId is no longer a file-ref field.
+    await adapter.saveType({ ...FILE_REF_TYPE, schema: STRING_TYPE.schema });
+    await adapter.patchContent('r1', { coverFileId: 'file-1' });
+
+    result = await adapter.queryRecords({ filter: { attachmentFileId: 'file-1' } });
+    expect(result.records).toEqual([]);
+  });
+
+  // A cold adapter (opened from persisted bytes) has an empty in-memory
+  // cache even though the `types` table already has the schema on disk —
+  // the lazy-fill fallback in getFileRefFields() must still find it.
+  test('indexes file-ref fields for a type saved before this adapter instance existed', async () => {
+    const { persist, calls } = capturingPersist();
+    const first = await initAdapter({ persist });
+    await first.saveType(FILE_REF_TYPE);
+
+    const reopened = await SQLiteRecordAdapter.open({ bytes: calls[calls.length - 1] });
+    await reopened.createRecord(
+      makeRecord({ id: 'r1', typeId: FILE_REF_TYPE.id, content: { coverFileId: 'file-1' } }),
+    );
+
+    const result = await reopened.queryRecords({ filter: { attachmentFileId: 'file-1' } });
+    expect(result.records.map((r) => r.id)).toEqual(['r1']);
+  });
 });
 
 // -------------------------------------------------------

--- a/packages/sqlite-shared/src/query.ts
+++ b/packages/sqlite-shared/src/query.ts
@@ -89,12 +89,14 @@ export const buildWhereClause = (
     params.push(f.hasAttachment);
   }
 
-  // Attachment file ID filter — find records that reference a specific file
+  // Attachment file ID filter — find records that reference a specific file,
+  // either via an attachment association or a top-level file-ref content field
   if (f.attachmentFileId) {
     conditions.push(
-      `EXISTS (SELECT 1 FROM associations a WHERE a.record_id = r.id AND a.kind = 'attachment' AND a.file_id = ?)`,
+      `(EXISTS (SELECT 1 FROM associations a WHERE a.record_id = r.id AND a.kind = 'attachment' AND a.file_id = ?)
+        OR EXISTS (SELECT 1 FROM file_refs fr WHERE fr.record_id = r.id AND fr.file_id = ?))`,
     );
-    params.push(f.attachmentFileId);
+    params.push(f.attachmentFileId, f.attachmentFileId);
   }
 
   // Relationship filter

--- a/packages/sqlite-shared/src/record-logic.ts
+++ b/packages/sqlite-shared/src/record-logic.ts
@@ -44,7 +44,21 @@ export type SharedSqlRecordLogicDeps = {
   onWrite?: () => void | Promise<void>;
 };
 
+/** Top-level field names in `schema` whose kind is 'file-ref'. */
+const fileRefFieldNames = (schema: Record<string, { kind?: string }>): string[] =>
+  Object.keys(schema).filter((field) => schema[field].kind === 'file-ref');
+
 export class SharedSqlRecordLogic {
+  /**
+   * Per-typeId cache of file-ref field names, so syncFileRefs() doesn't hit
+   * the `types` table and re-parse its schema JSON on every single write —
+   * most types have no file-ref fields, and this makes that the common case
+   * cost one lookup ever, not one per write. Populated eagerly in saveType()
+   * and lazily (via getFileRefFields) for types saved before this cache
+   * existed in the process, e.g. right after open().
+   */
+  private readonly fileRefFieldsByType = new Map<string, string[]>();
+
   constructor(private readonly deps: SharedSqlRecordLogicDeps) {}
 
   private get exec(): SqlExecutor {
@@ -335,6 +349,10 @@ export class SharedSqlRecordLogic {
         toMs(type.createdAt),
       ],
     );
+    this.fileRefFieldsByType.set(
+      type.id,
+      fileRefFieldNames(type.schema as Record<string, { kind?: string }>),
+    );
     await this.write();
   }
 
@@ -427,23 +445,39 @@ export class SharedSqlRecordLogic {
   }
 
   /**
+   * File-ref field names for typeId, from the in-memory cache — falling
+   * back to a `types` lookup (and populating the cache) only for a typeId
+   * this process hasn't seen via saveType() yet, e.g. right after open().
+   */
+  private getFileRefFields(typeId: string): string[] {
+    const cached = this.fileRefFieldsByType.get(typeId);
+    if (cached) return cached;
+
+    const typeRow = this.exec.get<{ schema: string }>('SELECT schema FROM types WHERE id = ?', [
+      typeId,
+    ]);
+    const fields = typeRow
+      ? fileRefFieldNames(JSON.parse(typeRow.schema) as Record<string, { kind?: string }>)
+      : [];
+    this.fileRefFieldsByType.set(typeId, fields);
+    return fields;
+  }
+
+  /**
    * Replace a record's file_refs rows with whatever its content currently
    * holds in top-level file-ref fields, per its type's schema. Called on
    * every write that can change content or typeId, so the index never
    * drifts from what's actually stored. Only top-level scalars are
    * indexed — same limit as content-field query filtering generally.
+   * The vast majority of types have no file-ref fields at all, so the
+   * schema lookup is cached (see fileRefFieldsByType) — only the cheap,
+   * indexed delete runs unconditionally on every write.
    */
   private syncFileRefs(recordId: string, typeId: string, content: Record<string, unknown>): void {
     this.exec.run('DELETE FROM file_refs WHERE record_id = ?', [recordId]);
 
-    const typeRow = this.exec.get<{ schema: string }>('SELECT schema FROM types WHERE id = ?', [
-      typeId,
-    ]);
-    if (!typeRow) return;
-
-    const schema = JSON.parse(typeRow.schema) as Record<string, { kind?: string }>;
-    for (const [field, def] of Object.entries(schema)) {
-      if (def.kind !== 'file-ref') continue;
+    const fields = this.getFileRefFields(typeId);
+    for (const field of fields) {
       const value = content[field];
       if (typeof value === 'string') {
         this.exec.run(

--- a/packages/sqlite-shared/src/record-logic.ts
+++ b/packages/sqlite-shared/src/record-logic.ts
@@ -89,6 +89,7 @@ export class SharedSqlRecordLogic {
     }
 
     this.fts.insert(this.exec, record.id, JSON.stringify(record.content));
+    this.syncFileRefs(record.id, record.typeId, record.content);
     await this.write();
     return record;
   }
@@ -111,6 +112,7 @@ export class SharedSqlRecordLogic {
       [JSON.stringify(merged), toMs(new Date()), id],
     );
     this.fts.insert(this.exec, id, JSON.stringify(merged));
+    this.syncFileRefs(id, existing.typeId, merged);
     await this.write();
 
     const updated = await this.getRecord(id);
@@ -130,11 +132,12 @@ export class SharedSqlRecordLogic {
     await this.write();
   }
 
-  /** Deletes a record's FTS entry, associations, versions, and row. No write() call — callers batch it. */
+  /** Deletes a record's FTS entry, associations, versions, file-refs, and row. No write() call — callers batch it. */
   private hardDeleteRecord(id: string): void {
     this.fts.remove(this.exec, id);
     this.exec.run('DELETE FROM associations WHERE record_id = ?', [id]);
     this.exec.run('DELETE FROM versions WHERE record_id = ?', [id]);
+    this.exec.run('DELETE FROM file_refs WHERE record_id = ?', [id]);
     this.exec.run('DELETE FROM records WHERE id = ?', [id]);
   }
 
@@ -172,6 +175,7 @@ export class SharedSqlRecordLogic {
       if (target.associations.length) this.insertAssociations(id, target.associations);
     }
     this.fts.insert(this.exec, id, JSON.stringify(target.content));
+    this.syncFileRefs(id, target.typeId, target.content);
     await this.write();
 
     const updated = await this.getRecord(id);
@@ -190,6 +194,7 @@ export class SharedSqlRecordLogic {
       [toTypeId, JSON.stringify(content), toMs(new Date()), id],
     );
     this.fts.insert(this.exec, id, JSON.stringify(content));
+    this.syncFileRefs(id, toTypeId, content);
     await this.write();
 
     const updated = await this.getRecord(id);
@@ -243,8 +248,11 @@ export class SharedSqlRecordLogic {
     this.exec.exec('BEGIN');
     try {
       const referenced = this.exec.all<{ found: number }>(
-        `SELECT 1 as found FROM associations WHERE kind = 'attachment' AND file_id = ? LIMIT 1`,
-        [fileId],
+        `SELECT 1 as found FROM associations WHERE kind = 'attachment' AND file_id = ?
+         UNION ALL
+         SELECT 1 FROM file_refs WHERE file_id = ?
+         LIMIT 1`,
+        [fileId, fileId],
       );
       if (referenced.length) {
         throw new StackConflictError('Attachment is still referenced by one or more records');
@@ -416,5 +424,33 @@ export class SharedSqlRecordLogic {
       [recordId],
     );
     return rows.map(rowToAssociation);
+  }
+
+  /**
+   * Replace a record's file_refs rows with whatever its content currently
+   * holds in top-level file-ref fields, per its type's schema. Called on
+   * every write that can change content or typeId, so the index never
+   * drifts from what's actually stored. Only top-level scalars are
+   * indexed — same limit as content-field query filtering generally.
+   */
+  private syncFileRefs(recordId: string, typeId: string, content: Record<string, unknown>): void {
+    this.exec.run('DELETE FROM file_refs WHERE record_id = ?', [recordId]);
+
+    const typeRow = this.exec.get<{ schema: string }>('SELECT schema FROM types WHERE id = ?', [
+      typeId,
+    ]);
+    if (!typeRow) return;
+
+    const schema = JSON.parse(typeRow.schema) as Record<string, { kind?: string }>;
+    for (const [field, def] of Object.entries(schema)) {
+      if (def.kind !== 'file-ref') continue;
+      const value = content[field];
+      if (typeof value === 'string') {
+        this.exec.run(
+          'INSERT OR IGNORE INTO file_refs (record_id, field, file_id) VALUES (?, ?, ?)',
+          [recordId, field, value],
+        );
+      }
+    }
   }
 }

--- a/packages/sqlite-shared/src/schema.ts
+++ b/packages/sqlite-shared/src/schema.ts
@@ -54,6 +54,17 @@ export const RECORD_SCHEMA_SQL = `
     created_at    INTEGER NOT NULL
   ) STRICT;
 
+  -- One row per top-level file-ref content field on a record, kept in sync
+  -- on every content/typeId write. Lets the attachmentFileId query filter
+  -- and deleteAttachment()'s reference check see content-held file
+  -- references, not just attachment associations (see #63).
+  CREATE TABLE IF NOT EXISTS file_refs (
+    record_id TEXT NOT NULL REFERENCES records(id),
+    field     TEXT NOT NULL,
+    file_id   TEXT NOT NULL,
+    PRIMARY KEY (record_id, field)
+  ) STRICT;
+
   -- Indexes
   CREATE INDEX IF NOT EXISTS idx_records_type_id    ON records(type_id);
   CREATE INDEX IF NOT EXISTS idx_records_parent_id  ON records(parent_id);
@@ -66,6 +77,7 @@ export const RECORD_SCHEMA_SQL = `
   CREATE INDEX IF NOT EXISTS idx_assoc_kind_label   ON associations(kind, label);
   CREATE INDEX IF NOT EXISTS idx_assoc_kind_file_id ON associations(kind, file_id);
   CREATE INDEX IF NOT EXISTS idx_types_base_id      ON types(base_id);
+  CREATE INDEX IF NOT EXISTS idx_file_refs_file_id  ON file_refs(file_id);
 `;
 
 /**


### PR DESCRIPTION
## Summary

Closes #63.

The spec's attachment-delete contract promises a `409 Conflict` when a record's *content* references a fileId, not just when an `attachment` Association does — but there was no way to distinguish "content that references a file" from "content that happens to contain 64 hex characters." This adds `file-ref` as a scalar field kind to close that gap:

- `FieldDef` gains `kind: 'file-ref'` (`packages/core/src/types.ts`). Values must be well-formed fileIds (SHA-256 hex) — validated at write time, referential existence is not (same stance as `record-ref`).
- `isCompatible()` treats `file-ref` as exact-match only.
- Top-level `file-ref` content fields are now indexed the same way `attachment` Associations are: the `attachmentFileId` query filter, `deleteAttachment()`'s reference check (including the atomic `deleteUnreferencedAttachmentRecords` path), and `ScopedStack` attachment-access conveyance all now see a fileId held in a `file-ref` field.
- SQLite-backed adapters (`sqlite-shared`) track this via a new `file_refs` index table, kept in sync on every write that can change content or typeId (`createRecord`, `patchContent`, `restoreVersion`, `commitMigration`), and cleaned up on hard delete.
- `MemoryAdapter` computes the same match at query time against the record's registered type schema (no persisted index needed for the in-memory test double).
- A fileId stored in a plain `string` field continues to work but gets **none** of this — no delete protection, no access conveyance, no future GC protection. Documented explicitly in `docs/spec.md`.

Scoped to **top-level scalar** `file-ref` fields only, matching the existing limitation that only top-level scalars support exact-match content filtering in queries.

## Test plan

- [x] `packages/core/tests/validate.test.ts` — file-ref format validation (accepts well-formed SHA-256 hex, rejects wrong length/case/non-hex/non-string)
- [x] `packages/core/tests/schema.test.ts` — file-ref is exact-match-only in `isCompatible()`
- [x] `packages/core/tests/stack.test.ts` — `deleteAttachment()` blocked by a content-held `file-ref` field; unaffected by a plain `string` field with the same value
- [x] `packages/core/tests/scoped-stack.test.ts` — attachment access conveyed by a readable record's `file-ref` field; not conveyed by an equivalent `string` field
- [x] `packages/record-adapter-sqlite/tests/record.test.ts` and `packages/record-adapter-sqljs/tests/record.test.ts` — `file_refs` index population/query matching, updates on `patchContent`, cleanup on hard delete, and the atomic delete-block path
- [x] Full monorepo build, typecheck, lint, and test suite (611 tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014HAN9dvg8sP3a1yqeAo2fG)_