### PR TITLE
fix(core): make _attachment@1 mimeType a property of the fileId (#65)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -168,7 +168,9 @@ type AttachmentContent = {
 };
 ```
 
-An `_attachment@1` record is created each time `stack.putAttachment()` or `scopedStack.putAttachment()` is called — even if the same bytes were previously uploaded. Multiple `_attachment@1` records may therefore exist for the same `fileId`, each with its own `mimeType` and `filename`. The binary is stored only once (content-addressed deduplication), but each upload gets its own metadata record.
+An `_attachment@1` record is created each time `stack.putAttachment()` or `scopedStack.putAttachment()` is called — even if the same bytes were previously uploaded. Multiple `_attachment@1` records may therefore exist for the same `fileId`, each with its own `filename`. The binary is stored only once (content-addressed deduplication), but each upload gets its own metadata record.
+
+`mimeType` is not a per-record perspective the way `filename` is: it's a property of the `fileId` established by the first `_attachment@1` record ever created for it. Later uploads of the same bytes must declare a matching `mimeType` — a conflicting one is rejected with `StackValidationError` (422) — and once a record exists, none of `fileId`, `size`, or `mimeType` can be changed by `update()`; `filename` is the only mutable field. See [Attachments](#attachments) for the full rule and rationale.
 
 When uploaded via `Stack.putAttachment()` (owner-level), the record carries no `entityId`. When uploaded via `ScopedStack.putAttachment()`, the `entityId` is set to the uploading entity.
 
@@ -581,7 +583,11 @@ const meta = results.records[0]?.content as AttachmentContent | undefined;
 
 **Atomicity of the reference check.** The reference check and the metadata-record deletes must happen as one unit — otherwise a concurrent `associate()` can add a new reference in the gap between them, leaving a dangling association after the delete completes. Adapters MAY implement `StackRecordAdapter.deleteUnreferencedAttachmentRecords(fileId, metadataTypeId)` to close this race (`Stack.deleteAttachment()` uses it when present, falling back to a non-atomic check-then-act sequence otherwise). Byte deletion always happens after the metadata step commits: a crash in between leaves orphaned bytes, which is harmless and later reclaimed by garbage collection, rather than a dangling reference, which is not.
 
-**Deduplication:** Bytes are deduplicated — uploading the same content twice stores the binary only once. However, each call to `putAttachment()` creates a new `_attachment@1` record with its own `mimeType` and `filename`. The same `fileId` may have multiple `_attachment@1` records from separate uploads.
+**Deduplication:** Bytes are deduplicated — uploading the same content twice stores the binary only once. However, each call to `putAttachment()` creates a new `_attachment@1` record, so the same `fileId` may have multiple `_attachment@1` records from separate uploads.
+
+**`mimeType` is a property of the `fileId`, not the uploader's perspective.** The first `_attachment@1` record created for a given `fileId` establishes its `mimeType`; this is the value later served as `Content-Type` when no `?contentType`/`?filename` override is given (see Download, below). A later upload of the same bytes is free to declare a matching `mimeType` — it creates its own record with its own `filename` and `entityId`, same as always — but a **conflicting `mimeType` is rejected with `StackValidationError` (422)** rather than stored: a contradictory execution claim (e.g. one uploader's `image/png` against another's `text/html` for byte-identical content) must not survive in the data to confuse the next reader or a downstream cache. `filename` has no such rule — it stays per-uploader, and the requester's own record's `filename` is what's served to them (see Download).
+
+**Once created, an `_attachment@1` record's `fileId`, `size`, and `mimeType` are immutable — `filename` is the only field `update()` may change.** `fileId` and `size` describe the bytes themselves, so any attempted change is rejected (`StackValidationError`, 422). `mimeType`'s value was already pinned to the `fileId`'s established type at create time, so `update()` rejects any patch that touches it at all, including one that restates the same value — there's nothing a legitimate `mimeType` edit could accomplish that isn't already covered by the create-time rule above. To correct a wrongly-declared type, delete the attachment and re-upload: identical bytes hash to the same `fileId`, and the fresh first record establishes the corrected type.
 
 ### Garbage collection
 
@@ -949,7 +955,7 @@ The SDK's `Stack.putAttachment()` and `ScopedStack.putAttachment()` perform both
 GET /attachments/<fileId>?contentType=image/png&filename=photo.png
 ```
 
-When neither parameter is provided the server queries the `_attachment@1` record: the stored `mimeType` becomes `Content-Type`, and the filename is taken from the requester's own `_attachment@1` record (if one exists). Falls back to `Content-Type: application/octet-stream` when no metadata record is found.
+When neither parameter is provided the server queries `_attachment@1` records for the file: the **first-recorded** `mimeType` (see [Attachments](#attachments)) becomes `Content-Type` — deterministic regardless of how many records exist for the `fileId` or which requester is asking, since conflicting `mimeType`s are rejected at write time and can never coexist. The filename is taken from the requester's own `_attachment@1` record (if one exists), falling back to the first record's filename otherwise. Falls back to `Content-Type: application/octet-stream` when no metadata record is found.
 
 **Delete:** Owner only. Returns `409 Conflict` if any record in the stack still references the file (i.e. has it in an `attachment` association or its content references the `fileId`). The bytes and all `_attachment@1` metadata records for the file are removed atomically on success.
 

--- a/packages/conformance-fixtures/src/index.ts
+++ b/packages/conformance-fixtures/src/index.ts
@@ -71,6 +71,34 @@ export const createRecordFixtures: ConformanceFixture<WireRecord, WireRecord>[] 
       version: 1,
     },
   },
+  {
+    name: 'create-attachment-record-matching-mimetype-succeeds',
+    description:
+      '(#65) mimeType is a property of the fileId, established by the first _attachment@1 ' +
+      'record ever created for it. A second upload of the same bytes that declares a matching ' +
+      'mimeType succeeds and gets its own record — its own id, entityId, and filename — rather ' +
+      'than being deduplicated away. Assumes an _attachment@1 record already exists for ' +
+      '"fileId": "abc123..." with "mimeType": "image/png".',
+    method: 'POST',
+    path: '/records',
+    requestBody: {
+      id: 'rec-attachment-2',
+      typeId: '_attachment@1',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      content: { fileId: 'abc123', mimeType: 'image/png', size: 12345, filename: 'second.png' },
+      version: 1,
+    },
+    responseStatus: 200,
+    responseBody: {
+      id: 'rec-attachment-2',
+      typeId: '_attachment@1',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      content: { fileId: 'abc123', mimeType: 'image/png', size: 12345, filename: 'second.png' },
+      version: 1,
+    },
+  },
 ];
 
 // -------------------------------------------------------
@@ -355,6 +383,65 @@ export const errorResponseFixtures: ConformanceFixture<unknown, WireError>[] = [
         code: 'validation',
         message: 'Content validation failed',
         details: [{ path: 'title', message: 'expected string, got number' }],
+      },
+    },
+  },
+  {
+    name: 'error-validation-attachment-mimetype-conflict-on-create',
+    description:
+      '(#65) POST /records creating an _attachment@1 record whose mimeType conflicts with the ' +
+      'mimeType already established (by the first-ever record) for the same fileId returns 422 ' +
+      'with code "validation" — reconstructed as StackValidationError. A matching mimeType ' +
+      'would instead succeed (see create-attachment-record-matching-mimetype-succeeds). Assumes ' +
+      'an _attachment@1 record already exists for "fileId": "abc123..." with ' +
+      '"mimeType": "image/png".',
+    method: 'POST',
+    path: '/records',
+    requestBody: {
+      id: 'rec-attachment-3',
+      typeId: '_attachment@1',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+      content: { fileId: 'abc123', mimeType: 'text/html', size: 12345 },
+      version: 1,
+    },
+    responseStatus: 422,
+    responseBody: {
+      error: {
+        code: 'validation',
+        message: 'Content validation failed',
+        details: [
+          {
+            path: 'mimeType',
+            message:
+              'mimeType "text/html" conflicts with the mimeType "image/png" already ' +
+              'established for fileId "abc123" by an earlier upload',
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: 'error-validation-attachment-mimetype-immutable-on-update',
+    description:
+      '(#65) PATCH /records/:id against an _attachment@1 record is rejected with 422 / code ' +
+      '"validation" if the patch touches mimeType at all — even restating the current value. ' +
+      'filename is the only field an _attachment@1 update may change; fileId and size are ' +
+      'rejected the same way if the patch would actually change their stored value.',
+    method: 'PATCH',
+    path: '/records/rec-attachment-1',
+    requestBody: { mimeType: 'image/jpeg' },
+    responseStatus: 422,
+    responseBody: {
+      error: {
+        code: 'validation',
+        message: 'Content validation failed',
+        details: [
+          {
+            path: 'mimeType',
+            message: 'mimeType is immutable after creation; delete and re-upload to change it',
+          },
+        ],
       },
     },
   },

--- a/packages/core/src/stack.ts
+++ b/packages/core/src/stack.ts
@@ -579,6 +579,10 @@ export class Stack implements StackClient {
       throw new StackValidationError(errors);
     }
 
+    if (typeId === `${SYSTEM_TYPES.ATTACHMENT}@1`) {
+      await this.checkAttachmentMimeTypeOnCreate(content as unknown as AttachmentContent);
+    }
+
     if (opts.id !== undefined) {
       validateRecordId(opts.id);
       if (await this.adapter.getRecord(opts.id)) {
@@ -695,6 +699,14 @@ export class Stack implements StackClient {
     const errors = validateContent(merged, type.schema);
     if (errors.length > 0) {
       throw new StackValidationError(errors);
+    }
+
+    if (existing.typeId === `${SYSTEM_TYPES.ATTACHMENT}@1`) {
+      this.checkAttachmentImmutableFields(
+        content,
+        existing.content as AttachmentContent,
+        merged as AttachmentContent,
+      );
     }
 
     // Snapshot the raw stored state before overwriting
@@ -912,6 +924,85 @@ export class Stack implements StackClient {
   // -------------------------------------------------------
   // Attachments
   // -------------------------------------------------------
+
+  /**
+   * `_attachment@1` invariant (#65): mimeType is a property of the fileId,
+   * not the uploader's perspective — unlike filename, which is. Dedup means
+   * a second upload of identical bytes doesn't create a second file, it
+   * attaches a second execution claim to the first uploader's bytes; the
+   * first metadata record created for a given fileId fixes the type that
+   * gets served, so a later upload declaring a different mimeType is
+   * rejected rather than silently coexisting for the server to arbitrarily
+   * pick between. Cursor-walked (#50): a single unpaginated page could miss
+   * the fileId's earlier records and wrongly treat a conflicting upload as
+   * the first.
+   */
+  private async checkAttachmentMimeTypeOnCreate(content: AttachmentContent): Promise<void> {
+    const { fileId, mimeType } = content;
+    if (typeof fileId !== 'string') return; // schema validation already rejected this
+
+    const metadataTypeId = `${SYSTEM_TYPES.ATTACHMENT}@1`;
+    const results = await queryAllPages((q) => this.query(q), {
+      filter: {
+        typeId: metadataTypeId,
+        includeDeleted: true,
+        ...(this.features.contentFieldQuery && { content: { fileId } }),
+      },
+    });
+    const existing = this.features.contentFieldQuery
+      ? results
+      : results.filter((r) => (r.content as AttachmentContent).fileId === fileId);
+    if (existing.length === 0) return;
+
+    const first = existing.reduce((a, b) => (a.createdAt <= b.createdAt ? a : b));
+    const establishedMimeType = (first.content as AttachmentContent).mimeType;
+    if (mimeType !== establishedMimeType) {
+      throw new StackValidationError([
+        {
+          path: 'mimeType',
+          message:
+            `mimeType "${mimeType}" conflicts with the mimeType "${establishedMimeType}" ` +
+            `already established for fileId "${fileId}" by an earlier upload`,
+        },
+      ]);
+    }
+  }
+
+  /**
+   * `_attachment@1` invariant (#65): filename is the only mutable field
+   * once a metadata record exists. fileId and size describe the bytes
+   * themselves, so any change is rejected. mimeType's value was already
+   * pinned to the fileId's established type at create time (above) — even a
+   * same-value rewrite is refused, since first-recorded-wins leaves nothing
+   * legitimate for a later mimeType edit to do. The correction flow for a
+   * wrongly-declared type is delete + re-upload: identical bytes hash to
+   * the same fileId, and the fresh first record establishes the fix.
+   */
+  private checkAttachmentImmutableFields(
+    patch: Record<string, unknown | null>,
+    existing: AttachmentContent,
+    merged: AttachmentContent,
+  ): void {
+    const errors: ValidationError[] = [];
+    if (Object.prototype.hasOwnProperty.call(patch, 'mimeType')) {
+      errors.push({
+        path: 'mimeType',
+        message: 'mimeType is immutable after creation; delete and re-upload to change it',
+      });
+    }
+    if (
+      Object.prototype.hasOwnProperty.call(patch, 'fileId') &&
+      merged.fileId !== existing.fileId
+    ) {
+      errors.push({ path: 'fileId', message: 'fileId is immutable' });
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, 'size') && merged.size !== existing.size) {
+      errors.push({ path: 'size', message: 'size is immutable' });
+    }
+    if (errors.length > 0) {
+      throw new StackValidationError(errors);
+    }
+  }
 
   /**
    * Store raw bytes and return the content-addressed file ID.

--- a/packages/core/tests/stack.test.ts
+++ b/packages/core/tests/stack.test.ts
@@ -1082,6 +1082,140 @@ describe('putAttachment', () => {
 });
 
 // -------------------------------------------------------
+// _attachment@1 mimeType invariant (#65): first-recorded wins for serving,
+// a conflicting later upload is rejected rather than silently coexisting.
+// -------------------------------------------------------
+
+describe('_attachment@1 mimeType conflict on create', () => {
+  test('second upload of identical bytes with a matching mimeType succeeds', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    const fileId1 = await stack.putAttachment(data, 'image/png', 'first.png');
+    const fileId2 = await stack.putAttachment(data, 'image/png', 'second.png');
+
+    expect(fileId2).toBe(fileId1);
+    const result = await stack.query({ filter: { typeId: '_attachment@1' } });
+    expect(result.records).toHaveLength(2);
+  });
+
+  test('second upload of identical bytes with a conflicting mimeType is rejected', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    await stack.putAttachment(data, 'text/markdown');
+
+    await expect(stack.putAttachment(data, 'text/plain')).rejects.toThrow(StackValidationError);
+
+    // The rejected upload's metadata record must not have been created.
+    const result = await stack.query({ filter: { typeId: '_attachment@1' } });
+    expect(result.records).toHaveLength(1);
+  });
+
+  test('conflict is detected even when the established record is beyond the first query page (>50 records, fallback path)', async () => {
+    for (let i = 0; i < 55; i++) {
+      await stack.create('_attachment@1', {
+        fileId: `filler-${i}`,
+        mimeType: 'image/png',
+        size: 1,
+      });
+    }
+    const data = new Uint8Array([9, 9, 9]);
+    await stack.putAttachment(data, 'text/markdown');
+
+    await expect(stack.putAttachment(data, 'text/plain')).rejects.toThrow(StackValidationError);
+  });
+
+  test('a soft-deleted earlier record still establishes the mimeType', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    await stack.putAttachment(data, 'text/markdown');
+    const [metaRecord] = (await stack.query({ filter: { typeId: '_attachment@1' } })).records;
+    await stack.delete(metaRecord.id);
+
+    await expect(stack.putAttachment(data, 'text/plain')).rejects.toThrow(StackValidationError);
+  });
+
+  test('two different uploaders of identical bytes each get their own filename under a matching mimeType', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    const fileId = await stack.putAttachmentBytes(data);
+    await stack.create(
+      '_attachment@1',
+      { fileId, mimeType: 'image/png', size: 3, filename: 'alice.png' },
+      { entityId: 'entity-alice' },
+    );
+    await stack.create(
+      '_attachment@1',
+      { fileId, mimeType: 'image/png', size: 3, filename: 'bob.png' },
+      { entityId: 'entity-bob' },
+    );
+
+    const result = await stack.query({ filter: { typeId: '_attachment@1' } });
+    expect(result.records).toHaveLength(2);
+    expect(
+      result.records.every((r) => (r.content as Record<string, unknown>).mimeType === 'image/png'),
+    ).toBe(true);
+    expect(
+      result.records.map((r) => (r.content as Record<string, unknown>).filename).sort(),
+    ).toEqual(['alice.png', 'bob.png']);
+  });
+});
+
+// -------------------------------------------------------
+// _attachment@1 immutable fields on update (#65): filename is the only
+// field that may change after a metadata record is created.
+// -------------------------------------------------------
+
+describe('_attachment@1 immutable fields on update', () => {
+  test('filename may be changed', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    await stack.putAttachment(data, 'image/png', 'old.png');
+    const [record] = (await stack.query({ filter: { typeId: '_attachment@1' } })).records;
+
+    const updated = await stack.update(record.id, { filename: 'new.png' });
+
+    expect((updated.content as Record<string, unknown>).filename).toBe('new.png');
+  });
+
+  test('changing mimeType is rejected, even to the same value', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    await stack.putAttachment(data, 'image/png');
+    const [record] = (await stack.query({ filter: { typeId: '_attachment@1' } })).records;
+
+    await expect(stack.update(record.id, { mimeType: 'image/jpeg' })).rejects.toThrow(
+      StackValidationError,
+    );
+    await expect(stack.update(record.id, { mimeType: 'image/png' })).rejects.toThrow(
+      StackValidationError,
+    );
+  });
+
+  test('changing fileId is rejected', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    await stack.putAttachment(data, 'image/png');
+    const [record] = (await stack.query({ filter: { typeId: '_attachment@1' } })).records;
+
+    await expect(stack.update(record.id, { fileId: 'some-other-file' })).rejects.toThrow(
+      StackValidationError,
+    );
+  });
+
+  test('changing size is rejected', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    await stack.putAttachment(data, 'image/png');
+    const [record] = (await stack.query({ filter: { typeId: '_attachment@1' } })).records;
+
+    await expect(stack.update(record.id, { size: 999 })).rejects.toThrow(StackValidationError);
+  });
+
+  test('setting fileId or size to their current value is a no-op, not an error', async () => {
+    const data = new Uint8Array([1, 2, 3]);
+    await stack.putAttachment(data, 'image/png');
+    const [record] = (await stack.query({ filter: { typeId: '_attachment@1' } })).records;
+    const content = record.content as Record<string, unknown>;
+
+    await expect(
+      stack.update(record.id, { fileId: content.fileId, size: content.size }),
+    ).resolves.toBeDefined();
+  });
+});
+
+// -------------------------------------------------------
 // deleteAttachment
 // -------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #65.

- `Stack.create()`: creating an `_attachment@1` record now looks up existing metadata for the same `fileId` (cursor-walked past the 50-record page boundary per #50) and rejects a **conflicting `mimeType`** with `StackValidationError` (422). The first upload for a `fileId` establishes it; a later matching upload still gets its own record (own `filename`/`entityId`).
- `Stack.update()`: once an `_attachment@1` record exists, **`filename` is the only mutable field** — folding in the issue's adopted amendments: `fileId`/`size` changes are rejected, and `mimeType` is rejected if the patch touches it at all, even to restate the current value.
- Both checks live in `Stack`, so `ScopedStack.create()`/`update()` inherit them automatically through the existing delegation path — no separate wiring needed.
- `restoreVersion()` needed no changes: since `update()` blocks any change to those three fields, every version snapshot of an attachment record already shares identical values by construction.
- `docs/spec.md`: updated the Attachment record section, the Attachments how-to section, and the wire Download section to state the first-recorded-wins/immutability rules, and dropped the now-inaccurate "each upload gets its own mimeType" language.
- `packages/conformance-fixtures`: added fixtures pinning the wire behavior (matching-mimeType create succeeds, conflicting-mimeType create → 422/validation, mimeType-touching update → 422/validation) so `adapter-api` and any server implementation share the same pinned contract.

Out of scope (per the issue): the served `Content-Type` resolution and `?contentType`/dangerous-type forcing (#66) live in `haverstack/server`. This PR only makes the write-path invariant that determinism depends on.

## Test plan

- [x] `pnpm -r run test` — 566 tests passing across all packages, including 10 new tests in `packages/core/tests/stack.test.ts` (conflicting/matching mimeType on create, conflict detection past the pagination boundary, a soft-deleted first record still establishing the type, the two-uploader/one-file scenario, and the four immutable-field-on-update cases) and 3 new conformance fixtures exercised by `packages/adapter-api/tests/conformance.test.ts`
- [x] `pnpm -r run lint`
- [x] `pnpm -r run typecheck` for the changed packages (`core`, `conformance-fixtures`) — some other packages in the monorepo (`wire-types`, `record-adapter-sqlite`, `record-adapter-sqljs`) fail typecheck on a clean checkout too, pre-existing and unrelated (they need their workspace dependencies built first)


---
_Generated by [Claude Code](https://claude.ai/code/session_01J6TCxBwLKY4DBTJTemgK1V)_