### PR TITLE
Add attachment garbage collection sweep

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -33,7 +33,7 @@ stack.timezone; // from adapter.timezone
 
 `LocalAdapter.initialize()` fails if the file already exists. `LocalAdapter.open()` fails if the file does not exist. This makes the distinction explicit and prevents silent config divergence.
 
-Plugin and extension code that doesn't need to know the underlying backend should accept `StackClient` rather than the concrete `Stack` or `ScopedStack`. `StackClient` is the passable interface covering the full record API (`create`, `get`, `query`, `update`, `delete`, `undelete`, `associate`, `dissociate`, `setPermissions`, `getVersions`, `getVersion`, `restoreVersion`, `getAttachment`, `putAttachment`, `deleteAttachment`) plus a `features` getter. Both `Stack` and `ScopedStack` implement it.
+Plugin and extension code that doesn't need to know the underlying backend should accept `StackClient` rather than the concrete `Stack` or `ScopedStack`. `StackClient` is the passable interface covering the full record API (`create`, `get`, `query`, `update`, `delete`, `undelete`, `associate`, `dissociate`, `setPermissions`, `getVersions`, `getVersion`, `restoreVersion`, `getAttachment`, `putAttachment`, `deleteAttachment`, `collectAttachmentGarbage`) plus a `features` getter. Both `Stack` and `ScopedStack` implement it.
 
 **Stack identity** (`ownerEntityId`, `timezone`) is stored as a singleton `_config@1` record in the records table. Adapters expose these values as typed readonly properties (`adapter.ownerEntityId`, `adapter.timezone`) rather than as a generic key/value store.
 
@@ -473,11 +473,13 @@ The adapter contract is split into two focused interfaces that are composed into
 
 **`StackRecordAdapter`** — structured storage: capabilities, stack identity (`ownerEntityId`, `timezone`), all record/association/version/type methods, and optional lifecycle hooks (`flush`, `close`).
 
-**`StackBlobAdapter`** — binary storage: `putAttachment`, `getAttachment`, `deleteAttachment`, and optional lifecycle hooks.
+**`StackBlobAdapter`** — binary storage: `putAttachment`, `getAttachment`, `deleteAttachment`, an optional `listFiles()` capability, and optional lifecycle hooks.
 
 ```ts
 type StackAdapter = StackRecordAdapter & StackBlobAdapter;
 ```
+
+**Optional capabilities**, present on some adapters and not others, follow one pattern throughout: an optional interface method, checked for truthiness at the call site, with a described fallback when absent. `StackRecordAdapter.deleteUnreferencedAttachmentRecords()` (atomic reference check, [Attachments](#attachments)) and `StackBlobAdapter.listFiles()` (blob enumeration, used by [`collectAttachmentGarbage()`](#garbage-collection) to find bare-bytes orphans) are both this shape — no boolean flag in `capabilities`, just an optional method a caller checks for before using. `combineAdapters()` (below) preserves this: it forwards an optional method only when the underlying part actually implements it, never as a wrapper around a missing one.
 
 ### Package naming convention
 
@@ -574,12 +576,38 @@ const meta = results.records[0]?.content as AttachmentContent | undefined;
 - `Stack.getAttachment(fileId)` — no permission check; always succeeds if the bytes exist.
 - `ScopedStack.getAttachment(fileId)` — accessible if the requester is the owner, can read any record that references the file, or uploaded the file themselves and it hasn't been associated with a record yet. Throws `StackPermissionError` otherwise.
 
-- `Stack.deleteAttachment(fileId)` — deletes bytes and all `_attachment@1` metadata records for the file. Throws `StackConflictError` if any record still references the file — either via an `attachment` Association or via a top-level `file-ref` content field (see [Types](#types)). Throws `StackNotFoundError` if the file doesn't exist.
+- `Stack.deleteAttachment(fileId)` — deletes bytes and all `_attachment@1` metadata records for the file (including soft-deleted ones). Throws `StackConflictError` if any record — **live or soft-deleted** — still references the file, either via an `attachment` Association or via a top-level `file-ref` content field (see [Types](#types)). A soft-deleted record is recoverable via `undelete()` (see [Deletion](#deletion)) and must find its attachments intact, so it counts as a reference exactly like a live one. Throws `StackNotFoundError` if the file doesn't exist.
 - `ScopedStack.deleteAttachment(fileId)` — owner only. Throws `StackPermissionError` for non-owners. Delegates to `Stack.deleteAttachment()`.
 
 **Atomicity of the reference check.** The reference check and the metadata-record deletes must happen as one unit — otherwise a concurrent `associate()` can add a new reference in the gap between them, leaving a dangling association after the delete completes. Adapters MAY implement `StackRecordAdapter.deleteUnreferencedAttachmentRecords(fileId, metadataTypeId)` to close this race (`Stack.deleteAttachment()` uses it when present, falling back to a non-atomic check-then-act sequence otherwise). Byte deletion always happens after the metadata step commits: a crash in between leaves orphaned bytes, which is harmless and later reclaimed by garbage collection, rather than a dangling reference, which is not.
 
 **Deduplication:** Bytes are deduplicated — uploading the same content twice stores the binary only once. However, each call to `putAttachment()` creates a new `_attachment@1` record with its own `mimeType` and `filename`. The same `fileId` may have multiple `_attachment@1` records from separate uploads.
+
+### Garbage collection
+
+Attachment bytes are only ever removed by an explicit `deleteAttachment(fileId)` call — normal app flows delete _records_, and nothing notices when the last record referencing a file goes away. `collectAttachmentGarbage()` is an explicit, owner-invoked sweep that finds and removes those orphans. It is **not** automatic reference-counting: auto-delete on last dissociate/record-delete would coupling every record write to blob lifecycle and would race without a transactional adapter.
+
+```ts
+stack.collectAttachmentGarbage(opts?: {
+  graceMs?: number; // default: 24 hours
+  dryRun?: boolean; // default: false
+}): Promise<{ deleted: string[]; reclaimedBytes: number }>
+```
+
+**What counts as garbage:** a file is collectable only when _no_ record — live or soft-deleted — references it via an `attachment` Association or a `file-ref` content field. This is the same reference definition `deleteAttachment()` uses (above), and the same recoverability principle: nothing reachable from a soft-deleted (undelete-able) state gets destroyed.
+
+**`_attachment@1` metadata records never themselves count as references** — otherwise nothing would ever be garbage — but a file's _newest_ metadata record (or, for bare bytes with no metadata record at all, the blob's own storage timestamp) must be older than `graceMs` to be collected. This protects the legitimate upload-then-associate window: a file just uploaded and not yet attached to anything is not yet garbage, just new.
+
+**Bare-bytes orphans** — bytes stored by `putAttachmentBytes()`/`putAttachment()` with no `_attachment@1` record at all (e.g. a crash between storing bytes and writing metadata) — are only discoverable by enumerating the blob store directly, via the optional `StackBlobAdapter.listFiles()` capability (see [Adapters](#adapters)). An adapter that doesn't implement it still gets full protection for the common case (metadata-tracked files with no remaining reference); it simply can't find this rarer orphan class.
+
+Deletion goes through `deleteAttachment()` itself, so its usual conflict check runs once more per file at delete time. A file that turns out to be referenced again (or already gone) by then is skipped, not treated as a sweep failure — the sweep always completes and reports what it actually collected.
+
+`dryRun: true` computes and returns what _would_ be deleted, without deleting anything — useful for previewing a sweep before running it for real.
+
+**`Stack` vs `ScopedStack`:**
+
+- `Stack.collectAttachmentGarbage(opts?)` — owner-level, no permission check.
+- `ScopedStack.collectAttachmentGarbage(opts?)` — owner only. Throws `StackPermissionError` for non-owners (including anonymous requesters). Delegates to `Stack.collectAttachmentGarbage()`.
 
 ---
 

--- a/packages/adapter-local/src/index.ts
+++ b/packages/adapter-local/src/index.ts
@@ -27,6 +27,7 @@ import type {
   AdapterCapabilities,
   RecordId,
   FileId,
+  BlobFileInfo,
   TokenInfo,
 } from '@haverstack/core';
 import {
@@ -242,6 +243,11 @@ export class LocalAdapter implements StackAdapter {
 
   async deleteAttachment(fileId: FileId): Promise<void> {
     return this.blob.deleteAttachment(fileId);
+  }
+
+  /** DiskBlobAdapter always implements this — LocalAdapter always constructs one. */
+  async listFiles(): Promise<BlobFileInfo[]> {
+    return this.blob.listFiles!();
   }
 
   // -------------------------------------------------------

--- a/packages/adapter-local/tests/local.test.ts
+++ b/packages/adapter-local/tests/local.test.ts
@@ -128,6 +128,18 @@ describe('attachments', () => {
     await adapter.deleteAttachment(fileId);
     await expect(adapter.getAttachment(fileId)).rejects.toThrow();
   });
+
+  test('listFiles reports stored blobs with size and modifiedAt', async () => {
+    const adapter = await initAdapter();
+    const fileId = await adapter.putAttachment(Buffer.from('hello attachment'));
+
+    const files = await adapter.listFiles();
+
+    expect(files).toHaveLength(1);
+    expect(files[0].fileId).toBe(fileId);
+    expect(files[0].size).toBe(Buffer.from('hello attachment').byteLength);
+    expect(files[0].modifiedAt).toBeInstanceOf(Date);
+  });
 });
 
 // -------------------------------------------------------

--- a/packages/blob-adapter-disk/src/index.ts
+++ b/packages/blob-adapter-disk/src/index.ts
@@ -9,9 +9,9 @@
 
 import { createHash } from 'node:crypto';
 import { mkdirSync, existsSync } from 'fs';
-import { readFile, writeFile, unlink } from 'fs/promises';
+import { readFile, writeFile, unlink, readdir, stat } from 'fs/promises';
 import { join } from 'path';
-import type { StackBlobAdapter, FileId } from '@haverstack/core';
+import type { StackBlobAdapter, BlobFileInfo, FileId } from '@haverstack/core';
 
 const SHA256_HEX_RE = /^[0-9a-f]{64}$/;
 
@@ -47,5 +47,16 @@ export class DiskBlobAdapter implements StackBlobAdapter {
     } catch {
       // Non-fatal — file may already be gone.
     }
+  }
+
+  async listFiles(): Promise<BlobFileInfo[]> {
+    const entries = await readdir(this.dir);
+    const fileIds = entries.filter((name) => SHA256_HEX_RE.test(name));
+    return Promise.all(
+      fileIds.map(async (fileId) => {
+        const stats = await stat(join(this.dir, fileId));
+        return { fileId, size: stats.size, modifiedAt: stats.mtime };
+      }),
+    );
   }
 }

--- a/packages/blob-adapter-disk/tests/blob.test.ts
+++ b/packages/blob-adapter-disk/tests/blob.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, rmSync, existsSync, readdirSync } from 'fs';
+import { mkdirSync, rmSync, existsSync, readdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { DiskBlobAdapter } from '../src/index.js';
@@ -89,5 +89,44 @@ describe('DiskBlobAdapter', () => {
     expect(existsSync(newDir)).toBe(false);
     new DiskBlobAdapter(newDir);
     expect(existsSync(newDir)).toBe(true);
+  });
+
+  describe('listFiles', () => {
+    test('returns an empty array for an empty store', async () => {
+      expect(await adapter.listFiles()).toEqual([]);
+    });
+
+    test('lists every stored blob with fileId and size', async () => {
+      const id1 = await adapter.putAttachment(Buffer.from('hello'));
+      const id2 = await adapter.putAttachment(Buffer.from('a longer blob body'));
+
+      const files = await adapter.listFiles();
+      expect(files.map((f) => f.fileId).sort()).toEqual([id1, id2].sort());
+      expect(files.find((f) => f.fileId === id1)?.size).toBe(Buffer.from('hello').byteLength);
+      expect(files.find((f) => f.fileId === id2)?.size).toBe(
+        Buffer.from('a longer blob body').byteLength,
+      );
+    });
+
+    test('each entry carries a modifiedAt date', async () => {
+      const fileId = await adapter.putAttachment(Buffer.from('timestamped'));
+      const [file] = await adapter.listFiles();
+      expect(file.modifiedAt).toBeInstanceOf(Date);
+      expect(file.fileId).toBe(fileId);
+    });
+
+    test('deleted blobs no longer appear', async () => {
+      const fileId = await adapter.putAttachment(Buffer.from('temporary'));
+      await adapter.deleteAttachment(fileId);
+      expect(await adapter.listFiles()).toEqual([]);
+    });
+
+    test('ignores non-fileId entries in the storage directory', async () => {
+      const fileId = await adapter.putAttachment(Buffer.from('real blob'));
+      writeFileSync(join(testDir, '.DS_Store'), 'stray file');
+
+      const files = await adapter.listFiles();
+      expect(files.map((f) => f.fileId)).toEqual([fileId]);
+    });
   });
 });

--- a/packages/core/src/combine.ts
+++ b/packages/core/src/combine.ts
@@ -43,9 +43,20 @@ export function combineAdapters(parts: {
     getType: (id) => parts.record.getType(id),
     listTypes: () => parts.record.listTypes(),
 
+    // Conditionally spread so an unimplemented optional capability stays
+    // absent on the combined adapter, rather than silently becoming
+    // "supported" via a wrapper that forwards to a missing method.
+    ...(parts.record.deleteUnreferencedAttachmentRecords && {
+      deleteUnreferencedAttachmentRecords: (fileId: string, metadataTypeId: string) =>
+        parts.record.deleteUnreferencedAttachmentRecords!(fileId, metadataTypeId),
+    }),
+
     putAttachment: (data) => parts.blob.putAttachment(data),
     getAttachment: (id) => parts.blob.getAttachment(id),
     deleteAttachment: (id) => parts.blob.deleteAttachment(id),
+    ...(parts.blob.listFiles && {
+      listFiles: () => parts.blob.listFiles!(),
+    }),
 
     async flush() {
       await parts.record.flush?.();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,8 @@ export type {
   StackOptions,
   GetRecordOptions,
   DeleteRecordOptions,
+  CollectAttachmentGarbageOptions,
+  CollectAttachmentGarbageResult,
 } from './stack.js';
 
 // Permissions
@@ -62,6 +64,7 @@ export type {
   StackFeatures,
   StackRecordAdapter,
   StackBlobAdapter,
+  BlobFileInfo,
   StackAdapter,
   StackTokenStore,
   TokenInfo,

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -74,6 +74,22 @@ export type StackOptions = {
   idTimestampSkewMs?: number | null;
 };
 
+export type CollectAttachmentGarbageOptions = {
+  /**
+   * How recent an unreferenced file must be to survive collection, covering
+   * the legitimate upload-then-associate window. Default: 24 hours (see
+   * DEFAULT_GC_GRACE_MS). Pass 0 to collect anything unreferenced right now.
+   */
+  graceMs?: number;
+  /** Compute what would be deleted without deleting anything. Default: false. */
+  dryRun?: boolean;
+};
+
+export type CollectAttachmentGarbageResult = {
+  deleted: string[];
+  reclaimedBytes: number;
+};
+
 export type GetRecordOptions = {
   /**
    * Records are returned exactly as stored by default ("stored"). Pass
@@ -160,6 +176,16 @@ const RESERVED_ID_PREFIX = '_';
 const DEFAULT_ID_TIMESTAMP_SKEW_MS = 24 * 60 * 60 * 1000;
 
 /**
+ * Default grace period for Stack.collectAttachmentGarbage(): how recent an
+ * unreferenced file's newest _attachment@1 metadata record (or, for bare
+ * bytes with none, the blob's own modifiedAt) must be to still protect it
+ * from collection — covering the legitimate upload-then-associate window.
+ * Same value and rationale as DEFAULT_ID_TIMESTAMP_SKEW_MS: a generous
+ * tolerance at personal-stack scale.
+ */
+const DEFAULT_GC_GRACE_MS = 24 * 60 * 60 * 1000;
+
+/**
  * Format and reserved-prefix checks — full-trust context (Stack.create()).
  * Checked before the format check: the Crockford charset already excludes
  * "_", so a reserved-looking id (e.g. "_config") would otherwise just fail
@@ -230,6 +256,9 @@ export interface StackClient {
   putAttachmentBytes(data: Uint8Array): Promise<string>;
   putAttachment(data: Uint8Array, mimeType: string, filename?: string): Promise<string>;
   deleteAttachment(fileId: string): Promise<void>;
+  collectAttachmentGarbage(
+    opts?: CollectAttachmentGarbageOptions,
+  ): Promise<CollectAttachmentGarbageResult>;
 }
 
 // -------------------------------------------------------
@@ -944,7 +973,15 @@ export class Stack implements StackClient {
     fileId: string,
     metadataTypeId: string,
   ): Promise<string[]> {
-    const refResult = await this.query({ filter: { attachmentFileId: fileId }, limit: 1 });
+    // includeDeleted: a soft-deleted record is recoverable via undelete()
+    // (#59/#60), so it still counts as a reference — otherwise deleting the
+    // file now leaves that record's reference dangling the moment it's
+    // undeleted. Matches the atomic adapter path (record-logic.ts), which
+    // never filters on deleted_at at all.
+    const refResult = await this.query({
+      filter: { attachmentFileId: fileId, includeDeleted: true },
+      limit: 1,
+    });
     if (refResult.records.length > 0) {
       throw new StackConflictError('Attachment is still referenced by one or more records');
     }
@@ -952,10 +989,13 @@ export class Stack implements StackClient {
     // Cursor-walked: on adapters without contentFieldQuery, every
     // _attachment@1 record must be scanned in memory below, and a single
     // default page would leave metadata beyond page one un-deleted —
-    // exactly the orphan this method exists to prevent.
+    // exactly the orphan this method exists to prevent. includeDeleted here
+    // too, so a soft-deleted metadata record for this fileId is cleaned up
+    // rather than left behind pointing at bytes that no longer exist.
     const metaResults = await queryAllPages((q) => this.query(q), {
       filter: {
         typeId: metadataTypeId,
+        includeDeleted: true,
         ...(this.features.contentFieldQuery && { content: { fileId } }),
       },
     });
@@ -968,6 +1008,105 @@ export class Stack implements StackClient {
     }
 
     return metaRecords.map((r) => r.id);
+  }
+
+  /**
+   * Sweep for attachment bytes no longer reachable from any record — live
+   * or soft-deleted — and delete them (bytes + _attachment@1 metadata).
+   * "Reachable" is exactly what deleteAttachment()'s own reference check
+   * means: an `attachment` Association or a `file-ref` content field (#63)
+   * on a record in any state, since a soft-deleted record is recoverable
+   * via undelete() and must find its attachments intact (#59/#60).
+   *
+   * _attachment@1 metadata records never themselves count as references
+   * (else nothing would ever be garbage), but a file's newest metadata
+   * record — or, for bare bytes with no metadata at all, the blob's own
+   * modifiedAt — must be older than `graceMs` to be collected. This covers
+   * the legitimate upload-then-associate window.
+   *
+   * Bare-bytes orphans (bytes with zero metadata records, left by a
+   * putAttachment() that stored bytes but crashed before creating the
+   * metadata record) are only discoverable via StackBlobAdapter.listFiles()
+   * — optional, so this sweep simply can't find that orphan class on an
+   * adapter that doesn't implement it.
+   *
+   * Deletion goes through deleteAttachment() itself, so its usual conflict
+   * check runs once more per file at delete time; a file that turns out to
+   * be referenced or already gone by then is skipped, not treated as a
+   * sweep failure.
+   */
+  async collectAttachmentGarbage(
+    opts: CollectAttachmentGarbageOptions = {},
+  ): Promise<CollectAttachmentGarbageResult> {
+    const graceMs = opts.graceMs ?? DEFAULT_GC_GRACE_MS;
+    const dryRun = opts.dryRun ?? false;
+    const now = Date.now();
+
+    const metadataTypeId = `${SYSTEM_TYPES.ATTACHMENT}@1`;
+    const metaRecords = await queryAllPages((q) => this.query(q), {
+      filter: { typeId: metadataTypeId, includeDeleted: true },
+    });
+
+    // Newest metadata record's createdAt per fileId, and its size (constant
+    // across records sharing a fileId, since content-addressing guarantees
+    // identical bytes) — used for the grace check and reclaimedBytes.
+    const metaByFile = new Map<string, { newestAt: number; size: number }>();
+    for (const record of metaRecords) {
+      const content = record.content as AttachmentContent;
+      const createdAt = record.createdAt.getTime();
+      const existing = metaByFile.get(content.fileId);
+      if (!existing || createdAt > existing.newestAt) {
+        metaByFile.set(content.fileId, { newestAt: createdAt, size: content.size });
+      }
+    }
+
+    // Bare-bytes orphans: blobs with zero metadata records, only
+    // discoverable if the blob adapter implements listFiles().
+    const blobByFile = new Map<string, { modifiedAt: number; size: number }>();
+    if (this.adapter.listFiles) {
+      for (const file of await this.adapter.listFiles()) {
+        blobByFile.set(file.fileId, { modifiedAt: file.modifiedAt.getTime(), size: file.size });
+      }
+    }
+
+    const candidateFileIds = new Set([...metaByFile.keys(), ...blobByFile.keys()]);
+
+    const deleted: string[] = [];
+    let reclaimedBytes = 0;
+
+    for (const fileId of candidateFileIds) {
+      const refResult = await this.query({
+        filter: { attachmentFileId: fileId, includeDeleted: true },
+        limit: 1,
+      });
+      if (refResult.records.length > 0) continue;
+
+      const meta = metaByFile.get(fileId);
+      const blob = blobByFile.get(fileId);
+      const newestAt = meta?.newestAt ?? blob?.modifiedAt;
+      if (newestAt !== undefined && now - newestAt < graceMs) continue;
+
+      const size = meta?.size ?? blob?.size ?? 0;
+
+      if (dryRun) {
+        deleted.push(fileId);
+        reclaimedBytes += size;
+        continue;
+      }
+
+      try {
+        await this.deleteAttachment(fileId);
+      } catch (err) {
+        // Raced with a new reference, or another sweep/call already removed
+        // it — not a sweep failure, just move on to the next candidate.
+        if (err instanceof StackConflictError || err instanceof StackNotFoundError) continue;
+        throw err;
+      }
+      deleted.push(fileId);
+      reclaimedBytes += size;
+    }
+
+    return { deleted, reclaimedBytes };
   }
 
   // -------------------------------------------------------
@@ -1473,5 +1612,18 @@ export class ScopedStack implements StackClient {
       throw new StackPermissionError('Only the stack owner can delete attachments');
     }
     return this.stack.deleteAttachment(fileId);
+  }
+
+  /**
+   * Sweep for unreferenced attachment bytes and delete them. Only the stack
+   * owner may run this. Delegates to Stack.collectAttachmentGarbage().
+   */
+  async collectAttachmentGarbage(
+    opts?: CollectAttachmentGarbageOptions,
+  ): Promise<CollectAttachmentGarbageResult> {
+    if (this.requesterEntityId !== this.stack.ownerEntityId) {
+      throw new StackPermissionError('Only the stack owner can collect attachment garbage');
+    }
+    return this.stack.collectAttachmentGarbage(opts);
   }
 }

--- a/packages/core/src/testing.ts
+++ b/packages/core/src/testing.ts
@@ -9,6 +9,7 @@ import type {
   Association,
   Permission,
   AdapterCapabilities,
+  BlobFileInfo,
 } from './types.js';
 import { applyMergePatch } from './merge.js';
 
@@ -33,6 +34,7 @@ export class MemoryAdapter implements StackAdapter {
   readonly order: string[] = [];
   readonly versions = new Map<string, RecordVersion[]>();
   readonly types = new Map<string, StackType>();
+  readonly blobs = new Map<string, { data: Uint8Array; modifiedAt: Date }>();
 
   constructor({
     ownerEntityId = '',
@@ -238,14 +240,34 @@ export class MemoryAdapter implements StackAdapter {
   /** Content-addressed, like the real adapters — needed so file-ref values (SHA-256 hex) validate. */
   async putAttachment(data: Uint8Array): Promise<string> {
     const hashBuffer = await crypto.subtle.digest('SHA-256', data as BufferSource);
-    return Array.from(new Uint8Array(hashBuffer))
+    const fileId = Array.from(new Uint8Array(hashBuffer))
       .map((b) => b.toString(16).padStart(2, '0'))
       .join('');
+    if (!this.blobs.has(fileId)) {
+      this.blobs.set(fileId, { data, modifiedAt: new Date() });
+    }
+    return fileId;
   }
-  async getAttachment(_fileId: string): Promise<Uint8Array> {
-    return new Uint8Array();
+  // Deliberately lenient for fileIds never actually put (returns empty bytes,
+  // not an error) — a lot of existing tests exercise permission logic with
+  // synthetic fileIds that were never uploaded. Subclass and override this
+  // method to test the genuinely-missing-file path (see stack.test.ts).
+  async getAttachment(fileId: string): Promise<Uint8Array> {
+    return this.blobs.get(fileId)?.data ?? new Uint8Array();
   }
-  async deleteAttachment(_fileId: string) {}
+  async deleteAttachment(fileId: string) {
+    this.blobs.delete(fileId);
+  }
+  // Declared as an optional field (not a fixed method) so a test subclass
+  // can override it to `undefined`, simulating an adapter that doesn't
+  // implement this capability (see stack.test.ts's NoListFilesAdapter).
+  listFiles?: () => Promise<BlobFileInfo[]> = async () => {
+    return [...this.blobs.entries()].map(([fileId, blob]) => ({
+      fileId,
+      size: blob.data.byteLength,
+      modifiedAt: blob.modifiedAt,
+    }));
+  };
 
   flush?: () => Promise<void>;
   close?: () => Promise<void>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -425,6 +425,14 @@ export interface StackRecordAdapter {
   close?(): Promise<void>;
 }
 
+/** One stored blob, as reported by StackBlobAdapter.listFiles(). */
+export type BlobFileInfo = {
+  fileId: FileId;
+  size: number;
+  /** When the blob was written. Used to apply a GC grace period to fresh, not-yet-associated uploads. */
+  modifiedAt: Date;
+};
+
 /**
  * The blob-storage half of an adapter. Handles raw binary data only;
  * attachment metadata lives on _attachment@1 records in the record adapter.
@@ -434,6 +442,18 @@ export interface StackBlobAdapter {
   putAttachment(data: Uint8Array): Promise<FileId>;
   getAttachment(fileId: FileId): Promise<Uint8Array>;
   deleteAttachment(fileId: FileId): Promise<void>;
+
+  /**
+   * Enumerate every blob currently in storage. Optional — capability-flagged,
+   * like StackRecordAdapter.deleteUnreferencedAttachmentRecords(). Without it,
+   * Stack.collectAttachmentGarbage() can still collect files that have
+   * _attachment@1 metadata but no live/soft-deleted referencing record; it
+   * just can't find bare-bytes orphans (bytes with zero metadata records at
+   * all, left by a putAttachment() that stored bytes but crashed before
+   * creating the metadata record) — enumerating the store directly is the
+   * only way to find those.
+   */
+  listFiles?(): Promise<BlobFileInfo[]>;
 
   // Lifecycle
   flush?(): Promise<void>;

--- a/packages/core/tests/combine.test.ts
+++ b/packages/core/tests/combine.test.ts
@@ -1,0 +1,197 @@
+import { describe, test, expect } from 'vitest';
+import { combineAdapters } from '../src/combine.js';
+import type {
+  StackRecordAdapter,
+  StackBlobAdapter,
+  AdapterCapabilities,
+  BlobFileInfo,
+  RecordId,
+  FileId,
+  TypeId,
+} from '../src/types.js';
+
+// -------------------------------------------------------
+// Minimal fakes
+// -------------------------------------------------------
+
+const capabilities: AdapterCapabilities = {
+  fullTextSearch: false,
+  contentFieldQuery: false,
+  sortableFields: ['createdAt', 'updatedAt', 'version'],
+};
+
+/** Bare-minimum StackRecordAdapter — only what combineAdapters() touches. */
+function makeRecordAdapter(overrides: Partial<StackRecordAdapter> = {}): StackRecordAdapter {
+  return {
+    capabilities,
+    ownerEntityId: 'owner-123',
+    timezone: 'UTC',
+    createRecord: async (r) => r,
+    getRecord: async () => null,
+    patchContent: async () => {
+      throw new Error('not implemented');
+    },
+    deleteRecord: async () => {},
+    undeleteRecord: async () => {
+      throw new Error('not implemented');
+    },
+    queryRecords: async () => ({ records: [], cursor: null, total: 0 }),
+    associate: async () => {},
+    dissociate: async () => {},
+    setPermissions: async () => {},
+    getVersions: async () => [],
+    getVersion: async () => null,
+    saveVersion: async () => {},
+    restoreVersion: async () => {
+      throw new Error('not implemented');
+    },
+    commitMigration: async () => {
+      throw new Error('not implemented');
+    },
+    saveType: async () => {},
+    getType: async () => null,
+    listTypes: async () => [],
+    ...overrides,
+  };
+}
+
+/** Bare-minimum StackBlobAdapter — only what combineAdapters() touches. */
+function makeBlobAdapter(overrides: Partial<StackBlobAdapter> = {}): StackBlobAdapter {
+  return {
+    putAttachment: async () => 'file-id',
+    getAttachment: async () => new Uint8Array(),
+    deleteAttachment: async () => {},
+    ...overrides,
+  };
+}
+
+describe('combineAdapters', () => {
+  test('forwards ownerEntityId, timezone, and capabilities from the record adapter', () => {
+    const adapter = combineAdapters({
+      record: makeRecordAdapter({ ownerEntityId: 'owner-xyz', timezone: 'Europe/London' }),
+      blob: makeBlobAdapter(),
+    });
+    expect(adapter.ownerEntityId).toBe('owner-xyz');
+    expect(adapter.timezone).toBe('Europe/London');
+    expect(adapter.capabilities).toBe(capabilities);
+  });
+
+  test('forwards basic record and blob operations to their respective parts', async () => {
+    let created: unknown;
+    let putBytes: unknown;
+    const adapter = combineAdapters({
+      record: makeRecordAdapter({
+        createRecord: async (r) => {
+          created = r;
+          return r;
+        },
+      }),
+      blob: makeBlobAdapter({
+        putAttachment: async (data) => {
+          putBytes = data;
+          return 'computed-id';
+        },
+      }),
+    });
+
+    const record = {
+      id: 'r1',
+      typeId: 'note@1' as TypeId,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      content: {},
+      version: 1,
+    };
+    await adapter.createRecord(record);
+    expect(created).toBe(record);
+
+    const bytes = new Uint8Array([1, 2, 3]);
+    const fileId = await adapter.putAttachment(bytes);
+    expect(putBytes).toBe(bytes);
+    expect(fileId).toBe('computed-id');
+  });
+
+  // Optional capabilities must round-trip exactly: present when the
+  // underlying part implements them, absent otherwise. A wrapper that
+  // always defines the key (even forwarding to a missing method) would
+  // make Stack.deleteAttachment()/collectAttachmentGarbage() silently
+  // "detect" a capability that was never actually implemented.
+  describe('optional capability forwarding', () => {
+    test('deleteUnreferencedAttachmentRecords is present when the record adapter implements it', async () => {
+      let calledWith: [FileId, TypeId] | undefined;
+      const adapter = combineAdapters({
+        record: makeRecordAdapter({
+          deleteUnreferencedAttachmentRecords: async (fileId, metadataTypeId) => {
+            calledWith = [fileId, metadataTypeId];
+            return ['meta1'] as RecordId[];
+          },
+        }),
+        blob: makeBlobAdapter(),
+      });
+
+      expect(adapter.deleteUnreferencedAttachmentRecords).toBeDefined();
+      const result = await adapter.deleteUnreferencedAttachmentRecords!('file-1', '_attachment@1');
+      expect(result).toEqual(['meta1']);
+      expect(calledWith).toEqual(['file-1', '_attachment@1']);
+    });
+
+    test('deleteUnreferencedAttachmentRecords is absent when the record adapter does not implement it', () => {
+      const adapter = combineAdapters({
+        record: makeRecordAdapter(),
+        blob: makeBlobAdapter(),
+      });
+      expect(adapter.deleteUnreferencedAttachmentRecords).toBeUndefined();
+    });
+
+    test('listFiles is present when the blob adapter implements it', async () => {
+      const files: BlobFileInfo[] = [{ fileId: 'f1', size: 3, modifiedAt: new Date() }];
+      const adapter = combineAdapters({
+        record: makeRecordAdapter(),
+        blob: makeBlobAdapter({ listFiles: async () => files }),
+      });
+
+      expect(adapter.listFiles).toBeDefined();
+      expect(await adapter.listFiles!()).toBe(files);
+    });
+
+    test('listFiles is absent when the blob adapter does not implement it', () => {
+      const adapter = combineAdapters({
+        record: makeRecordAdapter(),
+        blob: makeBlobAdapter(),
+      });
+      expect(adapter.listFiles).toBeUndefined();
+    });
+  });
+
+  describe('lifecycle', () => {
+    test('flush() calls both parts', async () => {
+      let recordFlushed = false;
+      let blobFlushed = false;
+      const adapter = combineAdapters({
+        record: makeRecordAdapter({ flush: async () => void (recordFlushed = true) }),
+        blob: makeBlobAdapter({ flush: async () => void (blobFlushed = true) }),
+      });
+      await adapter.flush!();
+      expect(recordFlushed).toBe(true);
+      expect(blobFlushed).toBe(true);
+    });
+
+    test('close() calls both parts', async () => {
+      let recordClosed = false;
+      let blobClosed = false;
+      const adapter = combineAdapters({
+        record: makeRecordAdapter({ close: async () => void (recordClosed = true) }),
+        blob: makeBlobAdapter({ close: async () => void (blobClosed = true) }),
+      });
+      await adapter.close!();
+      expect(recordClosed).toBe(true);
+      expect(blobClosed).toBe(true);
+    });
+
+    test('flush() and close() are safe when neither part implements them', async () => {
+      const adapter = combineAdapters({ record: makeRecordAdapter(), blob: makeBlobAdapter() });
+      await expect(adapter.flush!()).resolves.toBeUndefined();
+      await expect(adapter.close!()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/core/tests/scoped-stack.test.ts
+++ b/packages/core/tests/scoped-stack.test.ts
@@ -900,3 +900,29 @@ describe('ScopedStack.getAttachment — file-ref content fields', () => {
     );
   });
 });
+
+// -------------------------------------------------------
+// ScopedStack.collectAttachmentGarbage — owner only (#64)
+// -------------------------------------------------------
+
+describe('ScopedStack.collectAttachmentGarbage', () => {
+  test('owner can run the sweep', async () => {
+    const fileId = await stack.putAttachment(new Uint8Array([1]), 'image/png');
+
+    const result = await stack.asEntity(OWNER).collectAttachmentGarbage({ graceMs: 0 });
+
+    expect(result.deleted).toEqual([fileId]);
+  });
+
+  test('non-owner is denied', async () => {
+    await expect(stack.asEntity(MEMBER).collectAttachmentGarbage({ graceMs: 0 })).rejects.toThrow(
+      StackPermissionError,
+    );
+  });
+
+  test('anonymous requester is denied', async () => {
+    await expect(stack.asEntity(null).collectAttachmentGarbage({ graceMs: 0 })).rejects.toThrow(
+      StackPermissionError,
+    );
+  });
+});

--- a/packages/core/tests/stack.test.ts
+++ b/packages/core/tests/stack.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../src/stack.js';
 import { generateId, crockford32Encode } from '../src/id.js';
 import { MemoryAdapter } from '../src/testing.js';
+import type { BlobFileInfo } from '../src/types.js';
 
 // -------------------------------------------------------
 // Test setup
@@ -1099,6 +1100,36 @@ describe('deleteAttachment', () => {
     await expect(stack.deleteAttachment(fileId)).rejects.toThrow(StackConflictError);
   });
 
+  // #64: a soft-deleted record is recoverable via undelete() — deleting the
+  // file it still references now would leave that reference dangling the
+  // moment the record comes back.
+  test('throws StackConflictError when only a soft-deleted record still references the file', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    const fileId = await stack.putAttachment(data, 'image/png');
+    const note = await stack.create(NOTE_V1, { text: 'hi' });
+    await stack.associate(note.id, {
+      kind: 'attachment',
+      label: 'cover',
+      fileId,
+      mimeType: 'image/png',
+    });
+    await stack.delete(note.id);
+
+    await expect(stack.deleteAttachment(fileId)).rejects.toThrow(StackConflictError);
+  });
+
+  test('hard-deletes a soft-deleted _attachment@1 metadata record too (fallback path)', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    const fileId = await stack.putAttachment(data, 'image/png');
+    const [metaRecord] = (await stack.query({ filter: { typeId: '_attachment@1' } })).records;
+    await stack.delete(metaRecord.id);
+
+    await stack.deleteAttachment(fileId);
+
+    const result = await stack.query({ filter: { typeId: '_attachment@1', includeDeleted: true } });
+    expect(result.records).toHaveLength(0);
+  });
+
   test('deletes the _attachment@1 metadata record when unreferenced (fallback path)', async () => {
     const data = new Uint8Array([1, 2, 3]);
     const fileId = await stack.putAttachment(data, 'image/png');
@@ -1208,5 +1239,176 @@ describe('deleteAttachment', () => {
     await atomicStack.deleteAttachment(fileId);
 
     expect(calls).toEqual(['atomic']);
+  });
+});
+
+// -------------------------------------------------------
+// collectAttachmentGarbage
+// -------------------------------------------------------
+
+describe('collectAttachmentGarbage', () => {
+  test('collects a file whose only referencing record was hard-deleted', async () => {
+    const fileId = await stack.putAttachment(new Uint8Array([1]), 'image/png');
+    const note = await stack.create(NOTE_V1, { text: 'hi' });
+    await stack.associate(note.id, {
+      kind: 'attachment',
+      label: 'cover',
+      fileId,
+      mimeType: 'image/png',
+    });
+    await stack.delete(note.id, { hard: true });
+
+    const result = await stack.collectAttachmentGarbage({ graceMs: 0 });
+
+    expect(result.deleted).toEqual([fileId]);
+    const meta = await stack.query({ filter: { typeId: '_attachment@1', includeDeleted: true } });
+    expect(meta.records).toHaveLength(0);
+  });
+
+  test('does not collect a file referenced by a live record', async () => {
+    const fileId = await stack.putAttachment(new Uint8Array([1]), 'image/png');
+    const note = await stack.create(NOTE_V1, { text: 'hi' });
+    await stack.associate(note.id, {
+      kind: 'attachment',
+      label: 'cover',
+      fileId,
+      mimeType: 'image/png',
+    });
+
+    const result = await stack.collectAttachmentGarbage({ graceMs: 0 });
+
+    expect(result.deleted).toEqual([]);
+  });
+
+  // #64 rule 1: soft-deleted records are recoverable via undelete() (#59/#60)
+  // and must find their attachments intact — so they still count as references.
+  test('does not collect a file referenced only by a soft-deleted record', async () => {
+    const fileId = await stack.putAttachment(new Uint8Array([1]), 'image/png');
+    const note = await stack.create(NOTE_V1, { text: 'hi' });
+    await stack.associate(note.id, {
+      kind: 'attachment',
+      label: 'cover',
+      fileId,
+      mimeType: 'image/png',
+    });
+    await stack.delete(note.id);
+
+    const result = await stack.collectAttachmentGarbage({ graceMs: 0 });
+
+    expect(result.deleted).toEqual([]);
+  });
+
+  // #63: a file-ref content field is a real reference too, same as an
+  // attachment Association.
+  test('does not collect a file referenced only via a file-ref content field', async () => {
+    const photoType = 'com.example.test/photo-note@1';
+    await stack.defineType(photoType, 'Photo note', {
+      coverFileId: { kind: 'file-ref', required: true },
+    });
+    const fileId = await stack.putAttachment(new Uint8Array([1]), 'image/png');
+    await stack.create(photoType, { coverFileId: fileId });
+
+    const result = await stack.collectAttachmentGarbage({ graceMs: 0 });
+
+    expect(result.deleted).toEqual([]);
+  });
+
+  test('default grace period protects a fresh unreferenced upload', async () => {
+    await stack.putAttachment(new Uint8Array([1]), 'image/png');
+
+    const result = await stack.collectAttachmentGarbage();
+
+    expect(result.deleted).toEqual([]);
+    const meta = await stack.query({ filter: { typeId: '_attachment@1' } });
+    expect(meta.records).toHaveLength(1);
+  });
+
+  test('graceMs: 0 collects an unreferenced upload immediately', async () => {
+    const fileId = await stack.putAttachment(new Uint8Array([1]), 'image/png');
+
+    const result = await stack.collectAttachmentGarbage({ graceMs: 0 });
+
+    expect(result.deleted).toEqual([fileId]);
+  });
+
+  test('reports reclaimedBytes summed across deleted files', async () => {
+    const fileId1 = await stack.putAttachment(new Uint8Array([1, 2, 3]), 'image/png');
+    const fileId2 = await stack.putAttachment(new Uint8Array([1, 2, 3, 4, 5]), 'image/png');
+
+    const result = await stack.collectAttachmentGarbage({ graceMs: 0 });
+
+    expect(result.deleted.sort()).toEqual([fileId1, fileId2].sort());
+    expect(result.reclaimedBytes).toBe(8);
+  });
+
+  test('dryRun reports what would be deleted without deleting anything', async () => {
+    const fileId = await stack.putAttachment(new Uint8Array([1, 2, 3]), 'image/png');
+
+    const result = await stack.collectAttachmentGarbage({ graceMs: 0, dryRun: true });
+
+    expect(result.deleted).toEqual([fileId]);
+    expect(result.reclaimedBytes).toBe(3);
+    const meta = await stack.query({ filter: { typeId: '_attachment@1' } });
+    expect(meta.records).toHaveLength(1);
+  });
+
+  // A putAttachmentBytes() upload that never gets a metadata record (e.g. a
+  // crash between storing bytes and creating _attachment@1) is only
+  // discoverable via StackBlobAdapter.listFiles().
+  test('collects a bare-bytes orphan discovered via listFiles()', async () => {
+    const fileId = await stack.putAttachmentBytes(new Uint8Array([9, 9, 9]));
+
+    const result = await stack.collectAttachmentGarbage({ graceMs: 0 });
+
+    expect(result.deleted).toEqual([fileId]);
+    expect(result.reclaimedBytes).toBe(3);
+  });
+
+  test('adapter without listFiles() still collects metadata-tracked orphans', async () => {
+    class NoListFilesAdapter extends MemoryAdapter {
+      override listFiles: (() => Promise<BlobFileInfo[]>) | undefined = undefined;
+    }
+    const noListFilesStack = await Stack.create(
+      new NoListFilesAdapter({ ownerEntityId: 'owner-123', timezone: 'UTC' }),
+    );
+    const fileId = await noListFilesStack.putAttachment(new Uint8Array([1]), 'image/png');
+
+    const result = await noListFilesStack.collectAttachmentGarbage({ graceMs: 0 });
+
+    expect(result.deleted).toEqual([fileId]);
+  });
+
+  test('adapter without listFiles() cannot find bare-bytes orphans', async () => {
+    class NoListFilesAdapter extends MemoryAdapter {
+      override listFiles: (() => Promise<BlobFileInfo[]>) | undefined = undefined;
+    }
+    const noListFilesStack = await Stack.create(
+      new NoListFilesAdapter({ ownerEntityId: 'owner-123', timezone: 'UTC' }),
+    );
+    await noListFilesStack.putAttachmentBytes(new Uint8Array([9, 9, 9]));
+
+    const result = await noListFilesStack.collectAttachmentGarbage({ graceMs: 0 });
+
+    expect(result.deleted).toEqual([]);
+  });
+
+  // A concurrent associate() landing between the sweep's own scan and its
+  // per-file deleteAttachment() call would make that call throw
+  // StackConflictError — the sweep must skip that one file, not abort, and
+  // must keep collecting everything else it already found.
+  test('a file whose delete call races is skipped, not thrown, and the rest of the sweep still completes', async () => {
+    const racedFileId = await stack.putAttachment(new Uint8Array([1]), 'image/png');
+    const okFileId = await stack.putAttachment(new Uint8Array([2, 2]), 'image/png');
+
+    const realDeleteAttachment = stack.deleteAttachment.bind(stack);
+    stack.deleteAttachment = async (fileId: string) => {
+      if (fileId === racedFileId) throw new StackConflictError('simulated race');
+      return realDeleteAttachment(fileId);
+    };
+
+    const result = await stack.collectAttachmentGarbage({ graceMs: 0 });
+
+    expect(result.deleted).toEqual([okFileId]);
+    expect(result.reclaimedBytes).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary

Closes #64.

Attachment bytes were only ever removed by an explicit `deleteAttachment(fileId)` call — normal app flows delete *records*, and nothing noticed when the last record referencing a file went away. This adds an explicit, owner-invoked sweep to find and remove those orphans.

- `Stack.collectAttachmentGarbage(opts?)` / `ScopedStack.collectAttachmentGarbage(opts?)` (owner-only): collects attachment bytes no longer reachable from any record — **live or soft-deleted** — via an `attachment` Association or a `file-ref` content field (#63). A soft-deleted record is recoverable via `undelete()` and must find its attachments intact, so it still counts as a reference.
- `_attachment@1` metadata records never themselves count as references (else nothing would ever be garbage), but a file's newest metadata record — or, for bare bytes with none, the blob's own storage timestamp — must be older than `graceMs` (default 24h) to be collected. This protects the legitimate upload-then-associate window.
- Deletion goes through `deleteAttachment()` itself, so its usual conflict check runs once more per file at delete time; a file that races (referenced again, or already gone) is skipped, not treated as a sweep failure — the sweep always completes and reports what it actually collected.
- `dryRun: true` computes and returns what would be deleted without deleting anything.
- New optional `StackBlobAdapter.listFiles()` capability (same "optional method, checked for truthiness" pattern as `deleteUnreferencedAttachmentRecords`), implemented in `blob-adapter-disk` and `MemoryAdapter`, wired through `LocalAdapter`. This is what finds **bare-bytes orphans** — bytes with zero metadata records at all, left by a `putAttachment()` that stored bytes but crashed before writing metadata — which are otherwise undiscoverable. An adapter without it still gets full protection for the common case.

### Two latent bugs fixed along the way

- `deleteAttachment()`'s non-atomic fallback path didn't pass `includeDeleted` on its reference check or its metadata-cleanup scan, so a soft-deleted (recoverable) record's attachment reference didn't block deletion, and a soft-deleted metadata record was never cleaned up. The atomic adapter path already got this right (it doesn't filter on `deleted_at` at all); the fallback now matches.
- `combineAdapters()` silently dropped optional adapter capabilities (`deleteUnreferencedAttachmentRecords`, and now `listFiles`) instead of forwarding them when the underlying part actually implements them — meaning a record adapter that supports the atomic delete path lost that capability the moment it was composed via `combineAdapters()`.

## Test plan

- [x] `packages/core/tests/stack.test.ts` — `collectAttachmentGarbage`: basic collection, live/soft-deleted/file-ref reference protection, default and explicit grace period, `reclaimedBytes` accounting, `dryRun`, bare-bytes orphan collection via `listFiles()`, graceful behavior when `listFiles()` is absent, and a simulated delete-time race that's skipped without aborting the sweep. Plus regression tests for the two `includeDeleted` fixes.
- [x] `packages/core/tests/scoped-stack.test.ts` — owner-only gating (owner/non-owner/anonymous).
- [x] `packages/core/tests/combine.test.ts` (new) — optional-capability forwarding round-trips exactly (present when implemented, absent when not), plus basic composition and lifecycle behavior.
- [x] `packages/blob-adapter-disk/tests/blob.test.ts` — `listFiles()` enumeration, sizes, timestamps, post-delete removal, ignoring stray non-fileId files.
- [x] `packages/adapter-local/tests/local.test.ts` — `listFiles()` through the real combined adapter.
- [x] Full monorepo build, typecheck, lint, and test suite (627 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014HAN9dvg8sP3a1yqeAo2fG)_