### PR TITLE
fix(core): result-not-source dangerous-type forcing for attachment downloads (#66)

### DIFF
--- a/docs/spec.md
+++ b/docs/spec.md
@@ -946,16 +946,31 @@ The SDK's `Stack.putAttachment()` and `ScopedStack.putAttachment()` perform both
 
 **Download:** Two optional query parameters control the response metadata and, when both are supplied, allow the server to skip the `_attachment@1` database lookup entirely:
 
-| Parameter      | Effect                                                                                                                         |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `?contentType` | Sets `Content-Type` on the response. Dangerous types (HTML, SVG, JS, XML) are forced to `application/octet-stream` regardless. |
-| `?filename`    | Sets the filename in `Content-Disposition`. Also infers `Content-Type` from the file extension when `?contentType` is omitted. |
+| Parameter      | Effect                                                                                                                               |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `?contentType` | Candidate `Content-Type` for the response.                                                                                           |
+| `?filename`    | Sets the filename in `Content-Disposition`. Also a candidate source for `Content-Type` (below), used when `?contentType` is omitted. |
 
 ```
 GET /attachments/<fileId>?contentType=image/png&filename=photo.png
 ```
 
-When neither parameter is provided the server queries `_attachment@1` records for the file: the **first-recorded** `mimeType` (see [Attachments](#attachments)) becomes `Content-Type` — deterministic regardless of how many records exist for the `fileId` or which requester is asking, since conflicting `mimeType`s are rejected at write time and can never coexist. The filename is taken from the requester's own `_attachment@1` record (if one exists), falling back to the first record's filename otherwise. Falls back to `Content-Type: application/octet-stream` when no metadata record is found.
+**Candidate `Content-Type` resolution**, in order — the first source that yields a value wins:
+
+1. `?contentType`, if given.
+2. Extension inference from `?filename`, if given and the extension is recognized.
+3. The **first-recorded** `mimeType` on an `_attachment@1` record for the file (see [Attachments](#attachments)) — deterministic regardless of how many records exist for the `fileId` or which requester is asking, since conflicting `mimeType`s are rejected at write time and can never coexist.
+4. `application/octet-stream`, if none of the above apply.
+
+**Dangerous-type forcing applies to the result of that resolution, not to whichever source produced it** (#66) — a server that forces only the `?contentType` case and leaves the other two sources unguarded has a spec-conformance gap, not a defensible partial implementation. Compute the candidate first, _then_ apply the policy below to whatever came out:
+
+- **Safe list** — passes through unforced: `image/*` (**except** `image/svg+xml`), `video/*`, `audio/*`, `application/pdf`, `text/plain`, `application/octet-stream`. Checked against the MIME type's base (parameters like `; charset=...` stripped, comparison case-insensitive), so neither casing nor a parameter can smuggle an unsafe type past the check.
+- **Everything else** is forced to `Content-Type: application/octet-stream` with `Content-Disposition: attachment` — forcing the content type alone is not sufficient, since disposition determines whether a browser treats the response as inline-renderable at all.
+- **`X-Content-Type-Options: nosniff` is sent on every attachment download response**, forced or not — without it, browsers may sniff an `application/octet-stream` body back into the dangerous type the forcing just removed, undoing the downgrade.
+
+`@haverstack/core` exports the canonical implementation of this resolution and policy — `resolveAttachmentDownloadContentType()`, `isSafeAttachmentContentType()`, `inferContentTypeFromFilename()`, and the `NOSNIFF_HEADER_NAME`/`NOSNIFF_HEADER_VALUE` constants — so server implementations share one safe-list rather than each re-deriving it.
+
+The filename in `Content-Disposition` is taken from `?filename` if given, else the requester's own `_attachment@1` record (if one exists), falling back to the first record's filename otherwise.
 
 **Delete:** Owner only. Returns `409 Conflict` if any record in the stack still references the file (i.e. has it in an `attachment` association or its content references the `fileId`). The bytes and all `_attachment@1` metadata records for the file are removed atomically on success.
 

--- a/packages/conformance-fixtures/src/index.ts
+++ b/packages/conformance-fixtures/src/index.ts
@@ -465,10 +465,120 @@ export const errorResponseFixtures: ConformanceFixture<unknown, WireError>[] = [
 ];
 
 // -------------------------------------------------------
+// Attachment download: dangerous-type forcing (#66)
+// -------------------------------------------------------
+//
+// GET /attachments/:fileId doesn't fit ConformanceFixture: there's no JSON
+// request or response body (it's a binary download), and what's actually
+// being pinned here is response *headers* — Content-Type, Content-
+// Disposition, and X-Content-Type-Options — not a body shape. Hence a
+// separate, narrower fixture type.
+//
+// The candidate Content-Type is computed source-by-source (?contentType,
+// then extension inference from ?filename, then the stored _attachment@1
+// mimeType, then application/octet-stream) and the safe-list is applied to
+// *that result*, never to the source — so each fixture below pins one
+// (source, type) pair, and forcing must catch the dangerous ones
+// regardless of which source produced them. See
+// resolveAttachmentDownloadContentType() in @haverstack/core, which is the
+// canonical implementation of this same table.
+
+export type AttachmentDownloadFixture = {
+  /** Unique, stable name — usable as a test-case id. */
+  name: string;
+  /** What this fixture pins down, and why. Also states any assumed prior state (e.g. an existing _attachment@1 record), since GET takes no body. */
+  description: string;
+  /** Request path including query string, e.g. "/attachments/abc123?contentType=text/html". */
+  path: string;
+  /** Response headers this GET must produce. Only the headers a fixture pins are listed here; anything else about the response is unconstrained by it. */
+  responseHeaders: Record<string, string>;
+};
+
+const NOSNIFF = { 'X-Content-Type-Options': 'nosniff' };
+
+export const attachmentDownloadFixtures: AttachmentDownloadFixture[] = [
+  {
+    name: 'attachment-download-contenttype-param-safe-passes-through',
+    description: 'A safe ?contentType is served as given.',
+    path: '/attachments/abc123?contentType=image/png',
+    responseHeaders: { 'Content-Type': 'image/png', ...NOSNIFF },
+  },
+  {
+    name: 'attachment-download-contenttype-param-dangerous-forced',
+    description:
+      'A dangerous ?contentType is forced to application/octet-stream — the one case the ' +
+      'pre-#66 spec already covered, kept here so the full three-source matrix is in one place.',
+    path: '/attachments/abc123?contentType=text/html',
+    responseHeaders: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Disposition': 'attachment',
+      ...NOSNIFF,
+    },
+  },
+  {
+    name: 'attachment-download-filename-extension-safe-passes-through',
+    description:
+      'With no ?contentType, a safe type inferred from the ?filename extension is served as given.',
+    path: '/attachments/abc123?filename=photo.png',
+    responseHeaders: { 'Content-Type': 'image/png', ...NOSNIFF },
+  },
+  {
+    name: 'attachment-download-filename-extension-dangerous-forced',
+    description:
+      '(#66) With no ?contentType, a dangerous type inferred from the ?filename extension must ' +
+      "still be forced — this was the spec's silent gap: extension inference had no forcing " +
+      'language at all, so `?filename=payload.html` was the unhardened path into the same XSS ' +
+      'this policy exists to prevent.',
+    path: '/attachments/abc123?filename=payload.html',
+    responseHeaders: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Disposition': 'attachment',
+      ...NOSNIFF,
+    },
+  },
+  {
+    name: 'attachment-download-stored-mimetype-safe-passes-through',
+    description:
+      'With no query params, a safe stored _attachment@1 mimeType is served as given. Assumes ' +
+      'an _attachment@1 record exists for "fileId": "abc123" with "mimeType": "image/png".',
+    path: '/attachments/abc123',
+    responseHeaders: { 'Content-Type': 'image/png', ...NOSNIFF },
+  },
+  {
+    name: 'attachment-download-stored-mimetype-dangerous-forced',
+    description:
+      '(#66) With no query params, a dangerous stored mimeType must still be forced — this was ' +
+      "the spec's other silent gap, and the one #65's escalation scenario depends on: a lying " +
+      'or dishonest _attachment@1 record must not reach the response header unforced just ' +
+      'because it came from storage rather than a query param. Assumes an _attachment@1 record ' +
+      'exists for "fileId": "def456" with "mimeType": "text/html".',
+    path: '/attachments/def456',
+    responseHeaders: {
+      'Content-Type': 'application/octet-stream',
+      'Content-Disposition': 'attachment',
+      ...NOSNIFF,
+    },
+  },
+  {
+    name: 'attachment-download-no-metadata-defaults-to-octet-stream',
+    description:
+      'With no query params and no _attachment@1 record for the fileId, the response falls ' +
+      'back to application/octet-stream — already the safe default, so unforced in the sense ' +
+      'that nothing needed overriding, but nosniff is still present.',
+    path: '/attachments/no-metadata-file',
+    responseHeaders: { 'Content-Type': 'application/octet-stream', ...NOSNIFF },
+  },
+];
+
+// -------------------------------------------------------
 // All fixtures
 // -------------------------------------------------------
 
-/** Every fixture across every endpoint, for consumers that want to iterate uniformly. */
+/**
+ * Every fixture across every endpoint, for consumers that want to iterate
+ * uniformly. Excludes attachmentDownloadFixtures — a different shape
+ * (response headers, not a JSON body), imported separately.
+ */
 export const allConformanceFixtures: ConformanceFixture[] = [
   ...createRecordFixtures,
   ...patchContentFixtures,

--- a/packages/core/src/attachment-download.ts
+++ b/packages/core/src/attachment-download.ts
@@ -1,0 +1,128 @@
+/**
+ * Stack — Attachment Download Content-Type Resolution
+ * -------------------------------------------------------
+ * Shared, pure implementation of the `GET /attachments/:fileId` dangerous-
+ * type policy (spec §Attachments, "Download"; see #66). Core has no HTTP
+ * server of its own — this module exists so `haverstack/server` and any
+ * other server implementation share one safe-list and one forcing
+ * computation, rather than each re-deriving it and risking drift on a
+ * security-relevant policy (the same "written once, not a per-server
+ * convention" principle applied elsewhere to adapter invariants).
+ *
+ * The policy is result-not-source: `resolveAttachmentDownloadContentType()`
+ * computes a single candidate type from whichever source wins (explicit
+ * param, then filename extension, then stored metadata, then
+ * application/octet-stream) and applies the safe-list to *that value* —
+ * so a server can't accidentally leave a hole by routing a dangerous type
+ * through the one source forcing used to skip.
+ */
+
+/** MIME types that pass through unforced, regardless of source. */
+const SAFE_EXACT_TYPES = new Set(['application/pdf', 'text/plain', 'application/octet-stream']);
+
+/** MIME type prefixes that pass through unforced, except for UNSAFE_OVERRIDES below. */
+const SAFE_PREFIXES = ['image/', 'video/', 'audio/'];
+
+/**
+ * Matches a SAFE_PREFIXES entry but is script-capable and must still be
+ * forced — image/svg+xml is the reason a plain prefix check isn't enough.
+ */
+const UNSAFE_OVERRIDES = new Set(['image/svg+xml']);
+
+/** application/octet-stream: the forced replacement for any unsafe type. */
+export const FORCED_CONTENT_TYPE = 'application/octet-stream';
+
+export const NOSNIFF_HEADER_NAME = 'X-Content-Type-Options';
+export const NOSNIFF_HEADER_VALUE = 'nosniff';
+
+/** Strips MIME parameters ("text/html; charset=utf-8" -> "text/html") and lowercases, so parameter tricks and casing can't bypass the safe-list check. */
+function normalizeMimeType(mimeType: string): string {
+  return mimeType.split(';')[0].trim().toLowerCase();
+}
+
+/**
+ * Whether a MIME type may be served as-is (Content-Type set to it, no
+ * forced download). Checked against the normalized base type — any
+ * parameters or casing on the input don't affect the result.
+ */
+export function isSafeAttachmentContentType(mimeType: string): boolean {
+  const normalized = normalizeMimeType(mimeType);
+  if (UNSAFE_OVERRIDES.has(normalized)) return false;
+  if (SAFE_EXACT_TYPES.has(normalized)) return true;
+  return SAFE_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+/**
+ * Extension -> candidate MIME type, used only when resolving from a
+ * `?filename` param with no explicit `?contentType` (spec: extension
+ * inference). Deliberately includes dangerous types (html, svg, js, xml)
+ * — forcing applies to the computed candidate, not to how it was computed,
+ * so listing them here is what lets the safe-list catch them.
+ */
+const EXTENSION_MIME_TYPES: Readonly<Record<string, string>> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  bmp: 'image/bmp',
+  avif: 'image/avif',
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  mov: 'video/quicktime',
+  mp3: 'audio/mpeg',
+  wav: 'audio/wav',
+  ogg: 'audio/ogg',
+  pdf: 'application/pdf',
+  txt: 'text/plain',
+  html: 'text/html',
+  htm: 'text/html',
+  xhtml: 'application/xhtml+xml',
+  svg: 'image/svg+xml',
+  js: 'text/javascript',
+  mjs: 'text/javascript',
+  xml: 'application/xml',
+  xsl: 'text/xsl',
+};
+
+/** Infers a candidate MIME type from a filename's extension. Returns undefined for no extension or an unrecognized one — the caller falls through to the next source. */
+export function inferContentTypeFromFilename(filename: string): string | undefined {
+  const match = /\.([a-z0-9]+)$/i.exec(filename);
+  return match ? EXTENSION_MIME_TYPES[match[1].toLowerCase()] : undefined;
+}
+
+export type AttachmentDownloadContentType = {
+  /** The Content-Type header value to serve. */
+  contentType: string;
+  /**
+   * Whether the dangerous-type policy overrode the candidate. When true,
+   * the server MUST also force `Content-Disposition: attachment` — Content-
+   * Type forcing alone doesn't stop a browser from sniffing the body back
+   * into the original type without both nosniff (always required, see
+   * NOSNIFF_HEADER_NAME/VALUE) and a non-inline disposition.
+   */
+  forced: boolean;
+};
+
+/**
+ * Resolve the Content-Type served for `GET /attachments/:fileId`, per spec
+ * §Attachments "Download": `?contentType` wins if present, else extension
+ * inference from `?filename`, else the stored `_attachment@1` mimeType,
+ * else `application/octet-stream` — then the safe-list is applied to
+ * whichever candidate that produced.
+ */
+export function resolveAttachmentDownloadContentType(input: {
+  contentTypeParam?: string;
+  filenameParam?: string;
+  storedMimeType?: string;
+}): AttachmentDownloadContentType {
+  const candidate =
+    input.contentTypeParam ||
+    (input.filenameParam && inferContentTypeFromFilename(input.filenameParam)) ||
+    input.storedMimeType ||
+    FORCED_CONTENT_TYPE;
+
+  return isSafeAttachmentContentType(candidate)
+    ? { contentType: candidate, forced: false }
+    : { contentType: FORCED_CONTENT_TYPE, forced: true };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,3 +93,12 @@ export { hashSchema, isCompatible, parseTypeId, buildTypeId, baseIdOf } from './
 export { validateContent, isValid } from './validate.js';
 export type { ValidationError } from './validate.js';
 export { applyMergePatch } from './merge.js';
+export {
+  isSafeAttachmentContentType,
+  inferContentTypeFromFilename,
+  resolveAttachmentDownloadContentType,
+  FORCED_CONTENT_TYPE,
+  NOSNIFF_HEADER_NAME,
+  NOSNIFF_HEADER_VALUE,
+} from './attachment-download.js';
+export type { AttachmentDownloadContentType } from './attachment-download.js';

--- a/packages/core/tests/attachment-download.test.ts
+++ b/packages/core/tests/attachment-download.test.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect } from 'vitest';
+import {
+  isSafeAttachmentContentType,
+  inferContentTypeFromFilename,
+  resolveAttachmentDownloadContentType,
+  FORCED_CONTENT_TYPE,
+} from '../src/attachment-download.js';
+
+// -------------------------------------------------------
+// isSafeAttachmentContentType
+// -------------------------------------------------------
+
+describe('isSafeAttachmentContentType', () => {
+  test.each([
+    'image/png',
+    'image/jpeg',
+    'video/mp4',
+    'audio/mpeg',
+    'application/pdf',
+    'text/plain',
+    'application/octet-stream',
+  ])('%s is safe', (mimeType) => {
+    expect(isSafeAttachmentContentType(mimeType)).toBe(true);
+  });
+
+  test.each([
+    'text/html',
+    'application/xhtml+xml',
+    'image/svg+xml',
+    'text/javascript',
+    'application/javascript',
+    'application/xml',
+    'text/xml',
+    'text/xsl',
+  ])('%s is not safe', (mimeType) => {
+    expect(isSafeAttachmentContentType(mimeType)).toBe(false);
+  });
+
+  test('image/svg+xml is excluded despite matching the image/ prefix', () => {
+    expect(isSafeAttachmentContentType('image/svg+xml')).toBe(false);
+  });
+
+  test('is case-insensitive', () => {
+    expect(isSafeAttachmentContentType('IMAGE/PNG')).toBe(true);
+    expect(isSafeAttachmentContentType('TEXT/HTML')).toBe(false);
+  });
+
+  test('strips MIME parameters before checking (parameter tricks cannot bypass the safe-list)', () => {
+    expect(isSafeAttachmentContentType('text/plain; charset=utf-8')).toBe(true);
+    expect(isSafeAttachmentContentType('text/html; charset=utf-7')).toBe(false);
+  });
+});
+
+// -------------------------------------------------------
+// inferContentTypeFromFilename
+// -------------------------------------------------------
+
+describe('inferContentTypeFromFilename', () => {
+  test('infers from a known extension', () => {
+    expect(inferContentTypeFromFilename('photo.png')).toBe('image/png');
+  });
+
+  test('infers dangerous types too — forcing is applied to the result, not the inference', () => {
+    expect(inferContentTypeFromFilename('payload.html')).toBe('text/html');
+    expect(inferContentTypeFromFilename('payload.svg')).toBe('image/svg+xml');
+  });
+
+  test('is case-insensitive on the extension', () => {
+    expect(inferContentTypeFromFilename('photo.PNG')).toBe('image/png');
+  });
+
+  test('returns undefined for an unrecognized extension', () => {
+    expect(inferContentTypeFromFilename('archive.zip')).toBeUndefined();
+  });
+
+  test('returns undefined for a filename with no extension', () => {
+    expect(inferContentTypeFromFilename('README')).toBeUndefined();
+  });
+});
+
+// -------------------------------------------------------
+// resolveAttachmentDownloadContentType — source precedence
+// -------------------------------------------------------
+
+describe('resolveAttachmentDownloadContentType — source precedence', () => {
+  test('?contentType wins over everything else', () => {
+    const result = resolveAttachmentDownloadContentType({
+      contentTypeParam: 'image/png',
+      filenameParam: 'payload.html',
+      storedMimeType: 'video/mp4',
+    });
+    expect(result).toEqual({ contentType: 'image/png', forced: false });
+  });
+
+  test('extension inference from ?filename wins when ?contentType is absent', () => {
+    const result = resolveAttachmentDownloadContentType({
+      filenameParam: 'photo.png',
+      storedMimeType: 'video/mp4',
+    });
+    expect(result).toEqual({ contentType: 'image/png', forced: false });
+  });
+
+  test('falls through to stored mimeType when ?filename has no recognized extension', () => {
+    const result = resolveAttachmentDownloadContentType({
+      filenameParam: 'archive.zip',
+      storedMimeType: 'image/png',
+    });
+    expect(result).toEqual({ contentType: 'image/png', forced: false });
+  });
+
+  test('stored mimeType is used when no query params are given', () => {
+    const result = resolveAttachmentDownloadContentType({ storedMimeType: 'image/png' });
+    expect(result).toEqual({ contentType: 'image/png', forced: false });
+  });
+
+  test('falls back to application/octet-stream when nothing is known', () => {
+    const result = resolveAttachmentDownloadContentType({});
+    expect(result).toEqual({ contentType: FORCED_CONTENT_TYPE, forced: false });
+  });
+});
+
+// -------------------------------------------------------
+// resolveAttachmentDownloadContentType — dangerous-type forcing (#66)
+// -------------------------------------------------------
+
+describe('resolveAttachmentDownloadContentType — forcing applies to the result, not the source', () => {
+  test('forces a dangerous ?contentType param', () => {
+    const result = resolveAttachmentDownloadContentType({ contentTypeParam: 'text/html' });
+    expect(result).toEqual({ contentType: FORCED_CONTENT_TYPE, forced: true });
+  });
+
+  test('forces a dangerous type inferred from ?filename', () => {
+    const result = resolveAttachmentDownloadContentType({ filenameParam: 'payload.html' });
+    expect(result).toEqual({ contentType: FORCED_CONTENT_TYPE, forced: true });
+  });
+
+  test('forces a dangerous stored mimeType (e.g. a lying _attachment@1 record, #65)', () => {
+    const result = resolveAttachmentDownloadContentType({ storedMimeType: 'text/html' });
+    expect(result).toEqual({ contentType: FORCED_CONTENT_TYPE, forced: true });
+  });
+
+  test('a safe type from any source passes through unforced', () => {
+    expect(resolveAttachmentDownloadContentType({ contentTypeParam: 'image/png' }).forced).toBe(
+      false,
+    );
+    expect(resolveAttachmentDownloadContentType({ filenameParam: 'photo.png' }).forced).toBe(false);
+    expect(resolveAttachmentDownloadContentType({ storedMimeType: 'image/png' }).forced).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #66.

`Stack`/`ScopedStack.getAttachment()` never took `?contentType`/`?filename` query params — the three-source Content-Type resolution this issue describes (`?contentType`, extension inference from `?filename`, stored `_attachment@1` mimeType) is entirely an HTTP-server concern that doesn't exist anywhere in this repo today. So instead of a `Stack` method change (like #65), this adds a shared pure implementation of the policy in `@haverstack/core` for `haverstack/server` (and any other server implementation) to consume, rather than each re-deriving a security-relevant safe-list independently — the same "written once, not a per-server convention" principle already applied to other invariants in this issue set (#67, #68).

- **`packages/core/src/attachment-download.ts`** (new): `resolveAttachmentDownloadContentType()` computes the candidate type (`?contentType` → extension inference from `?filename` → stored `mimeType` → `application/octet-stream`) and applies a safe-list to *that result*, never to the source — so a server can't leave a hole by routing a dangerous type through whichever source forcing used to skip. Also exports `isSafeAttachmentContentType()`, `inferContentTypeFromFilename()`, `FORCED_CONTENT_TYPE`, and the `NOSNIFF_HEADER_NAME`/`NOSNIFF_HEADER_VALUE` constants. Safe-list (per the issue's recommendation over an ad hoc deny-list): `image/*` (except `image/svg+xml`), `video/*`, `audio/*`, `application/pdf`, `text/plain`, `application/octet-stream` — checked against the MIME type's base, case-insensitively, so parameter tricks (`text/html; charset=...`) or casing can't bypass it. Everything else forces `Content-Type: application/octet-stream` + `Content-Disposition: attachment`.
- **`docs/spec.md`**: rewrote the Download section with the normative result-not-source forcing rule, the safe-list, and the `X-Content-Type-Options: nosniff` requirement on every attachment response (forced or not).
- **`packages/conformance-fixtures`**: added `attachmentDownloadFixtures` — dangerous type × each of the three sources → forced; safe type × each source → passes through; nosniff present on every response. Kept as a separate fixture type from `ConformanceFixture` since `GET /attachments/:fileId` has no JSON body — what's being pinned is response *headers*, not a body shape. Not wired into `adapter-api`'s existing fixture loops, since `APIAdapter.getAttachment()` has no query-param/header surface to test against them (a plain bytes fetch); these are for `haverstack/server`'s own test suite (and for our in-repo unit tests against the pure function directly).

## Test plan

- [x] `pnpm -r run test` — 620 tests passing across all packages, including 32 new tests in `packages/core/tests/attachment-download.test.ts` covering safe-list membership (incl. the `image/svg+xml` exclusion, case-insensitivity, parameter stripping), extension inference (incl. dangerous extensions inferring their real type, since forcing applies downstream), source precedence, and forcing per source
- [x] `pnpm --filter @haverstack/core run build/typecheck/lint`
- [x] `pnpm --filter @haverstack/conformance-fixtures run build/typecheck/lint`


---
_Generated by [Claude Code](https://claude.ai/code/session_01J6TCxBwLKY4DBTJTemgK1V)_